### PR TITLE
feat(events): include filesystem_paths in download.success

### DIFF
--- a/crates/riven-core/src/events/event.rs
+++ b/crates/riven-core/src/events/event.rs
@@ -128,6 +128,12 @@ pub enum RivenEvent {
         plugin_name: String,
         provider: Option<String>,
         duration_seconds: f64,
+        /// VFS paths of the media files this download made available, resolved
+        /// from `filesystem_entries` at emit time (a season/show carries every
+        /// child episode's path). Lets downstream consumers — e.g. an external
+        /// library scanner — act on the payload alone without a follow-up query.
+        #[serde(default)]
+        filesystem_paths: Vec<String>,
     },
     #[serde(rename = "riven.media-item.stream-link.requested")]
     MediaItemStreamLinkRequested {

--- a/crates/riven-core/src/plugin/traits.rs
+++ b/crates/riven-core/src/plugin/traits.rs
@@ -265,6 +265,9 @@ pub trait Plugin: Send + Sync + 'static {
                 plugin_name,
                 provider,
                 duration_seconds,
+                // Carried on the raw event for outbound consumers (webhooks);
+                // the in-process DownloadSuccessInfo dispatch doesn't need it.
+                filesystem_paths: _,
             } => {
                 let info = DownloadSuccessInfo {
                     id: *id,

--- a/crates/riven-queue/src/application/download/persist.rs
+++ b/crates/riven-queue/src/application/download/persist.rs
@@ -642,6 +642,7 @@ pub async fn persist_season(
 
     let duration = start_time.elapsed();
     let display_title = format!("{} - {}", show.title, item.title);
+    let filesystem_paths = download_success_paths(id).await;
     queue
         .notify(RivenEvent::MediaItemDownloadSuccess {
             id,
@@ -655,6 +656,7 @@ pub async fn persist_season(
             plugin_name: dl.plugin_name,
             provider: dl.provider,
             duration_seconds: duration.as_secs_f64(),
+            filesystem_paths,
         })
         .await;
     tracing::info!(
@@ -799,6 +801,7 @@ pub async fn persist_show(
         .fetch_add(1, Ordering::SeqCst);
 
     let duration = start_time.elapsed();
+    let filesystem_paths = download_success_paths(id).await;
     queue
         .notify(RivenEvent::MediaItemDownloadSuccess {
             id,
@@ -812,6 +815,7 @@ pub async fn persist_show(
             plugin_name: dl.plugin_name,
             provider: dl.provider,
             duration_seconds: duration.as_secs_f64(),
+            filesystem_paths,
         })
         .await;
     tracing::info!(
@@ -1066,6 +1070,25 @@ async fn persist_supplied_show_download(
     Ok(())
 }
 
+/// Resolve the VFS media paths a just-completed download exposes, for
+/// attaching to `MediaItemDownloadSuccess`. The recursive lookup walks child
+/// items, so a season/show id yields every completed episode's path. It is
+/// best-effort: a lookup failure logs and yields an empty list rather than
+/// blocking the success notification.
+async fn download_success_paths(id: i64) -> Vec<String> {
+    match repo::get_media_entry_paths_for_items(&[id]).await {
+        Ok(paths) => paths,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                id,
+                "failed to resolve filesystem paths for download-success event"
+            );
+            Vec::new()
+        }
+    }
+}
+
 pub async fn finalize_download_success(
     id: i64,
     item: &MediaItem,
@@ -1083,6 +1106,7 @@ pub async fn finalize_download_success(
         .fetch_add(1, Ordering::SeqCst);
 
     let duration = start_time.elapsed();
+    let filesystem_paths = download_success_paths(id).await;
     queue
         .notify(RivenEvent::MediaItemDownloadSuccess {
             id,
@@ -1096,6 +1120,7 @@ pub async fn finalize_download_success(
             plugin_name: plugin_name.unwrap_or_default(),
             provider,
             duration_seconds: duration.as_secs_f64(),
+            filesystem_paths,
         })
         .await;
     tracing::info!(


### PR DESCRIPTION
Attach the VFS media paths a finished download exposes to MediaItemDownloadSuccess, resolved from filesystem_entries at emit time via the existing recursive get_media_entry_paths_for_items (so a season/show carries every child episode's path). Lets outbound webhook consumers act on the payload alone without a follow-up query. Additive and #[serde(default)], so existing consumers are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download success notifications now include the filesystem paths made available by the completed download.
  * Path information is provided directly in the notification, reducing the need for follow-up lookups.

* **Bug Fixes**
  * Download completion notifications continue to be delivered even when filesystem path resolution is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->