### PR TITLE
Update Jellyfin/Emby Plugin

### DIFF
--- a/crates/plugin-emby-jellyfin/src/lib.rs
+++ b/crates/plugin-emby-jellyfin/src/lib.rs
@@ -26,7 +26,9 @@ pub struct EmbyPlugin;
 #[derive(Default)]
 pub struct JellyfinPlugin;
 
-const MEDIA_SERVER_TOKEN_HEADER: &str = "X-Emby-Token";
+/// Legacy header understood by Emby, and by Jellyfin servers older than 12.0
+/// (as a fallback, when legacy auth hasn't been disabled).
+const EMBY_TOKEN_HEADER: &str = "X-Emby-Token";
 
 #[derive(Serialize)]
 struct LibraryUpdate<'a> {
@@ -42,15 +44,23 @@ struct PathUpdate<'a> {
     update_type: &'a str,
 }
 
+/// Builds an authenticated request for a media server.
+/// Jellyfin 12.0 disabled the legacy headers i.e. X-Emby-Token by default. 
+/// Jellyfin reimplementation uses `ApiKey` which supports >=10.8 
+/// Emby has not made this change continues to use `X-Emby-Token` header.
 fn media_server_request(
     client: &reqwest::Client,
     method: Method,
     url: &str,
     api_key: &str,
+    plugin: &str,
 ) -> reqwest::RequestBuilder {
-    client
-        .request(method, url)
-        .header(MEDIA_SERVER_TOKEN_HEADER, api_key)
+    let req = client.request(method, url);
+    if plugin == "jellyfin" {
+        req.query(&[("ApiKey", api_key)])
+    } else {
+        req.header(EMBY_TOKEN_HEADER, api_key)
+    }
 }
 
 /// Notify a Jellyfin/Emby server that the given VFS paths were created.
@@ -76,7 +86,7 @@ pub(crate) async fn notify_paths(
     let body = LibraryUpdate { updates };
     let resp = http
         .send(server_profile(plugin), |client| {
-            media_server_request(client, Method::POST, &url, api_key).json(&body)
+            media_server_request(client, Method::POST, &url, api_key, plugin).json(&body)
         })
         .await?;
 
@@ -98,7 +108,7 @@ async fn refresh_library(
     tracing::debug!(plugin, target_url = %url, "requesting media server library refresh");
     let resp = http
         .send(server_profile(plugin), |client| {
-            media_server_request(client, Method::POST, &url, api_key)
+            media_server_request(client, Method::POST, &url, api_key, plugin)
         })
         .await?;
 
@@ -311,7 +321,8 @@ async fn get_artwork(
     );
     let response = http
         .send(server_profile(server), |client| {
-            media_server_request(client, Method::GET, &url, api_key).header("accept", "image/*")
+            media_server_request(client, Method::GET, &url, api_key, server)
+                .header("accept", "image/*")
         })
         .await?
         .error_for_status()?;
@@ -352,7 +363,7 @@ async fn get_active_sessions(
     tracing::debug!(server, target_url = %url, "fetching active playback sessions from media server");
     let resp: Vec<MediaServerSession> = http
         .get_json(server_profile(server), url.clone(), |client| {
-            media_server_request(client, Method::GET, &url, api_key)
+            media_server_request(client, Method::GET, &url, api_key, server)
         })
         .await?;
 

--- a/crates/plugin-emby-jellyfin/src/tests.rs
+++ b/crates/plugin-emby-jellyfin/src/tests.rs
@@ -21,13 +21,14 @@ fn rewrite_media_path_handles_slashes_once() {
 }
 
 #[test]
-fn media_server_request_uses_header_auth_without_query_token() {
+fn media_server_request_uses_header_auth_emby() {
     let client = reqwest::Client::new();
     let request = media_server_request(
         &client,
         reqwest::Method::POST,
         "https://emby.example.test/Library/Media/Updated",
         "secret-token",
+        "emby",
     )
     .build()
     .expect("request should build");
@@ -35,11 +36,34 @@ fn media_server_request_uses_header_auth_without_query_token() {
     assert_eq!(
         request
             .headers()
-            .get(MEDIA_SERVER_TOKEN_HEADER)
+            .get(EMBY_TOKEN_HEADER)
             .and_then(|value| value.to_str().ok()),
         Some("secret-token")
     );
     assert_eq!(request.url().query(), None);
+}
+
+#[test]
+fn media_server_request_uses_query_auth_jellyfin() {
+    let client = reqwest::Client::new();
+    let request = media_server_request(
+        &client,
+        reqwest::Method::POST,
+        "https://jellyfin.example.test/Library/Media/Updated",
+        "secret-token",
+        "jellyfin",
+    )
+    .build()
+    .expect("request should build");
+    assert_eq!(request.headers().get(EMBY_TOKEN_HEADER), None);
+    assert_eq!(
+        request
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "ApiKey")
+            .map(|(_, value)| value.into_owned()),
+        Some("secret-token".to_string())
+    );
 }
 
 #[test]


### PR DESCRIPTION
- Jellyfin/Emby plugin now checks which plugin is being used. If it is Emby it will continue to use X-Emby-Token.
- If the plugin is Jellyfin it will instead use ApiKey. This is due to X-Emby-Token being depreciated from Jellyfin and being disabled by default in 12.0 and will be removed in 13.0 according to a dev post I've seen.
- The code passes when running "make verify" and "cargo clippy --workspace --all-targets -- -D warnings" as recommended by contributing.md. 
- I've tested it both on Jellyfin 12.0 RC 4 and 10.11.11 (albeit less on 10.11.11) and the code now works for both versions, prior to this it would fail on 12.0.  
- There is an unrelated issue using make verify relating to rkyv and warning regarding proc-macro-error2 being unmaintained.

This is my first time make a pull request of this size/for a project of this complexity. Let me know if there are any mistakes or things that should be changed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication compatibility for Jellyfin media-server requests.
  * Preserved Emby authentication behavior using the token header.
  * Updated media-server operations, including library refreshes, artwork, notifications, and session requests, to authenticate correctly for each provider.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->