### PR TITLE
fix: job-level retry backoff bypassed the cooldown, duplicate notify on multi-candidate failures, stuck unreleased-transition loop

### DIFF
--- a/crates/riven-db/src/repo/media.rs
+++ b/crates/riven-db/src/repo/media.rs
@@ -157,6 +157,21 @@ pub(crate) const FAILED_ATTEMPTS_COOLDOWN_SQL: &str = "(
     END)
 )";
 
+/// Same escalating tiers as [`FAILED_ATTEMPTS_COOLDOWN_SQL`], for callers that
+/// schedule a delayed re-attempt directly (e.g. `handle_validate`'s
+/// job-level retry) instead of going through [`get_pending_items_for_retry`].
+/// That job-level retry doesn't consult the DB cooldown at all — without
+/// this, an item stuck failing every download keeps retrying every 30
+/// minutes forever instead of backing off. Keep both in sync.
+pub fn cooldown_for_failed_attempts(failed_attempts: i32) -> chrono::Duration {
+    match failed_attempts {
+        n if n >= 10 => chrono::Duration::hours(24),
+        n if n >= 5 => chrono::Duration::hours(6),
+        n if n >= 2 => chrono::Duration::hours(2),
+        _ => chrono::Duration::minutes(30),
+    }
+}
+
 /// Fetch all pending top-level items needing a retry: Indexed, Scraped, or PartiallyCompleted.
 pub async fn get_pending_items_for_retry(item_type: MediaItemType) -> Result<Vec<MediaItem>> {
     Ok(media_items::Entity::find()

--- a/crates/riven-db/src/repo/media.rs
+++ b/crates/riven-db/src/repo/media.rs
@@ -427,8 +427,25 @@ pub async fn transition_unreleased_aired() -> Result<Vec<i64>> {
         .into_tuple()
         .all(orm())
         .await?;
+    if ids.is_empty() {
+        return Ok(ids);
+    }
     super::state::recompute(&ids).await?;
-    Ok(ids)
+
+    // A show/season can still legitimately be `Unreleased` after recompute —
+    // e.g. a show whose own air date has passed but has a season that hasn't
+    // aired yet. Only report ids that actually left `Unreleased`; otherwise
+    // this query re-matches the same stuck item on every caller tick
+    // forever, each time re-cascading a `process_media_item` push to its
+    // children for nothing.
+    Ok(media_items::Entity::find()
+        .filter(media_items::Column::Id.is_in(ids))
+        .filter(media_items::Column::State.ne(MediaItemState::Unreleased))
+        .select_only()
+        .column(media_items::Column::Id)
+        .into_tuple()
+        .all(orm())
+        .await?)
 }
 
 pub async fn blacklist_stream_by_hash(media_item_id: i64, info_hash: &str) -> Result<()> {

--- a/crates/riven-db/tests/media.rs
+++ b/crates/riven-db/tests/media.rs
@@ -1,0 +1,41 @@
+use riven_db::repo::media::cooldown_for_failed_attempts;
+
+// Must mirror `FAILED_ATTEMPTS_COOLDOWN_SQL`'s tiers exactly — this is the
+// job-level retry's only backoff signal, since it doesn't go through
+// `get_pending_items_for_retry`'s SQL filter.
+
+#[test]
+fn base_tier_under_two_failures() {
+    assert_eq!(
+        cooldown_for_failed_attempts(0),
+        chrono::Duration::minutes(30)
+    );
+    assert_eq!(
+        cooldown_for_failed_attempts(1),
+        chrono::Duration::minutes(30)
+    );
+}
+
+#[test]
+fn escalates_at_two_failures() {
+    assert_eq!(cooldown_for_failed_attempts(2), chrono::Duration::hours(2));
+    assert_eq!(cooldown_for_failed_attempts(4), chrono::Duration::hours(2));
+}
+
+#[test]
+fn escalates_at_five_failures() {
+    assert_eq!(cooldown_for_failed_attempts(5), chrono::Duration::hours(6));
+    assert_eq!(cooldown_for_failed_attempts(9), chrono::Duration::hours(6));
+}
+
+#[test]
+fn escalates_at_ten_failures() {
+    assert_eq!(
+        cooldown_for_failed_attempts(10),
+        chrono::Duration::hours(24)
+    );
+    assert_eq!(
+        cooldown_for_failed_attempts(1000),
+        chrono::Duration::hours(24)
+    );
+}

--- a/crates/riven-queue/src/application/download/persist.rs
+++ b/crates/riven-queue/src/application/download/persist.rs
@@ -139,11 +139,15 @@ pub async fn persist_movie(
         );
         largest
     } else {
+        // Blacklist only — this is one candidate among possibly many the
+        // outer stream loop still has left to try; a per-candidate notify
+        // here would fire `MediaItemDownloadPartialSuccess` once per dead
+        // candidate, each independently pushing the item to `Validate` and
+        // scheduling its own 30-minute re-scrape. The loop's single
+        // exhausted-all-candidates check is the only place that should
+        // notify for this attempt.
         tracing::warn!(id, info_hash = %info_hash, "torrent has no files — blacklisting stream");
         blacklist_stream(id, info_hash).await;
-        queue
-            .notify(RivenEvent::MediaItemDownloadPartialSuccess { id })
-            .await;
         return false;
     };
 
@@ -156,14 +160,14 @@ pub async fn persist_movie(
     drop(config);
 
     if !has_playable_url(file) {
+        // See the "torrent has no files" branch above: blacklist and let
+        // the outer stream loop try the next candidate without firing a
+        // per-candidate notify.
         tracing::warn!(
             id, info_hash = %info_hash, filename = %file.filename,
             "matched movie file has no playable URL — blacklisting stream"
         );
         blacklist_stream(id, info_hash).await;
-        queue
-            .notify(RivenEvent::MediaItemDownloadPartialSuccess { id })
-            .await;
         return false;
     }
 
@@ -317,15 +321,14 @@ pub async fn persist_episode(
     }
 
     if matched.is_empty() {
+        // Blacklist only — see the equivalent branch in `persist_movie` for
+        // why this must not notify per candidate.
         tracing::warn!(
             id, season = season_number, episode = episode_number,
             info_hash = %info_hash,
             "no playable torrent file matched episode — blacklisting stream"
         );
         blacklist_stream(id, info_hash).await;
-        queue
-            .notify(RivenEvent::MediaItemDownloadPartialSuccess { id })
-            .await;
         return false;
     }
 

--- a/crates/riven-queue/src/application/process_media_item.rs
+++ b/crates/riven-queue/src/application/process_media_item.rs
@@ -18,7 +18,7 @@
 //! `push_process_media_item`. This prevents multiple writers re-scheduling
 //! the same scrape into the future indefinitely.
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Utc};
 use riven_core::types::{MediaItemState, MediaItemType};
 use riven_db::entities::MediaItem;
 use riven_db::repo;
@@ -142,7 +142,11 @@ async fn handle_validate(job: &ProcessMediaItemJob, item: &MediaItem, queue: &Jo
         }
         MediaItemState::Failed | MediaItemState::Paused => {}
         MediaItemState::Scraped | MediaItemState::Indexed | MediaItemState::Unreleased => {
-            let at = Utc::now() + Duration::minutes(30);
+            // Mirrors `FAILED_ATTEMPTS_COOLDOWN_SQL`'s escalating tiers — this
+            // job-level re-push doesn't go through `get_pending_items_for_retry`,
+            // so without this it would keep retrying every 30 minutes forever
+            // regardless of how many times the item has already failed.
+            let at = Utc::now() + repo::cooldown_for_failed_attempts(item.failed_attempts);
             tracing::debug!(
                 id = item.id,
                 run_at = %at,


### PR DESCRIPTION
## Summary

Three further gaps in the retry/notification path, found live in production after #5 landed — notifications had dropped sharply but not to the expected level, and a couple of items kept looping.

- **Job-level retry backoff ignored `failed_attempts` entirely.** `handle_validate()`'s delayed self-reschedule (the path taken after any download failure) was hardcoded to `Utc::now() + 30 minutes`, completely bypassing the escalating 30min/2h/6h/24h cooldown that `FAILED_ATTEMPTS_COOLDOWN_SQL` and #5 established for the DB-level retry scan. This is a second, independent retry mechanism that never consulted the DB cooldown at all — an item stuck failing every download kept retrying every 30 minutes forever, regardless of how many times it had already failed. Confirmed live via direct Redis `scheduled` ZSET inspection: fixed 30-minute gaps despite `failed_attempts` reaching 4–8. Fixed with a new `cooldown_for_failed_attempts()` helper shared between the SQL filter's tiers and this job-level scheduling call.

- **Per-candidate download failure fired a premature retry notify.** `persist_movie`/`persist_episode` called `queue.notify(MediaItemDownloadPartialSuccess)` once per dead candidate inside the outer stream-loop (torrent has no files / no playable URL / no file matched the episode), instead of only once after all candidates in an attempt were exhausted. Each notify independently pushed the item to `Validate` and scheduled its own delayed re-scrape, so an attempt with N dead candidates produced N duplicate scheduled jobs. Confirmed live via diagnostic tracing: 5 duplicate `Validate` steps for one item, 3 duplicate scheduled jobs for another within 2 seconds. Fixed by removing the notify from these branches — blacklisting the candidate and returning `false` is enough; the outer loop's single exhausted-all-candidates check is the only place that should notify for the attempt.

- **`transition_unreleased_aired()` could loop on the same item forever.** It selected items by their own `aired_at` date without checking whether `recompute()` actually moved them out of `Unreleased` — a show whose own air date passed but that still has an unreleased future season remains legitimately `Unreleased` after recompute, so it matched the query again on every 2-minute tick. Confirmed live: one spurious log line + cascade every 2 minutes before the fix, zero over 5+ minutes after. Fixed by only returning ids that actually left `Unreleased`.

## Test plan

- [x] `cargo test -p riven-db -p riven-queue` — added unit tests for `cooldown_for_failed_attempts`'s tiers (`crates/riven-db/tests/media.rs`); the other two fixes are DB/queue-coupled and verified live against production per CONTRIBUTING.md's integration-only carve-out (consistent with #5's precedent).
- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` — all clean on this branch after merging latest `main`.
- [x] Deployed to a live production instance; confirmed clean startup and normal processing, and confirmed each fix's specific failure signature (duplicate scheduled jobs, fixed-30-min cadence, 2-minute spurious loop) no longer reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Retry delays now increase after repeated download or processing failures, helping reduce unnecessary repeated attempts.
  - Media items are reported as completed only when their state successfully changes, improving processing accuracy.
  - Prevented misleading partial-success notifications when downloaded content cannot be used or matched.
- **Bug Fixes**
  - Improved handling of failed media persistence and retry scheduling for more reliable download workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->