### PR TITLE
fix: NZB download dispatch tries every configured debrid store before stremthru

### DIFF
--- a/crates/plugin-stremthru/src/lib.rs
+++ b/crates/plugin-stremthru/src/lib.rs
@@ -74,15 +74,43 @@ fn get_configured_stores(settings: &PluginSettings) -> Vec<(&'static str, String
         .collect()
 }
 
-/// Newz-capable stores: the configured debrid stores plus `stremthru` itself
-/// when `stremthruauth` is set (a self-hosted StremThru with NNTP +
-/// Newznab indexers configured in its dashboard).
-fn get_newz_stores(settings: &PluginSettings) -> Vec<(&'static str, String)> {
+/// Candidate stores for stream-link generation/refresh: the configured debrid
+/// (torz) stores plus `stremthru` itself when `stremthruauth` is set. An
+/// entry originally served via newz needs `stremthru` in this list to remain
+/// reachable for the link refresh; entries served via a debrid store need
+/// that store. Unlike [`get_newz_dispatch_stores`], it's fine for this list
+/// to include stores that can't serve newz — the caller pins/filters by the
+/// specific store that already generated the link, so an irrelevant entry is
+/// simply never tried.
+fn get_link_stores(settings: &PluginSettings) -> Vec<(&'static str, String)> {
     let mut stores = get_configured_stores(settings);
     if let Some(auth) = settings.get("stremthruauth") {
         stores.push(("stremthru", auth.to_string()));
     }
     stores
+}
+
+/// Stores to try when dispatching a fresh NZB for download. `/v0/store/newz`
+/// only accepts a self-hosted StremThru instance (NNTP + Newznab indexers
+/// configured in its own dashboard) — debrid stores (realdebrid, alldebrid,
+/// torbox, ...) reject every newz dispatch with a 400 `store does not
+/// support newz`, so they must never be included here (unlike
+/// [`get_link_stores`], every store in this list is actually tried in a
+/// fresh, unpinned attempt, so an irrelevant one isn't just wasted — it
+/// spends a real request and dings that store's health score).
+///
+/// Deliberately gated on `stremthruauth` alone, not `newznabenabled`:
+/// `newznabenabled` only controls whether this plugin's own aggregator is
+/// queried when *scraping*, but download dispatch is broadcast to every
+/// plugin regardless of which one scraped the result — a self-hosted
+/// StremThru can serve as a pure download backend for NZBs found by another
+/// plugin (e.g. a dedicated Newznab plugin), so the download step must stay
+/// decoupled from the scrape-side toggle.
+fn get_newz_dispatch_stores(settings: &PluginSettings) -> Vec<(&'static str, String)> {
+    settings
+        .get("stremthruauth")
+        .map(|auth| vec![("stremthru", auth.to_string())])
+        .unwrap_or_default()
 }
 
 fn store_score_key(store: &str) -> String {
@@ -265,7 +293,7 @@ impl Plugin for StremthruPlugin {
         let mut any_network_error = false;
 
         if is_nzb_info_hash(info_hash) {
-            let newz_stores = get_newz_stores(&ctx.settings);
+            let newz_stores = get_newz_dispatch_stores(&ctx.settings);
             let newz_scores = get_store_scores(&ctx.redis, &newz_stores).await;
             return handle_newz_download(info_hash, &base_url, &newz_stores, &newz_scores, ctx)
                 .await;
@@ -528,7 +556,7 @@ impl Plugin for StremthruPlugin {
         ctx: &PluginContext,
     ) -> anyhow::Result<HookResponse> {
         let base_url = base_url(&ctx.settings);
-        let stores = get_newz_stores(&ctx.settings);
+        let stores = get_link_stores(&ctx.settings);
         let score_map = get_store_scores(&ctx.redis, &stores).await;
         let mut ordered_stores: Vec<(&str, &str)> = stores
             .iter()

--- a/crates/plugin-stremthru/src/tests/mod.rs
+++ b/crates/plugin-stremthru/src/tests/mod.rs
@@ -48,3 +48,50 @@ fn store_score_key_is_namespaced_by_store() {
         "plugin:stremthru:store-score:realdebrid"
     );
 }
+
+#[test]
+fn newz_dispatch_stores_excludes_debrid_stores() {
+    // Debrid stores reject every `/v0/store/newz` call with a 400 — a
+    // configured debrid API key must never end up in this list, even
+    // alongside a configured `stremthruauth`.
+    let stores = get_newz_dispatch_stores(&settings(&[
+        ("realdebridapikey", "rd-token"),
+        ("alldebridapikey", "ad-token"),
+        ("stremthruauth", "st-token"),
+    ]));
+
+    assert_eq!(stores, vec![("stremthru", "st-token".to_string())]);
+}
+
+#[test]
+fn newz_dispatch_stores_empty_without_stremthruauth() {
+    // No stremthruauth means no newz-capable store at all — must not fall
+    // back to trying debrid stores, which would just spend a wasted request
+    // and ding their health score for an API they don't support.
+    let stores = get_newz_dispatch_stores(&settings(&[
+        ("realdebridapikey", "rd-token"),
+        ("torboxapikey", "torbox-token"),
+    ]));
+
+    assert!(stores.is_empty());
+}
+
+#[test]
+fn link_stores_include_both_debrid_and_stremthru() {
+    // Unlike get_newz_dispatch_stores, this list backs stream-link
+    // generation/refresh, which is always pinned/filtered to one specific
+    // store by the caller — so it's fine (and necessary) for it to include
+    // every possible originating store, newz-capable or not.
+    let stores = get_link_stores(&settings(&[
+        ("realdebridapikey", "rd-token"),
+        ("stremthruauth", "st-token"),
+    ]));
+
+    assert_eq!(
+        stores,
+        vec![
+            ("realdebrid", "rd-token".to_string()),
+            ("stremthru", "st-token".to_string()),
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2.

`get_newz_stores()` built the store list for a fresh NZB download attempt (`on_download_requested` → `handle_newz_download`) from `get_configured_stores()` (every debrid store with an API key configured) plus `stremthru` when `stremthruauth` was set. Debrid stores (realdebrid, alldebrid, torbox, ...) are torz-only and reject every `/v0/store/newz` call with a 400 `store does not support newz` — confirmed against the exact production log in the issue. So every NZB download attempt burned a spurious failing request per configured debrid store before, if ever, reaching `stremthru`; with no `stremthruauth` set, NZB downloads could never succeed at all. Each spurious 400 also calls `adjust_store_score(store, -1)`, and that score is keyed only by store name — shared with normal torrent (torz) dispatch — so this was quietly degrading debrid stores' health scores used for legitimate torrent downloads too, on top of the wasted requests.

This is independent of `newznabenabled`: that setting only gates whether this plugin's own aggregator is queried when *scraping* (`on_scrape_requested`). Download dispatch is broadcast to every registered plugin regardless of which one scraped the result (`queue.registry.dispatch(event)`), so `on_download_requested` fires for any NZB-format `info_hash` (`nzb-` prefix) found by any plugin — e.g. a dedicated Newznab plugin. A self-hosted StremThru can serve as a pure download backend for those NZBs, decoupled from its own search feature, so `stremthruauth` alone is the correct gate for the download step.

## Fix

Split the single `get_newz_stores()` into two correctly-scoped functions, since it had two call sites with genuinely different requirements:

- **`get_newz_dispatch_stores`**: only `stremthru` when `stremthruauth` is set. Used for the fresh-download dispatch (`on_download_requested`), where *every* store in the returned list is actually tried in an unpinned attempt — so an irrelevant store isn't just wasted, it spends a real request and dings that store's health score.
- **`get_link_stores`** (renamed from `get_newz_stores`, behavior unchanged): the original debrid + stremthru list, still used by `on_stream_link_requested`. There it's fine to include stores that can't serve newz, since that call always pins/filters to the one specific store that already generated the entry — an irrelevant store is simply never tried.

## Test plan

- [x] `cargo test -p plugin-stremthru` — added 3 unit tests: `get_newz_dispatch_stores` excludes debrid stores even when both a debrid key and `stremthruauth` are configured, is empty without `stremthruauth` (no silent fallback to debrid stores), and `get_link_stores` still returns both.
- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` — all clean on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NZB download routing to use StremThru when configured, avoiding unintended dispatch to other debrid services.
  * Preserved stream-link generation and refreshing across all eligible configured services.

* **Tests**
  * Added coverage for NZB routing and stream-link service selection, including behavior when StremThru authentication is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->