### PR TITLE
fix: scraped items with no downloadable streams bypass the retry cooldown (3 code paths)

### DIFF
--- a/crates/riven-db/src/repo/media.rs
+++ b/crates/riven-db/src/repo/media.rs
@@ -138,12 +138,17 @@ pub async fn get_items_by_state(
         .await?)
 }
 
-/// Escalating cooldown applied to items with `failed_attempts > 0` so a
-/// repeatedly-failing item doesn't get re-enqueued every retry cycle and
-/// starve fresh content.
+/// Escalating cooldown applied to every pending item so a repeatedly-scraped
+/// item doesn't get re-enqueued every retry cycle and starve fresh content.
+/// `last_scrape_attempt_at IS NULL` alone covers "never scraped yet" —
+/// deliberately does NOT also bypass on `failed_attempts = 0`, since that's
+/// an item's normal resting state after *any* scrape that links at least
+/// one new (but not necessarily usable) stream: `reset_failed_attempts`
+/// zeroes the counter without meaning "skip the cooldown," and the `ELSE`
+/// tier below already covers `failed_attempts` 0/1 with the base 30-minute
+/// wait via the recency check.
 pub(crate) const FAILED_ATTEMPTS_COOLDOWN_SQL: &str = "(
-    failed_attempts = 0
-    OR last_scrape_attempt_at IS NULL
+    last_scrape_attempt_at IS NULL
     OR last_scrape_attempt_at < NOW() - (CASE
         WHEN failed_attempts >= 10 THEN INTERVAL '24 hours'
         WHEN failed_attempts >= 5  THEN INTERVAL '6 hours'
@@ -373,6 +378,15 @@ pub async fn update_scraped(id: i64) -> Result<()> {
             media_items::Column::ScrapedTimes,
             Expr::col(media_items::Column::ScrapedTimes).add(1),
         )
+        // Stamped on every scrape completion regardless of outcome — not
+        // just failures — so `FAILED_ATTEMPTS_COOLDOWN_SQL`'s recency check
+        // applies even to an item that keeps finding a trickle of new (but
+        // never good enough to download) streams each cycle, resetting
+        // `failed_attempts` to 0 without ever recording that a scrape just
+        // happened. Without this, such an item's `last_scrape_attempt_at`
+        // stays NULL forever and it gets re-scraped on every retry tick
+        // with no cooldown at all.
+        .col_expr(media_items::Column::LastScrapeAttemptAt, Expr::cust("NOW()"))
         .col_expr(media_items::Column::UpdatedAt, Expr::cust("NOW()"))
         .filter(media_items::Column::Id.eq(id))
         .exec(orm())

--- a/crates/riven-db/src/repo/mod.rs
+++ b/crates/riven-db/src/repo/mod.rs
@@ -63,6 +63,14 @@ pub async fn retry_items_by_ids(ids: Vec<i64>) -> Result<u64> {
     }
     let result = media_items::Entity::update_many()
         .col_expr(media_items::Column::FailedAttempts, Expr::value(0))
+        // A manual retry must take effect on the very next `retry_library()`
+        // tick, not remain subject to `FAILED_ATTEMPTS_COOLDOWN_SQL`'s
+        // recency check — that cooldown exists to throttle *automatic*
+        // re-attempts, not a user's explicit "retry now". Clearing
+        // `last_scrape_attempt_at` alongside `failed_attempts` is what
+        // actually restores eligibility; resetting `failed_attempts` alone
+        // does nothing if the item was scraped within the last 30 minutes.
+        .col_expr(media_items::Column::LastScrapeAttemptAt, Expr::cust("NULL"))
         .col_expr(media_items::Column::UpdatedAt, Expr::cust("NOW()"))
         .filter(media_items::Column::Id.is_in(ids.iter().copied()))
         .exec(orm())

--- a/crates/riven-queue/src/application/download/mod.rs
+++ b/crates/riven-queue/src/application/download/mod.rs
@@ -210,6 +210,20 @@ pub async fn run_rank_streams(id: i64, job: &RankStreamsJob, queue: &JobQueue) {
     queue.push_download(download_job).await;
 }
 
+/// Bump `failed_attempts` on a failed download attempt — the same counter
+/// (and `FAILED_ATTEMPTS_COOLDOWN_SQL` escalating backoff) a scrape that
+/// finds no new streams uses. Without this, an item stuck in `Scraped`
+/// state with a ranked-but-never-downloadable stream (e.g. cinema-only CAM
+/// releases) never re-enters the scrape flow at all: `handle_scrape`'s
+/// "already scraped, try download instead" shortcut keeps retrying the
+/// same failing download every `retry_library()` tick forever, since only
+/// an actual scrape completion stamps `last_scrape_attempt_at`.
+async fn record_download_failure(id: i64) {
+    if let Err(err) = repo::increment_failed_attempts(id).await {
+        tracing::warn!(id, %err, "failed to increment failed_attempts");
+    }
+}
+
 /// find-valid-torrent + download-item fused. Reloads the item (matches
 /// `findOneOrFail` semantics at the step boundary), iterates ranked streams
 /// per profile, and per stream walks `(plugin, provider)` combinations with
@@ -253,6 +267,7 @@ pub async fn run(id: i64, job: &DownloadJob, queue: &JobQueue) {
 
     if all_streams.is_empty() {
         tracing::debug!(id, "no streams available for download");
+        record_download_failure(id).await;
         queue
             .notify(RivenEvent::MediaItemDownloadError {
                 id,
@@ -655,6 +670,7 @@ async fn run_downloads(
 
     if !any_success {
         tracing::debug!(id, title = %item.title, "no valid torrent found after trying cached candidates");
+        record_download_failure(id).await;
         queue
             .notify(RivenEvent::MediaItemDownloadError {
                 id,


### PR DESCRIPTION
## Summary

A released title with only unusable releases so far (e.g. cinema-only CAM/HDTS rips of a title with no proper release yet) can get retried on every single `retry_library()` tick — as often as every 10 minutes, indefinitely — instead of the intended escalating 30min/2h/6h/24h backoff, firing a fresh failure notification each time. Found and confirmed against a live production instance: a movie sitting at `failed_attempts=0` for weeks, generating dozens of notifications a day.

Three independent code paths bypass the cooldown mechanism, for different reasons — this PR fixes all three, each verified live against the running production instance as they were found.

### Fix 1 — scrape-retry path (`crates/riven-db/src/repo/media.rs`)

1. `last_scrape_attempt_at` was only ever stamped inside `increment_failed_attempts` — i.e. only on a scrape that found **zero** new streams. Any scrape that links at least one new (but not necessarily usable) stream calls `reset_failed_attempts` instead, which zeroes `failed_attempts` without touching `last_scrape_attempt_at`. For a title that keeps surfacing a slow trickle of new-but-junk uploads (common for CAM/HDTS-only cinema releases, where indexers keep getting fresh reposts under new info_hashes), `last_scrape_attempt_at` never gets set at all.

2. `FAILED_ATTEMPTS_COOLDOWN_SQL` had a `failed_attempts = 0 OR ...` bypass clause that made the whole recency check moot whenever the counter was at 0 — which, per #1, is an item's normal resting state after any such "found something new but useless" scrape. Combined with `last_scrape_attempt_at IS NULL`, an item stuck in this loop was **permanently** eligible for the next retry tick with no cooldown at all, not even the base 30-minute tier.

**Fix**: `update_scraped()` now stamps `last_scrape_attempt_at` on every scrape completion regardless of outcome. Removed the cooldown SQL's `failed_attempts = 0 OR` bypass clause — `last_scrape_attempt_at IS NULL` alone already correctly covers "never scraped yet," and the existing `ELSE` tier already gives `failed_attempts` 0/1 the intended base 30-minute wait via the recency check.

### Fix 2 — download-retry path (`crates/riven-queue/src/application/download/mod.rs`)

This turned out to be the one actually generating the reported notifications ("no valid torrent found after trying cached candidates" popups). An item already in `Scraped` state with at least one ranked stream — even an unusable one — never re-enters the scrape flow at all: `handle_scrape`'s "already scraped, try download instead of re-scraping" shortcut calls `push_download_from_best_stream` and returns immediately on success, without ever calling `push_scrape`. Since only the scrape flow's `update_scraped()` stamps `last_scrape_attempt_at`, an item stuck in this shortcut loop stayed permanently eligible for `retry_library()` regardless of Fix 1 — it just kept retrying the same failing download every tick, firing a `MediaItemDownloadError` notification each time.

**Fix**: both `MediaItemDownloadError` failure points in `run()` (no streams available at all, and no candidate downloadable after trying cache/debrid) now call the same `increment_failed_attempts` used by scrape failures, feeding the identical `failed_attempts` counter and cooldown. A later successful download isn't a "one-way ratchet" concern: it moves the item to `Completed` state via `state::recompute()`, which removes it from the retry pool regardless of the counter's value.

### Fix 3 — manual retry button (`crates/riven-db/src/repo/mod.rs`)

Found while testing Fixes 1 and 2 live: the "retry" button's mutation (`retry_items_by_ids`) only reset `failed_attempts` to 0, never touching `last_scrape_attempt_at`. Before Fix 1, that was enough — the old bypass meant resetting the counter alone always restored eligibility. With the bypass correctly removed, a manual retry now only resets the counter, but the cooldown tier is still computed against the *unchanged* `last_scrape_attempt_at` — so clicking "retry" on an item scraped within the last 30 minutes silently did nothing until that window naturally expired, with no indication to the user that their retry hadn't taken effect.

**Fix**: `retry_items_by_ids()` now also clears `last_scrape_attempt_at` to `NULL`. The cooldown exists to throttle *automatic* re-attempts, not a user's explicit "retry now" — a manual retry should always take effect on the very next `retry_library()` tick.

## Verification

All three fixes were verified live against the real running production instance as each was found, not just unit-tested in isolation:

- **Fix 1**: `FAILED_ATTEMPTS_COOLDOWN_SQL` is a raw time-based SQL fragment with no DB-integration test harness in this crate, so verified against real production data instead — ran the old vs. new filter logic directly against a real affected row via `psql`: old filter reports the item eligible immediately (the bug); new filter, simulating a stamped scrape, correctly excludes it for 30 minutes.
- **Fix 2**: redeployed to production with this fix, and the very next `retry_library()` tick reproduced the exact failing download for the real affected item (id 36139, stuck at `failed_attempts=0` for weeks). Confirmed the fix caught it — `failed_attempts` incremented and `last_scrape_attempt_at` was stamped for the first time ever — and confirmed via the cooldown query that the item is now correctly excluded from further retries.
- **Fix 3**: redeployed to production with this fix, and confirmed via a real item (id 37107, "Disclosure Day", ~27 minutes into its 30-minute cooldown window) that triggering `retryItems` immediately clears `last_scrape_attempt_at` and the item becomes eligible right away, rather than still being blocked for the remaining ~3 minutes.

## Test plan

- [x] `cargo test -p riven-db -p riven-queue -p riven-api` — all passing, no regressions
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean on touched files
- [x] `cargo fmt --all --check` clean (no unrelated formatting changes bundled in)
- [x] Fix 1 verified against a real affected production row (SQL-level before/after comparison)
- [x] Fix 2 verified live end-to-end against the real affected production item (redeployed, reproduced the bug, confirmed the fix engages and the cooldown correctly applies afterward)
- [x] Fix 3 verified live end-to-end against a real production item mid-cooldown (redeployed, confirmed manual retry now takes immediate effect)