### PR TITLE
fix(seerr): mark media available via the media endpoint

### DIFF
--- a/crates/plugin-seerr/src/lib.rs
+++ b/crates/plugin-seerr/src/lib.rs
@@ -87,19 +87,42 @@ impl Plugin for SeerrPlugin {
 
         let request_id = get_seerr_request_id(info.id).await;
         if let Some(rid) = request_id {
-            let mark_url = format!("{base_url}/api/v1/request/{rid}/available");
-            tracing::debug!(request_id = rid, target_url = %mark_url, "marking seerr request as available");
-            if let Err(e) = ctx
+            // Seerr tracks availability on the media record, not the request, so
+            // resolve the request's media id first, then mark that media available.
+            let request_url = format!("{base_url}/api/v1/request/{rid}");
+            let fetched: anyhow::Result<SeerrRequest> = ctx
                 .http
-                .send(PROFILE, |client| {
-                    client.post(&mark_url).header("x-api-key", api_key)
+                .get_json(PROFILE, request_url.clone(), |client| {
+                    client.get(&request_url).header("x-api-key", api_key)
                 })
-                .await
-                .and_then(|r| r.error_for_status())
-            {
-                tracing::warn!(error = %e, request_id = rid, "failed to mark seerr request as available");
-            } else {
-                tracing::info!(request_id = rid, "marked seerr request as available");
+                .await;
+            let media_id = match fetched {
+                Ok(request) => request.media.and_then(|media| media.id),
+                Err(e) => {
+                    tracing::warn!(error = %e, request_id = rid, "failed to fetch seerr request for media id");
+                    None
+                }
+            };
+
+            if let Some(media_id) = media_id {
+                let mark_url = format!("{base_url}/api/v1/media/{media_id}/available");
+                tracing::debug!(request_id = rid, media_id, target_url = %mark_url, "marking seerr media as available");
+                if let Err(e) = ctx
+                    .http
+                    .send(PROFILE, |client| {
+                        client
+                            .post(&mark_url)
+                            .header("x-api-key", api_key)
+                            .header("content-type", "application/json")
+                            .body("{}")
+                    })
+                    .await
+                    .and_then(|r| r.error_for_status())
+                {
+                    tracing::warn!(error = %e, request_id = rid, media_id, "failed to mark seerr media as available");
+                } else {
+                    tracing::info!(request_id = rid, media_id, "marked seerr media as available");
+                }
             }
         }
         Ok(HookResponse::Empty)
@@ -243,6 +266,7 @@ struct SeerrRequest {
 
 #[derive(Deserialize)]
 struct SeerrMedia {
+    id: Option<i64>,
     #[serde(rename = "tmdbId")]
     tmdb_id: Option<i64>,
     #[serde(rename = "tvdbId")]

--- a/crates/plugin-seerr/src/tests/mod.rs
+++ b/crates/plugin-seerr/src/tests/mod.rs
@@ -45,6 +45,21 @@ fn request_response_deserializes_media_and_requested_seasons() {
 }
 
 #[test]
+fn request_media_id_deserializes() {
+    let response: SeerrRequestResponse = serde_json::from_value(serde_json::json!({
+        "results": [
+            { "id": 789, "type": "tv", "media": { "id": 793, "tvdbId": 379169 } }
+        ]
+    }))
+    .expect("seerr response should deserialize");
+
+    assert_eq!(
+        response.results[0].media.as_ref().and_then(|media| media.id),
+        Some(793)
+    );
+}
+
+#[test]
 fn plugin_schema_declares_default_url_and_filter() {
     let schema = SeerrPlugin.settings_schema();
 


### PR DESCRIPTION
The `on_download_success` hook marked requests available via `POST /api/v1/request/{id}/available`, which Overseerr/Seerr rejects with `400` — that route only accepts `approve`/`decline`. Completed requests were never marked available (stayed "Processing").

Availability lives on the media object, so this resolves the request's `media.id` and POSTs to `/api/v1/media/{id}/available` with a JSON body instead.

Adds a test for the new `media.id` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Seerr availability updates by resolving the associated media before marking it available.
  * Added safeguards to prevent incorrect updates when request or media information is unavailable.

* **Tests**
  * Added coverage confirming media identifiers are correctly read from Seerr responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->