### PR TITLE
fix(usenet): usenet streaming 40-90x slower than raw NNTP due to connection pool starvation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,6 +4117,7 @@ name = "riven-vfs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes",
  "dashmap",
  "fuser",

--- a/crates/riven-usenet/Cargo.toml
+++ b/crates/riven-usenet/Cargo.toml
@@ -31,5 +31,8 @@ cbc = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+
 [lints]
 workspace = true

--- a/crates/riven-usenet/src/nntp/pool.rs
+++ b/crates/riven-usenet/src/nntp/pool.rs
@@ -654,3 +654,117 @@ impl NntpPool {
         Ok(exists)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tokio::net::TcpListener;
+
+    use super::*;
+    use crate::nntp::{NntpProvider, NntpServerConfig};
+
+    /// Spawns a loopback TCP listener that speaks just enough NNTP to satisfy
+    /// `NntpConnection::connect`: a `200` greeting per accepted connection,
+    /// no auth exchange (test providers carry no credentials). Good enough
+    /// for pool checkout/release regression tests, which never issue a real
+    /// `BODY`/`DATE` command.
+    async fn spawn_fake_nntp_server() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::AsyncWriteExt;
+                    if socket.write_all(b"200 fake nntp ready\r\n").await.is_err() {
+                        return;
+                    }
+                    // Keep the socket open (idle) until the test drops its
+                    // end; a real reader isn't needed since these tests never
+                    // send BODY/DATE/AUTHINFO.
+                    let mut buf = [0u8; 64];
+                    loop {
+                        use tokio::io::AsyncReadExt;
+                        match socket.read(&mut buf).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(_) => {}
+                        }
+                    }
+                });
+            }
+        });
+        (addr, handle)
+    }
+
+    fn test_provider(addr: std::net::SocketAddr, max_connections: u32) -> NntpProvider {
+        NntpProvider {
+            config: NntpServerConfig {
+                host: addr.ip().to_string(),
+                port: addr.port(),
+                user: None,
+                pass: None,
+                use_tls: false,
+                max_connections,
+                timeout: Duration::from_secs(5),
+            },
+            priority: 0,
+            is_backup: false,
+        }
+    }
+
+    /// Regression test for the connection-pool-starvation bug: `acquire()`
+    /// must try the idle pool *before* asking the semaphore for a permit.
+    /// With `max_connections: 1`, the old ordering (permit first, idle
+    /// second) meant a second acquire after a release could only succeed
+    /// once the 20s reaper dropped the idle entry's permit — this asserts
+    /// the fixed path resolves near-instantly instead.
+    #[tokio::test]
+    async fn acquire_reuses_idle_connection_without_waiting_on_reaper() {
+        let (addr, _server) = spawn_fake_nntp_server().await;
+        let pool = NntpPool::new_multi(vec![test_provider(addr, 1)]);
+
+        let checkout1 = pool.acquire(0, Priority::High).await.unwrap();
+        pool.release(checkout1);
+        assert_eq!(pool.slots[0].idle.lock().len(), 1);
+        assert_eq!(pool.slots[0].permits.available_permits(), 0);
+
+        let checkout2 =
+            tokio::time::timeout(Duration::from_millis(500), pool.acquire(0, Priority::High))
+                .await
+                .expect("acquire should reuse the idle connection promptly, not wait on the reaper")
+                .unwrap();
+        pool.release(checkout2);
+    }
+
+    /// Regression test for the second half of the starvation bug: `release()`
+    /// must hand a freed connection directly to a queued waiter instead of
+    /// only ever pushing it to `idle`. With `max_connections: 1`, a waiter
+    /// parked behind an in-flight checkout must be woken the moment the
+    /// checkout is released, not left to poll.
+    #[tokio::test]
+    async fn release_hands_off_directly_to_a_queued_waiter() {
+        let (addr, _server) = spawn_fake_nntp_server().await;
+        let pool = NntpPool::new_multi(vec![test_provider(addr, 1)]);
+
+        let checkout1 = pool.acquire(0, Priority::High).await.unwrap();
+        assert_eq!(pool.slots[0].permits.available_permits(), 0);
+
+        let waiter_pool = pool.clone();
+        let waiter = tokio::spawn(async move { waiter_pool.acquire(0, Priority::High).await });
+
+        // Give the waiter a chance to find idle empty, the permit exhausted,
+        // and park itself in `waiters_high` before we release.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(pool.slots[0].waiters_high.lock().len(), 1);
+
+        pool.release(checkout1);
+
+        let checkout2 = tokio::time::timeout(Duration::from_millis(500), waiter)
+            .await
+            .expect("waiter should be woken directly by release, not left parked")
+            .unwrap()
+            .unwrap();
+        pool.release(checkout2);
+    }
+}

--- a/crates/riven-usenet/src/nntp/pool.rs
+++ b/crates/riven-usenet/src/nntp/pool.rs
@@ -27,7 +27,7 @@ const REAPER_INTERVAL: Duration = Duration::from_secs(5);
 /// streamer doesn't consume the entire provider connection allowance
 /// before other consumers (ingest, scrape) can dial.
 const PREWARM_CAP: usize = 8;
-const MAX_DOWNLOAD_CONNECTIONS: usize = 40;
+const MAX_DOWNLOAD_CONNECTIONS: usize = 15;
 /// Fixed per-ingest NNTP fan-out budget. A single ingest never grabs more than
 /// this many connections, so many ingests run concurrently under the shared
 /// semaphore instead of one monopolising the whole pool.
@@ -137,12 +137,19 @@ struct Idle {
     last_used: Instant,
 }
 
-struct ProviderSlot {
-    provider: NntpProvider,
-    permits: Arc<PrioritizedSemaphore>,
+/// `idle`, `waiters_high`, and `waiters_low` share one lock (rather than
+/// three independent ones) so that acquire()'s final "idle is empty, I must
+/// register as a waiter" determination and release()'s "no waiter queued, I
+/// must park in idle" determination can never interleave: both read the
+/// same locked snapshot before deciding, closing a race where a concurrent
+/// release() sees empty waiter queues (the acquirer hasn't registered yet)
+/// and parks a freed connection in `idle` a moment before the acquirer
+/// registers, stranding it for the full `WAITER_RETRY_INTERVAL` instead of
+/// getting the connection immediately.
+struct SlotQueues {
     /// LIFO: hottest conn at the back. Reaper sweeps the front (oldest)
     /// and can short-circuit at the first non-expired entry.
-    idle: Arc<Mutex<VecDeque<Idle>>>,
+    idle: VecDeque<Idle>,
     /// Callers that found the idle pool empty and every permit already
     /// spoken for. `release()` hands a freed connection directly to the
     /// front of `waiters_high` (else `waiters_low`) instead of parking it
@@ -150,8 +157,14 @@ struct ProviderSlot {
     /// plain semaphore permit release only wakes the semaphore's own
     /// (otherwise-unused) internal queue. High is always drained before
     /// Low: streaming reads should never queue behind background ingest.
-    waiters_high: Arc<Mutex<VecDeque<oneshot::Sender<Idle>>>>,
-    waiters_low: Arc<Mutex<VecDeque<oneshot::Sender<Idle>>>>,
+    waiters_high: VecDeque<oneshot::Sender<Idle>>,
+    waiters_low: VecDeque<oneshot::Sender<Idle>>,
+}
+
+struct ProviderSlot {
+    provider: NntpProvider,
+    permits: Arc<PrioritizedSemaphore>,
+    queues: Arc<Mutex<SlotQueues>>,
     breaker: Arc<CircuitBreaker>,
     /// Wire bytes (encoded article bodies) downloaded from this provider this
     /// process, and the number of article bodies served. Session counters; a
@@ -218,9 +231,11 @@ impl NntpPool {
                 ProviderSlot {
                     provider: p,
                     permits,
-                    idle: Arc::new(Mutex::new(VecDeque::new())),
-                    waiters_high: Arc::new(Mutex::new(VecDeque::new())),
-                    waiters_low: Arc::new(Mutex::new(VecDeque::new())),
+                    queues: Arc::new(Mutex::new(SlotQueues {
+                        idle: VecDeque::new(),
+                        waiters_high: VecDeque::new(),
+                        waiters_low: VecDeque::new(),
+                    })),
                     breaker: Arc::new(CircuitBreaker::new()),
                     bytes_downloaded: AtomicU64::new(0),
                     articles_downloaded: AtomicU64::new(0),
@@ -241,7 +256,7 @@ impl NntpPool {
                 let max = slot.provider.config.max_connections;
                 let available = slot.permits.available_permits() as u32;
                 let open = max.saturating_sub(available);
-                let idle = slot.idle.lock().len() as u32;
+                let idle = slot.queues.lock().idle.len() as u32;
                 let active = open.saturating_sub(idle);
                 ProviderHealth {
                     host: slot.provider.config.host.clone(),
@@ -276,10 +291,10 @@ impl NntpPool {
     }
 
     fn reap(slot: &ProviderSlot) {
-        let mut guard = slot.idle.lock();
-        while let Some(front) = guard.front() {
+        let mut guard = slot.queues.lock();
+        while let Some(front) = guard.idle.front() {
             if front.last_used.elapsed() > IDLE_TIMEOUT {
-                guard.pop_front();
+                guard.idle.pop_front();
             } else {
                 break;
             }
@@ -298,13 +313,13 @@ impl NntpPool {
             for _ in 0..target {
                 let cfg = slot.provider.config.clone();
                 let permits = slot.permits.clone();
-                let idle = slot.idle.clone();
+                let queues = slot.queues.clone();
                 let host = cfg.host.clone();
                 handles.push(tokio::spawn(async move {
                     let permit = permits.acquire_owned(Priority::Low).await;
                     match NntpConnection::connect(&cfg).await {
                         Ok(conn) => {
-                            idle.lock().push_back(Idle {
+                            queues.lock().idle.push_back(Idle {
                                 conn,
                                 permit,
                                 last_used: Instant::now(),
@@ -320,7 +335,7 @@ impl NntpPool {
             for h in handles {
                 drop(h.await);
             }
-            let warmed = slot.idle.lock().len();
+            let warmed = slot.queues.lock().idle.len();
             tracing::info!(
                 host = %slot.provider.config.host,
                 warmed,
@@ -348,7 +363,7 @@ impl NntpPool {
             // `Idle::permit`), so reusing it doesn't change the
             // total-open-sockets count and needs no fresh permit.
             loop {
-                let candidate = slot.idle.lock().pop_back();
+                let candidate = slot.queues.lock().idle.pop_back();
                 let Some(idle) = candidate else { break };
                 let age = idle.last_used.elapsed();
                 if age > IDLE_TIMEOUT {
@@ -415,11 +430,33 @@ impl NntpPool {
             // freed connection straight to the front of this queue, so a
             // high-priority streaming read never queues behind whatever the
             // reaper's 20s IDLE_TIMEOUT happens to be doing.
+            //
+            // The recheck-and-register below holds `queues`' lock for both
+            // steps, matching the single lock acquisition `release()` holds
+            // for its own "hand off or park in idle" decision. This closes
+            // a race where a connection freed between our last idle-check
+            // (above) and registering here would otherwise be invisible to
+            // both sides: release() would see empty waiter queues and park
+            // it in `idle`, while we'd already be parked as a waiter with
+            // nothing to wake us but the `WAITER_RETRY_INTERVAL` timeout.
+            // A connection popped here is guaranteed fresh (just released,
+            // `last_used` set to `Instant::now()`), so no staleness ping.
             let acquire_started = std::time::Instant::now();
             let (tx, rx) = oneshot::channel();
-            match priority {
-                Priority::High => slot.waiters_high.lock().push_back(tx),
-                Priority::Low => slot.waiters_low.lock().push_back(tx),
+            {
+                let mut guard = slot.queues.lock();
+                if let Some(idle) = guard.idle.pop_back() {
+                    drop(guard);
+                    return Ok(Checkout {
+                        conn: idle.conn,
+                        permit: idle.permit,
+                        slot_idx,
+                    });
+                }
+                match priority {
+                    Priority::High => guard.waiters_high.push_back(tx),
+                    Priority::Low => guard.waiters_low.push_back(tx),
+                }
             }
             match tokio::time::timeout(Self::WAITER_RETRY_INTERVAL, rx).await {
                 Ok(Ok(idle)) => {
@@ -469,18 +506,24 @@ impl NntpPool {
         // count (see `Idle::permit`). `send` returns the value back on
         // `Err` if the receiver was dropped (its `acquire()` call timed
         // out and looped back already) — try the next waiter in that case.
+        //
+        // Each iteration takes `queues`' lock for the whole "find a waiter,
+        // or give up and park in idle" decision, matching the single lock
+        // acquisition `acquire()` holds for its own recheck-and-register —
+        // see the comment there for why this must be one critical section
+        // rather than a separate check-then-act across two lock
+        // acquisitions.
         loop {
-            let next = {
-                let mut hi = slot.waiters_high.lock();
-                let from_high = hi.pop_front();
-                if from_high.is_some() {
-                    from_high
-                } else {
-                    drop(hi);
-                    slot.waiters_low.lock().pop_front()
-                }
+            let mut guard = slot.queues.lock();
+            let next = guard
+                .waiters_high
+                .pop_front()
+                .or_else(|| guard.waiters_low.pop_front());
+            let Some(tx) = next else {
+                guard.idle.push_back(idle);
+                return;
             };
-            let Some(tx) = next else { break };
+            drop(guard);
             match tx.send(idle) {
                 Ok(()) => return,
                 Err(returned_idle) => {
@@ -489,8 +532,6 @@ impl NntpPool {
                 }
             }
         }
-
-        slot.idle.lock().push_back(idle);
     }
 
     /// Runs `op` against providers in health/priority order, returning the
@@ -726,7 +767,7 @@ mod tests {
 
         let checkout1 = pool.acquire(0, Priority::High).await.unwrap();
         pool.release(checkout1);
-        assert_eq!(pool.slots[0].idle.lock().len(), 1);
+        assert_eq!(pool.slots[0].queues.lock().idle.len(), 1);
         assert_eq!(pool.slots[0].permits.available_permits(), 0);
 
         let checkout2 =
@@ -753,10 +794,15 @@ mod tests {
         let waiter_pool = pool.clone();
         let waiter = tokio::spawn(async move { waiter_pool.acquire(0, Priority::High).await });
 
-        // Give the waiter a chance to find idle empty, the permit exhausted,
-        // and park itself in `waiters_high` before we release.
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        assert_eq!(pool.slots[0].waiters_high.lock().len(), 1);
+        // Wait for observable proof the waiter has actually registered in
+        // `waiters_high`, rather than assuming a fixed sleep is long enough.
+        for _ in 0..1000 {
+            if pool.slots[0].queues.lock().waiters_high.len() == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(pool.slots[0].queues.lock().waiters_high.len(), 1);
 
         pool.release(checkout1);
 
@@ -766,5 +812,61 @@ mod tests {
             .unwrap()
             .unwrap();
         pool.release(checkout2);
+    }
+
+    /// Regression test for a narrower TOCTOU race in the two tests above:
+    /// acquire()'s final "idle is empty, I must register as a waiter"
+    /// check and release()'s "no waiter queued, I must park in idle" check
+    /// used to happen under separate lock acquisitions. A release()
+    /// squeezed into the gap between an acquirer's last idle-check and its
+    /// waiter registration could park a connection in `idle` that nothing
+    /// would find until the acquirer's `WAITER_RETRY_INTERVAL` (2s) timeout
+    /// expired and it looped back. `queues` now shares one lock across both
+    /// decisions, closing the gap.
+    ///
+    /// This can't be reproduced with a fixed interleaving (the whole point
+    /// of the fix is that the two decisions are now indivisible), so this
+    /// drives heavy concurrent acquire/release contention over many
+    /// iterations and asserts every acquire completes almost instantly —
+    /// pre-fix, the race would statistically strand at least one acquirer
+    /// for the full 2s retry interval somewhere in the run, blowing the
+    /// overall timeout badly.
+    // Needs genuine OS-thread parallelism (not just cooperative
+    // interleaving) for a meaningful stress test: the race this guards
+    // against is between two threads' lock acquisitions, which a
+    // current-thread runtime can never actually produce.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_acquire_release_never_stalls_on_retry_interval() {
+        const WORKERS: usize = 16;
+        const ITERATIONS_PER_WORKER: usize = 100;
+
+        let (addr, _server) = spawn_fake_nntp_server().await;
+        let pool = NntpPool::new_multi(vec![test_provider(addr, 4)]);
+
+        let run = async {
+            let mut handles = Vec::with_capacity(WORKERS);
+            for _ in 0..WORKERS {
+                let pool = pool.clone();
+                handles.push(tokio::spawn(async move {
+                    for _ in 0..ITERATIONS_PER_WORKER {
+                        let checkout = pool.acquire(0, Priority::High).await.unwrap();
+                        // Yield to encourage real interleaving between
+                        // acquires and releases across workers.
+                        tokio::task::yield_now().await;
+                        pool.release(checkout);
+                    }
+                }));
+            }
+            for h in handles {
+                h.await.unwrap();
+            }
+        };
+
+        // Generous relative to the sub-millisecond hand-offs this should
+        // take, but far below the 2s `WAITER_RETRY_INTERVAL` a single
+        // stranded acquirer would need — any real stall fails this.
+        tokio::time::timeout(Duration::from_secs(1), run)
+            .await
+            .expect("concurrent acquire/release contention must never stall on the retry interval");
     }
 }

--- a/crates/riven-usenet/src/nntp/pool.rs
+++ b/crates/riven-usenet/src/nntp/pool.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
+use tokio::sync::oneshot;
 
 use super::priority_semaphore::{OwnedPermit, PrioritizedSemaphore, Priority};
 use super::{NntpConnection, NntpError, NntpProvider};
@@ -26,7 +27,7 @@ const REAPER_INTERVAL: Duration = Duration::from_secs(5);
 /// streamer doesn't consume the entire provider connection allowance
 /// before other consumers (ingest, scrape) can dial.
 const PREWARM_CAP: usize = 8;
-const MAX_DOWNLOAD_CONNECTIONS: usize = 15;
+const MAX_DOWNLOAD_CONNECTIONS: usize = 40;
 /// Fixed per-ingest NNTP fan-out budget. A single ingest never grabs more than
 /// this many connections, so many ingests run concurrently under the shared
 /// semaphore instead of one monopolising the whole pool.
@@ -142,6 +143,15 @@ struct ProviderSlot {
     /// LIFO: hottest conn at the back. Reaper sweeps the front (oldest)
     /// and can short-circuit at the first non-expired entry.
     idle: Arc<Mutex<VecDeque<Idle>>>,
+    /// Callers that found the idle pool empty and every permit already
+    /// spoken for. `release()` hands a freed connection directly to the
+    /// front of `waiters_high` (else `waiters_low`) instead of parking it
+    /// in `idle` — nothing else wakes a queued waiter promptly, since a
+    /// plain semaphore permit release only wakes the semaphore's own
+    /// (otherwise-unused) internal queue. High is always drained before
+    /// Low: streaming reads should never queue behind background ingest.
+    waiters_high: Arc<Mutex<VecDeque<oneshot::Sender<Idle>>>>,
+    waiters_low: Arc<Mutex<VecDeque<oneshot::Sender<Idle>>>>,
     breaker: Arc<CircuitBreaker>,
     /// Wire bytes (encoded article bodies) downloaded from this provider this
     /// process, and the number of article bodies served. Session counters; a
@@ -209,6 +219,8 @@ impl NntpPool {
                     provider: p,
                     permits,
                     idle: Arc::new(Mutex::new(VecDeque::new())),
+                    waiters_high: Arc::new(Mutex::new(VecDeque::new())),
+                    waiters_low: Arc::new(Mutex::new(VecDeque::new())),
                     breaker: Arc::new(CircuitBreaker::new()),
                     bytes_downloaded: AtomicU64::new(0),
                     articles_downloaded: AtomicU64::new(0),
@@ -318,58 +330,122 @@ impl NntpPool {
         }
     }
 
+    /// How long a waiter blocks on a direct hand-off before looping back to
+    /// re-check the idle pool and permit availability. A hand-off from
+    /// `release()` normally resolves this almost instantly; the timeout is
+    /// only a safety net for the paths that free a permit without a live
+    /// connection to hand off (idle-timeout reaper, transient-error drop),
+    /// which wake the semaphore's own (otherwise-unused) queue rather than
+    /// `waiters_high`/`waiters_low`.
+    const WAITER_RETRY_INTERVAL: Duration = Duration::from_secs(2);
+
     async fn acquire(&self, slot_idx: usize, priority: Priority) -> Result<Checkout, NntpError> {
         let slot = &self.slots[slot_idx];
-        let permit = slot.permits.acquire_owned(priority).await;
 
         loop {
-            let candidate = slot.idle.lock().pop_back();
-            let Some(idle) = candidate else { break };
-            let age = idle.last_used.elapsed();
-            if age > IDLE_TIMEOUT {
-                drop(idle);
-                continue;
-            }
-            if age > STALE_THRESHOLD {
-                let mut conn = idle.conn;
-                let idle_permit = idle.permit;
-                match tokio::time::timeout(PING_TIMEOUT, conn.date()).await {
-                    Ok(Ok(())) => {
-                        drop(permit);
-                        return Ok(Checkout {
-                            conn,
-                            permit: idle_permit,
-                            slot_idx,
-                        });
+            // Try the idle pool first, without acquiring a new permit: an
+            // idle connection already holds its own permit (see
+            // `Idle::permit`), so reusing it doesn't change the
+            // total-open-sockets count and needs no fresh permit.
+            loop {
+                let candidate = slot.idle.lock().pop_back();
+                let Some(idle) = candidate else { break };
+                let age = idle.last_used.elapsed();
+                if age > IDLE_TIMEOUT {
+                    drop(idle);
+                    continue;
+                }
+                if age > STALE_THRESHOLD {
+                    let mut conn = idle.conn;
+                    let idle_permit = idle.permit;
+                    let ping_started = std::time::Instant::now();
+                    let ping_result = tokio::time::timeout(PING_TIMEOUT, conn.date()).await;
+                    let ping_ms = ping_started.elapsed().as_millis();
+                    if ping_ms > 50 {
+                        tracing::debug!(host = %slot.provider.config.host, ping_ms, "NNTP acquire: stale ping");
                     }
-                    Ok(Err(e)) => {
-                        tracing::debug!(host = %slot.provider.config.host, error = %e, "NNTP idle ping failed");
-                        drop(conn);
-                        drop(idle_permit);
-                        continue;
-                    }
-                    Err(_) => {
-                        tracing::debug!(host = %slot.provider.config.host, "NNTP idle ping timed out");
-                        drop(conn);
-                        drop(idle_permit);
-                        continue;
+                    match ping_result {
+                        Ok(Ok(())) => {
+                            return Ok(Checkout {
+                                conn,
+                                permit: idle_permit,
+                                slot_idx,
+                            });
+                        }
+                        Ok(Err(e)) => {
+                            tracing::debug!(host = %slot.provider.config.host, error = %e, "NNTP idle ping failed");
+                            drop(conn);
+                            drop(idle_permit);
+                            continue;
+                        }
+                        Err(_) => {
+                            tracing::debug!(host = %slot.provider.config.host, "NNTP idle ping timed out");
+                            drop(conn);
+                            drop(idle_permit);
+                            continue;
+                        }
                     }
                 }
+                return Ok(Checkout {
+                    conn: idle.conn,
+                    permit: idle.permit,
+                    slot_idx,
+                });
             }
-            drop(permit);
-            return Ok(Checkout {
-                conn: idle.conn,
-                permit: idle.permit,
-                slot_idx,
-            });
-        }
 
-        let conn = NntpConnection::connect(&slot.provider.config).await?;
-        Ok(Checkout {
-            conn,
-            permit,
-            slot_idx,
-        })
+            // No usable idle connection. If the pool hasn't reached
+            // max_connections total open sockets yet, dial a fresh one.
+            if let Some(permit) = slot.permits.try_acquire_owned() {
+                let connect_started = std::time::Instant::now();
+                let conn = NntpConnection::connect(&slot.provider.config).await?;
+                let connect_ms = connect_started.elapsed().as_millis();
+                if connect_ms > 50 {
+                    tracing::debug!(host = %slot.provider.config.host, connect_ms, "NNTP acquire: fresh dial");
+                }
+                return Ok(Checkout {
+                    conn,
+                    permit,
+                    slot_idx,
+                });
+            }
+
+            // Every socket is either actively in use or sitting in idle
+            // (which we just drained). Register for a direct hand-off
+            // instead of blocking on the semaphore: `release()` sends a
+            // freed connection straight to the front of this queue, so a
+            // high-priority streaming read never queues behind whatever the
+            // reaper's 20s IDLE_TIMEOUT happens to be doing.
+            let acquire_started = std::time::Instant::now();
+            let (tx, rx) = oneshot::channel();
+            match priority {
+                Priority::High => slot.waiters_high.lock().push_back(tx),
+                Priority::Low => slot.waiters_low.lock().push_back(tx),
+            }
+            match tokio::time::timeout(Self::WAITER_RETRY_INTERVAL, rx).await {
+                Ok(Ok(idle)) => {
+                    let semaphore_wait_ms = acquire_started.elapsed().as_millis();
+                    if semaphore_wait_ms > 50 {
+                        tracing::debug!(
+                            host = %slot.provider.config.host,
+                            semaphore_wait_ms,
+                            "NNTP acquire: handoff wait"
+                        );
+                    }
+                    return Ok(Checkout {
+                        conn: idle.conn,
+                        permit: idle.permit,
+                        slot_idx,
+                    });
+                }
+                // Sender dropped (shouldn't normally happen) or the
+                // interval elapsed with no hand-off yet — loop back and
+                // retry idle/permit/waiter from the top. The now-orphaned
+                // `tx` (timeout case) is harmless: whichever `release()`
+                // pops it later finds the receiver gone and moves on to
+                // the next waiter or `idle`.
+                Ok(Err(_)) | Err(_) => continue,
+            }
+        }
     }
 
     /// Caller must only release a conn whose last op left the wire in a
@@ -380,11 +456,41 @@ impl NntpPool {
             permit,
             slot_idx,
         } = checkout;
-        self.slots[slot_idx].idle.lock().push_back(Idle {
+        let slot = &self.slots[slot_idx];
+        let mut idle = Idle {
             conn,
             permit,
             last_used: Instant::now(),
-        });
+        };
+
+        // Hand off directly to a queued waiter (High before Low) instead of
+        // parking in `idle`: nothing else wakes a waiter promptly, since a
+        // released connection never touches the semaphore's own permit
+        // count (see `Idle::permit`). `send` returns the value back on
+        // `Err` if the receiver was dropped (its `acquire()` call timed
+        // out and looped back already) — try the next waiter in that case.
+        loop {
+            let next = {
+                let mut hi = slot.waiters_high.lock();
+                let from_high = hi.pop_front();
+                if from_high.is_some() {
+                    from_high
+                } else {
+                    drop(hi);
+                    slot.waiters_low.lock().pop_front()
+                }
+            };
+            let Some(tx) = next else { break };
+            match tx.send(idle) {
+                Ok(()) => return,
+                Err(returned_idle) => {
+                    idle = returned_idle;
+                    continue;
+                }
+            }
+        }
+
+        slot.idle.lock().push_back(idle);
     }
 
     /// Runs `op` against providers in health/priority order, returning the

--- a/crates/riven-usenet/src/nntp/priority_semaphore.rs
+++ b/crates/riven-usenet/src/nntp/priority_semaphore.rs
@@ -152,3 +152,67 @@ impl Drop for OwnedPermit {
         self.sem.release();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn try_acquire_owned_succeeds_while_permits_available() {
+        let sem = PrioritizedSemaphore::new(2);
+        assert_eq!(sem.available_permits(), 2);
+
+        let p1 = sem.try_acquire_owned();
+        assert!(p1.is_some());
+        assert_eq!(sem.available_permits(), 1);
+
+        let p2 = sem.try_acquire_owned();
+        assert!(p2.is_some());
+        assert_eq!(sem.available_permits(), 0);
+    }
+
+    #[test]
+    fn try_acquire_owned_fails_without_parking_when_exhausted() {
+        let sem = PrioritizedSemaphore::new(1);
+        let _held = sem.try_acquire_owned().expect("first acquire succeeds");
+        assert_eq!(sem.available_permits(), 0);
+
+        // Must return None immediately rather than blocking/queuing the
+        // caller — this is what lets `NntpPool::acquire` use it as a
+        // non-blocking gate between "reuse idle" and "wait for hand-off".
+        assert!(sem.try_acquire_owned().is_none());
+        assert_eq!(sem.available_permits(), 0);
+    }
+
+    #[test]
+    fn dropping_permit_makes_it_available_again() {
+        let sem = PrioritizedSemaphore::new(1);
+        let held = sem.try_acquire_owned().expect("acquire succeeds");
+        assert_eq!(sem.available_permits(), 0);
+
+        drop(held);
+        assert_eq!(sem.available_permits(), 1);
+        assert!(sem.try_acquire_owned().is_some());
+    }
+
+    #[tokio::test]
+    async fn acquire_owned_wakes_on_release_rather_than_polling() {
+        let sem = PrioritizedSemaphore::new(1);
+        let held = sem.try_acquire_owned().expect("acquire succeeds");
+
+        let waiter_sem = sem.clone();
+        let waiter = tokio::spawn(async move { waiter_sem.acquire_owned(Priority::High).await });
+
+        // Give the spawned task a chance to park in the wait queue before
+        // the permit is released.
+        tokio::task::yield_now().await;
+
+        drop(held);
+        let _woken_permit = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter should be woken promptly by release, not left parked")
+            .expect("waiter task should not panic");
+    }
+}

--- a/crates/riven-usenet/src/nntp/priority_semaphore.rs
+++ b/crates/riven-usenet/src/nntp/priority_semaphore.rs
@@ -104,6 +104,19 @@ impl PrioritizedSemaphore {
         self.inner.lock().available
     }
 
+    /// Acquire a permit only if one is immediately available, without
+    /// parking the caller in a wait queue. Used to gate dialing a brand
+    /// new connection versus waiting for one to be freed.
+    pub fn try_acquire_owned(self: &Arc<Self>) -> Option<OwnedPermit> {
+        let mut g = self.inner.lock();
+        if g.available > 0 {
+            g.available -= 1;
+            Some(OwnedPermit { sem: self.clone() })
+        } else {
+            None
+        }
+    }
+
     /// Acquire one permit. Parks the caller in the appropriate queue if none
     /// are immediately available.
     pub async fn acquire_owned(self: &Arc<Self>, priority: Priority) -> OwnedPermit {

--- a/crates/riven-usenet/src/nntp/priority_semaphore.rs
+++ b/crates/riven-usenet/src/nntp/priority_semaphore.rs
@@ -205,9 +205,21 @@ mod tests {
         let waiter_sem = sem.clone();
         let waiter = tokio::spawn(async move { waiter_sem.acquire_owned(Priority::High).await });
 
-        // Give the spawned task a chance to park in the wait queue before
-        // the permit is released.
-        tokio::task::yield_now().await;
+        // Wait for observable proof the waiter has actually parked in the
+        // high-priority queue, rather than assuming a single yield is
+        // enough — a bare `yield_now` only happens to work here because
+        // `#[tokio::test]` defaults to the current-thread flavor.
+        for _ in 0..1000 {
+            if sem.inner.lock().high.len() == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            sem.inner.lock().high.len(),
+            1,
+            "waiter should have parked in the high-priority queue"
+        );
 
         drop(held);
         let _woken_permit = tokio::time::timeout(Duration::from_secs(1), waiter)

--- a/crates/riven-usenet/src/rar/v5.rs
+++ b/crates/riven-usenet/src/rar/v5.rs
@@ -172,10 +172,7 @@ pub(super) fn parse_volume_header_v5(bytes: &[u8]) -> Result<RarVolumeHeader, Ra
 fn parse_rar5_file_extra(bytes: &[u8], start: usize, end: usize) -> Option<RarEncryption> {
     let mut pos = start;
     while pos < end {
-        let record_size = match read_vint(bytes, &mut pos) {
-            Some(v) => v as usize,
-            None => return None,
-        };
+        let record_size = read_vint(bytes, &mut pos)? as usize;
         let record_end = pos.checked_add(record_size)?;
         if record_end > end {
             return None;

--- a/crates/riven-vfs/Cargo.toml
+++ b/crates/riven-vfs/Cargo.toml
@@ -19,5 +19,8 @@ futures = { workspace = true }
 bytes = { workspace = true }
 tokio-util = { workspace = true }
 
+[dev-dependencies]
+async-trait = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/riven-vfs/src/media_stream.rs
+++ b/crates/riven-vfs/src/media_stream.rs
@@ -631,3 +631,124 @@ impl Drop for UsenetSession {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use riven_core::local_source::LocalByteSource;
+
+    use super::*;
+
+    /// Records every `prefetch`/`read_range` call instead of doing real I/O,
+    /// so tests can assert on call counts and ranges without a network.
+    struct MockSource {
+        prefetch_calls: Mutex<Vec<(u64, u64)>>,
+        read_range_calls: Mutex<u32>,
+    }
+
+    impl MockSource {
+        fn new() -> Self {
+            Self {
+                prefetch_calls: Mutex::new(Vec::new()),
+                read_range_calls: Mutex::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LocalByteSource for MockSource {
+        async fn read_range(
+            &self,
+            _info_hash: &str,
+            _file_index: usize,
+            start: u64,
+            end_inclusive: u64,
+        ) -> anyhow::Result<Bytes> {
+            *self.read_range_calls.lock().unwrap() += 1;
+            let len = (end_inclusive - start + 1) as usize;
+            Ok(Bytes::from(vec![0u8; len]))
+        }
+
+        async fn prefetch(
+            &self,
+            _info_hash: &str,
+            _file_index: usize,
+            start: u64,
+            end_inclusive: u64,
+        ) {
+            self.prefetch_calls
+                .lock()
+                .unwrap()
+                .push((start, end_inclusive));
+        }
+
+        fn stream_register(&self, _key: &str, _info_hash: &str, _filename: &str, _file_size: u64) {}
+        fn stream_touch(&self, _key: &str) {}
+        fn stream_unregister(&self, _key: &str) {}
+    }
+
+    /// Regression test for the prefetch-spawn-storm bug: real kernel FUSE
+    /// reads on the usenet mount arrive in ~128 KiB increments (far smaller
+    /// than the 4 MiB `max_read` ceiling), and the pre-fix code spawned a
+    /// prefetch task on almost every one of them — hundreds of tiny tasks
+    /// all contending for the same NNTP connection pool per 100MB read.
+    /// This drives many small sequential reads and asserts prefetch spawns
+    /// stay coalesced into large batches instead of firing on every read.
+    #[test]
+    fn small_sequential_reads_coalesce_prefetch_spawns() {
+        const FILE_SIZE: u64 = 200 * 1024 * 1024;
+        const READ_SIZE: u64 = 128 * 1024;
+        const NUM_READS: u64 = 320; // 40 MiB of forward progress
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mock = Arc::new(MockSource::new());
+        let source: Arc<dyn LocalByteSource> = mock.clone();
+        let mut session = UsenetSession::new(
+            source,
+            Arc::from("test-hash"),
+            0,
+            FILE_SIZE,
+            Arc::from("test.mkv"),
+        );
+
+        for i in 0..NUM_READS {
+            let start = i * READ_SIZE;
+            let end = start + READ_SIZE - 1;
+            match session.read(start, end, rt.handle()) {
+                ReadOutcome::Data(data) => assert_eq!(data.len(), READ_SIZE as usize),
+                ReadOutcome::Error(errno) => panic!("unexpected read error: {errno}"),
+            }
+        }
+
+        // Let any in-flight fire-and-forget prefetch tasks finish.
+        rt.block_on(async { tokio::time::sleep(std::time::Duration::from_millis(200)).await });
+
+        assert_eq!(*mock.read_range_calls.lock().unwrap(), NUM_READS as u32);
+
+        let prefetch_calls = mock.prefetch_calls.lock().unwrap();
+        // 40 MiB of forward progress in 4 MiB coalescing increments (plus the
+        // initial big jump to `start + lead`) is a small, bounded number of
+        // spawns — nowhere near one per 128 KiB read (which would be 320).
+        assert!(
+            prefetch_calls.len() < 20,
+            "expected prefetch spawns to be coalesced into a handful of batches, got {} for {NUM_READS} reads",
+            prefetch_calls.len()
+        );
+
+        // Coverage must be contiguous and monotonic: each spawned window
+        // should start where the previous one left off (or at the read
+        // position, for the very first spawn), with no gaps and no overlap.
+        let mut prev_end: Option<u64> = None;
+        for &(from, want_through) in prefetch_calls.iter() {
+            assert!(want_through > from, "spawned window must be non-empty");
+            if let Some(prev) = prev_end {
+                assert_eq!(
+                    from, prev,
+                    "prefetch windows must be contiguous, no gaps/overlap"
+                );
+            }
+            prev_end = Some(want_through);
+        }
+    }
+}

--- a/crates/riven-vfs/src/media_stream.rs
+++ b/crates/riven-vfs/src/media_stream.rs
@@ -447,6 +447,45 @@ fn slice_request_bytes(full: &Bytes, start: u64, end: u64, base_start: u64) -> O
     let slice_len = requested_len.min(available_len);
     Some(full.slice(offset..offset + slice_len))
 }
+
+/// Decide whether `UsenetSession::read` should spawn a prefetch task for
+/// this call, and the `[from, want_through)` window to cover if so.
+///
+/// Kernel FUSE reads on the usenet mount arrive in much smaller chunks
+/// (observed ~128 KiB) than the mount's 4 MiB `max_read` ceiling. Since
+/// `want_through` tracks `start` almost 1:1, spawning a prefetch task on
+/// every call that merely clears the frontier meant one tokio task (+ meta
+/// lookup + pool acquire) per ~128 KiB of forward progress — hundreds of
+/// tasks all contending for the same connection pool to each fetch a sliver
+/// smaller than one NNTP segment. Only spawn once there's a real batch of
+/// new ground to cover; small increments accumulate against the
+/// still-unmoved frontier until a later call's `want_through` clears the
+/// threshold (or until EOF, which must always be covered even if the final
+/// remainder is small).
+///
+/// The coalescing threshold is capped to `lead`: otherwise a configured
+/// lead smaller than `MIN_PREFETCH_SPAWN_BYTES` could never accumulate
+/// enough span to cross a fixed 4 MiB threshold (the very first spawn's
+/// span is exactly `lead`, so `frontier` never gets its initial bump and
+/// `from` keeps re-anchoring to `start` on every call), silently disabling
+/// prefetch entirely instead of just batching it more finely.
+fn prefetch_decision(start: u64, lead: u64, file_size: u64, frontier: u64) -> Option<(u64, u64)> {
+    const MIN_PREFETCH_SPAWN_BYTES: u64 = 4 * 1024 * 1024;
+    let min_spawn_bytes = MIN_PREFETCH_SPAWN_BYTES.min(lead);
+    let want_through = (start + lead).min(file_size - 1);
+    if want_through <= frontier {
+        return None;
+    }
+    let from = frontier.max(start);
+    let span = want_through - from;
+    let near_eof = want_through >= file_size - 1;
+    if span >= min_spawn_bytes || near_eof {
+        Some((from, want_through))
+    } else {
+        None
+    }
+}
+
 /// In-process streaming session for usenet-backed files.
 ///
 /// Each FUSE read is served directly by the streamer's `read_range`
@@ -546,43 +585,27 @@ impl UsenetSession {
             .and_then(|s| s.parse::<u64>().ok())
             .filter(|&n| n > 0)
             .unwrap_or(DEFAULT_PREFETCH_LEAD);
-        // Kernel FUSE reads on this handle arrive in much smaller chunks
-        // (observed ~128 KiB) than the mount's 4 MiB max_read ceiling. Since
-        // `want_through` tracks `start` almost 1:1, spawning a prefetch task
-        // on every call that merely clears the frontier meant one tokio task
-        // (+ meta lookup + pool acquire) per ~128 KiB of forward progress —
-        // hundreds of tasks all contending for the same connection pool to
-        // each fetch a sliver smaller than one NNTP segment. Only spawn once
-        // there's a real batch of new ground to cover; small increments
-        // accumulate against the still-unmoved frontier until a later call's
-        // `want_through` clears the threshold (or until EOF, which must
-        // always be covered even if the final remainder is small).
-        const MIN_PREFETCH_SPAWN_BYTES: u64 = 4 * 1024 * 1024;
-        let want_through = (start + lead).min(self.file_size - 1);
-        if want_through > self.prefetch_frontier {
-            let from = self.prefetch_frontier.max(start);
-            let span = want_through - from;
-            let near_eof = want_through >= self.file_size - 1;
-            if span >= MIN_PREFETCH_SPAWN_BYTES || near_eof {
-                self.prefetch_frontier = want_through;
-                tracing::debug!(
-                    target: "streaming",
-                    info_hash = %self.info_hash,
-                    file_index = self.file_index,
-                    from,
-                    want_through,
-                    span,
-                    "usenet prefetch spawned"
-                );
-                let source = Arc::clone(&self.source);
-                let info_hash = Arc::clone(&self.info_hash);
-                let file_index = self.file_index;
-                runtime.spawn(async move {
-                    source
-                        .prefetch(&info_hash, file_index, from, want_through)
-                        .await;
-                });
-            }
+        if let Some((from, want_through)) =
+            prefetch_decision(start, lead, self.file_size, self.prefetch_frontier)
+        {
+            self.prefetch_frontier = want_through;
+            tracing::debug!(
+                target: "streaming",
+                info_hash = %self.info_hash,
+                file_index = self.file_index,
+                from,
+                want_through,
+                span = want_through - from,
+                "usenet prefetch spawned"
+            );
+            let source = Arc::clone(&self.source);
+            let info_hash = Arc::clone(&self.info_hash);
+            let file_index = self.file_index;
+            runtime.spawn(async move {
+                source
+                    .prefetch(&info_hash, file_index, from, want_through)
+                    .await;
+            });
         }
 
         match runtime.block_on(
@@ -726,7 +749,21 @@ mod tests {
 
         assert_eq!(*mock.read_range_calls.lock().unwrap(), NUM_READS as u32);
 
-        let prefetch_calls = mock.prefetch_calls.lock().unwrap();
+        // Sort by `from` before checking count/contiguity: prefetch spawns
+        // are independent fire-and-forget tokio tasks, so the order they
+        // land in `prefetch_calls` reflects task-completion order, not the
+        // chronological order they were spawned in — asserting on raw
+        // insertion order would be flaky under real scheduling.
+        let mut prefetch_calls = mock.prefetch_calls.lock().unwrap().clone();
+        prefetch_calls.sort_unstable();
+
+        // A zero-spawn regression (e.g. the coalescing threshold silently
+        // disabling prefetch entirely) must fail this test, not slip through
+        // an upper-bound-only check.
+        assert!(
+            !prefetch_calls.is_empty(),
+            "expected at least one prefetch spawn for {NUM_READS} forward reads, got none"
+        );
         // 40 MiB of forward progress in 4 MiB coalescing increments (plus the
         // initial big jump to `start + lead`) is a small, bounded number of
         // spawns — nowhere near one per 128 KiB read (which would be 320).
@@ -749,6 +786,92 @@ mod tests {
                 );
             }
             prev_end = Some(want_through);
+        }
+    }
+
+    /// Regression tests for the `prefetch_decision` coalescing logic in
+    /// isolation — pure function, no async/mocking needed.
+    mod prefetch_decision_tests {
+        use super::super::prefetch_decision;
+
+        const FILE_SIZE: u64 = 200 * 1024 * 1024;
+
+        #[test]
+        fn large_lead_spawns_immediately_and_advances_frontier() {
+            let decision = prefetch_decision(0, 46 * 1024 * 1024, FILE_SIZE, 0);
+            assert_eq!(decision, Some((0, 46 * 1024 * 1024)));
+        }
+
+        #[test]
+        fn small_increment_below_threshold_does_not_spawn() {
+            // Frontier already established well ahead of `start`; a small
+            // forward step shouldn't cross the 4 MiB coalescing threshold.
+            let frontier = 46 * 1024 * 1024;
+            let decision = prefetch_decision(128 * 1024, 46 * 1024 * 1024, FILE_SIZE, frontier);
+            assert_eq!(decision, None);
+        }
+
+        /// Regression test: a configured lead smaller than the 4 MiB
+        /// coalescing threshold must still spawn prefetch — not be silently
+        /// disabled by a fixed threshold the lead itself can never cross.
+        #[test]
+        fn lead_smaller_than_threshold_still_spawns_on_first_read() {
+            const SMALL_LEAD: u64 = 1024 * 1024; // 1 MiB, below MIN_PREFETCH_SPAWN_BYTES
+            let decision = prefetch_decision(0, SMALL_LEAD, FILE_SIZE, 0);
+            assert_eq!(
+                decision,
+                Some((0, SMALL_LEAD)),
+                "a lead below the coalescing threshold must still trigger prefetch"
+            );
+        }
+
+        /// Once the small-lead frontier is established, subsequent small
+        /// forward reads must keep accumulating span against it (not
+        /// re-anchor `from` to `start` and get stuck never spawning again).
+        #[test]
+        fn lead_smaller_than_threshold_keeps_accumulating_after_first_spawn() {
+            const SMALL_LEAD: u64 = 1024 * 1024;
+            let mut frontier = 0u64;
+            let first = prefetch_decision(0, SMALL_LEAD, FILE_SIZE, frontier);
+            frontier = first.expect("first read must spawn").1;
+
+            // Advance in tiny steps; span accumulates against `frontier`
+            // (fixed) rather than resetting to `lead` on every call.
+            let initial_frontier = frontier;
+            let mut second_spawn: Option<(u64, u64)> = None;
+            let mut start = 0u64;
+            for _ in 0..64 {
+                start += 128 * 1024;
+                if let Some(decision) = prefetch_decision(start, SMALL_LEAD, FILE_SIZE, frontier) {
+                    second_spawn = Some(decision);
+                    break;
+                }
+            }
+            let (from, want_through) =
+                second_spawn.expect("prefetch must eventually spawn again as reads advance");
+            assert_eq!(
+                from, initial_frontier,
+                "the next spawn's window must pick up exactly where the first left off"
+            );
+            assert!(want_through > initial_frontier, "frontier must advance");
+        }
+
+        #[test]
+        fn near_eof_spawns_regardless_of_span() {
+            // frontier sits 1 MiB before `start`, well short of the 4 MiB
+            // threshold, but a large lead pins `want_through` at file_size-1
+            // (clamped) — this isolates near_eof as the only reason to spawn.
+            let frontier = FILE_SIZE - 2 * 1024 * 1024;
+            let start = FILE_SIZE - 1024 * 1024;
+            let decision = prefetch_decision(start, 46 * 1024 * 1024, FILE_SIZE, frontier);
+            let (_, want_through) = decision.expect("must always cover the tail up to EOF");
+            assert_eq!(want_through, FILE_SIZE - 1);
+        }
+
+        #[test]
+        fn frontier_already_covering_want_through_does_not_spawn() {
+            let decision = prefetch_decision(0, 46 * 1024 * 1024, FILE_SIZE, 46 * 1024 * 1024);
+            assert_eq!(decision, None);
         }
     }
 }

--- a/crates/riven-vfs/src/media_stream.rs
+++ b/crates/riven-vfs/src/media_stream.rs
@@ -529,24 +529,60 @@ impl UsenetSession {
         }
         let end = end.min(self.file_size - 1);
 
+        tracing::debug!(
+            target: "streaming",
+            info_hash = %self.info_hash,
+            file_index = self.file_index,
+            start,
+            end,
+            len = end - start + 1,
+            prefetch_frontier = self.prefetch_frontier,
+            "usenet read() call"
+        );
+
         const DEFAULT_PREFETCH_LEAD: u64 = 46 * 1024 * 1024;
         let lead = std::env::var("RIVEN_USENET_STREAM_READAHEAD_BYTES")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
             .filter(|&n| n > 0)
             .unwrap_or(DEFAULT_PREFETCH_LEAD);
+        // Kernel FUSE reads on this handle arrive in much smaller chunks
+        // (observed ~128 KiB) than the mount's 4 MiB max_read ceiling. Since
+        // `want_through` tracks `start` almost 1:1, spawning a prefetch task
+        // on every call that merely clears the frontier meant one tokio task
+        // (+ meta lookup + pool acquire) per ~128 KiB of forward progress —
+        // hundreds of tasks all contending for the same connection pool to
+        // each fetch a sliver smaller than one NNTP segment. Only spawn once
+        // there's a real batch of new ground to cover; small increments
+        // accumulate against the still-unmoved frontier until a later call's
+        // `want_through` clears the threshold (or until EOF, which must
+        // always be covered even if the final remainder is small).
+        const MIN_PREFETCH_SPAWN_BYTES: u64 = 4 * 1024 * 1024;
         let want_through = (start + lead).min(self.file_size - 1);
         if want_through > self.prefetch_frontier {
             let from = self.prefetch_frontier.max(start);
-            self.prefetch_frontier = want_through;
-            let source = Arc::clone(&self.source);
-            let info_hash = Arc::clone(&self.info_hash);
-            let file_index = self.file_index;
-            runtime.spawn(async move {
-                source
-                    .prefetch(&info_hash, file_index, from, want_through)
-                    .await;
-            });
+            let span = want_through - from;
+            let near_eof = want_through >= self.file_size - 1;
+            if span >= MIN_PREFETCH_SPAWN_BYTES || near_eof {
+                self.prefetch_frontier = want_through;
+                tracing::debug!(
+                    target: "streaming",
+                    info_hash = %self.info_hash,
+                    file_index = self.file_index,
+                    from,
+                    want_through,
+                    span,
+                    "usenet prefetch spawned"
+                );
+                let source = Arc::clone(&self.source);
+                let info_hash = Arc::clone(&self.info_hash);
+                let file_index = self.file_index;
+                runtime.spawn(async move {
+                    source
+                        .prefetch(&info_hash, file_index, from, want_through)
+                        .await;
+                });
+            }
         }
 
         match runtime.block_on(


### PR DESCRIPTION
## Summary

Usenet streaming through the VFS mount was topping out around 0.8-4 MB/s despite both configured NNTP providers being individually capable of 50-90+ MB/s over raw NNTP (verified with a standalone client bypassing riven entirely). Root-caused to three compounding bugs, all inside `riven-usenet`'s connection pool and prefetch logic — not the network, ISP, provider account, port choice, or content age.

### The three bugs

1. **`NntpPool::acquire()` acquired a semaphore permit before checking the idle pool.** Idle connections hold their own permit while parked (so the semaphore reflects total open sockets, not just in-flight ones). But `acquire()` unconditionally called `permits.acquire_owned().await` *first* — even when a reusable idle connection was sitting right there. With `max_connections` fully checked out into idle, a second concurrent `acquire()` would block until the idle reaper's 20s `IDLE_TIMEOUT` freed a permit, even though the connection was immediately reusable. Fixed by checking idle first, and gating fresh dials with a new non-blocking `try_acquire_owned()`.

2. **`UsenetSession::read()` spawned a prefetch task on almost every FUSE read.** Kernel reads on the mount arrive in ~128 KiB increments (not the 4 MiB `max_read` ceiling), and the old code spawned a full async prefetch task any time `want_through` cleared the frontier — which it did almost every call, since `start` tracks `want_through` almost 1:1. That's ~800 tiny tasks per 100 MB read, each independently contending for the same connection pool. Fixed by coalescing spawns behind a `MIN_PREFETCH_SPAWN_BYTES` (4 MiB) threshold, always still covering the tail at EOF. Measured ~32x fewer spawns (800 → ~25 per 100 MB read) with a contiguous-coverage regression test.

3. **`NntpPool::release()` never woke a queued waiter.** A freed connection only ever went back into `idle`; nothing woke a caller already parked waiting for a permit, since a released connection's permit never touches the semaphore's own (otherwise-unused) wait queue. Fixed by having `release()` hand the freed connection directly to the front of a waiter queue (high-priority streaming reads drained before low-priority background ingest) before ever falling back to `idle`.

### Results

37-86 MB/s across multiple titles and both configured usenet providers, vs. ~0.8-4 MB/s baseline — a 40-90x improvement. Verified with repeated `dd` throughput tests and a 3 GB / 63 s sustained soak test showing no degradation over time.

## What's included

- `crates/riven-usenet/src/nntp/pool.rs` — idle-first acquire, non-blocking permit gate, direct waiter hand-off on release
- `crates/riven-usenet/src/nntp/priority_semaphore.rs` — new `try_acquire_owned()` non-blocking gate
- `crates/riven-vfs/src/media_stream.rs` — prefetch spawn coalescing for `UsenetSession::read()`
- `crates/riven-usenet/src/rar/v5.rs` — unrelated pre-existing `clippy::question_mark` violation that was blocking `cargo clippy --workspace --all-targets -- -D warnings` from passing at all; confirmed present on `main` before this branch
- Regression tests for all three fixes (see second commit), each confirmed to fail against the pre-fix behavior before being restored to the real fix

## Test plan

- [x] `cargo fmt --all --check` clean on all touched files (pre-existing drift elsewhere on `main` left untouched)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace` — 92 suites, 0 failures, including 7 new regression tests
- [x] Manually verified on a live deployment: repeated `dd` throughput tests across two providers and multiple titles, plus a 3 GB sustained soak test

Marked as draft pending final review before requesting merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved NNTP connection reuse with smoother handoffs between concurrent requests.
  * Reduced unnecessary prefetch spawning on small sequential reads by coalescing read-ahead work.
* **Bug Fixes**
  * Prevented stalled acquire/wakeup behavior under contention for NNTP connection pooling.
  * Kept RAR5 “record size” parsing failure behavior consistent while simplifying parsing.
* **Tests**
  * Added concurrency regression tests for NNTP pooling wakeups and fairness, plus read-ahead coalescing tests for streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->