### PR TITLE
fix(auth): validate OIDC issuer scheme before fetching discovery

### DIFF
--- a/crates/plugin-emby-jellyfin/src/lib.rs
+++ b/crates/plugin-emby-jellyfin/src/lib.rs
@@ -45,8 +45,8 @@ struct PathUpdate<'a> {
 }
 
 /// Builds an authenticated request for a media server.
-/// Jellyfin 12.0 disabled the legacy headers i.e. X-Emby-Token by default. 
-/// Jellyfin reimplementation uses `ApiKey` which supports >=10.8 
+/// Jellyfin 12.0 disabled the legacy headers i.e. X-Emby-Token by default.
+/// Jellyfin reimplementation uses `ApiKey` which supports >=10.8
 /// Emby has not made this change continues to use `X-Emby-Token` header.
 fn media_server_request(
     client: &reqwest::Client,

--- a/crates/riven-api/src/server/oidc.rs
+++ b/crates/riven-api/src/server/oidc.rs
@@ -23,20 +23,28 @@ struct DiscoveryDocument {
 }
 
 /// Fetches and parses `{issuer}/.well-known/openid-configuration`, rejecting
-/// a document whose `authorization_endpoint`, `token_endpoint` or
-/// `userinfo_endpoint` isn't `https://` — `client_secret` and access tokens
-/// go out to those endpoints, so a cleartext one (a misconfigured issuer, or
-/// discovery served over plain HTTP by an on-path attacker) would send
-/// credentials over the wire in the open. Plain `http://` is accepted only to
-/// a loopback address, since that traffic never leaves the machine — this
-/// module's own tests run discovery against a local mock server with no
-/// certificate.
+/// a cleartext issuer or a document whose `authorization_endpoint`,
+/// `token_endpoint` or `userinfo_endpoint` isn't `https://` —
+/// `client_secret` and access tokens go out to those endpoints, so any of
+/// this over plain HTTP (a misconfigured issuer, or a request or redirect
+/// intercepted by an on-path attacker) would send credentials over the wire
+/// in the open, or hand discovery itself to a document the attacker
+/// controls. Plain `http://` is accepted only to a loopback address, since
+/// that traffic never leaves the machine — this module's own tests run
+/// discovery against a local mock server with no certificate. Redirects are
+/// refused outright rather than validated one by one: a discovery document
+/// has no legitimate reason to live behind one.
 async fn discover(issuer: &str) -> anyhow::Result<DiscoveryDocument> {
     let issuer = issuer.trim_end_matches('/');
+    anyhow::ensure!(
+        is_https_or_loopback(issuer),
+        "issuer is not https and not a loopback address: {issuer}"
+    );
     let url = format!("{issuer}/.well-known/openid-configuration");
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
         .build()?;
     let response = client.get(&url).send().await?.error_for_status()?;
     let doc = response.json::<DiscoveryDocument>().await?;
@@ -162,6 +170,29 @@ mod tests {
             id: "broken".to_string(),
             name: "Broken".to_string(),
             issuer: "http://127.0.0.1:1".to_string(), // nothing listens on port 1
+            client_id: "id".to_string(),
+            client_secret: "secret".to_string(),
+            scopes: Vec::new(),
+            disable_sign_up: false,
+            trust_unverified_email: false,
+        }];
+
+        let resolved = resolve_providers(&configured).await;
+
+        assert!(resolved.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_providers_skips_a_non_loopback_cleartext_issuer() {
+        // Never sends a request — a cleartext, non-loopback issuer is refused
+        // before the fetch, since an on-path attacker intercepting that
+        // request could substitute their own discovery document (whose
+        // endpoints could themselves be `https://`, so validating only the
+        // returned endpoints isn't enough).
+        let configured = vec![OidcProviderSettings {
+            id: "insecure-issuer".to_string(),
+            name: "Insecure Issuer".to_string(),
+            issuer: "http://idp.example.com".to_string(),
             client_id: "id".to_string(),
             client_secret: "secret".to_string(),
             scopes: Vec::new(),


### PR DESCRIPTION
## Summary

Follow-up to #18. CodeRabbit's re-review on that PR caught one remaining gap after it had already merged: `discover()` validated the endpoints *returned by* the discovery document as `https://`-or-loopback, but the initial request that fetches the document itself went out over whatever scheme the configured `issuer` used — no validation.

- An on-path attacker intercepting a cleartext (`http://`) issuer's discovery request could substitute their own discovery document. Since that document's endpoints could themselves be `https://`, validating only the returned endpoints wasn't sufficient to catch this.
- `discover()` now rejects a non-loopback `http://` issuer before making any request, reusing the existing `is_https_or_loopback` helper.
- Also disables HTTP redirects on the discovery client (`reqwest::redirect::Policy::none()`). `reqwest`'s default policy follows up to 10 redirects across schemes, so a compromised HTTPS server redirecting to `http://` would otherwise bypass the issuer check the same way.
- Includes an incidental `cargo fmt` fix for trailing whitespace in `plugin-emby-jellyfin` — unrelated pre-existing drift on `main` that fails the workspace-wide `fmt-check` gate regardless of this change, so it needed fixing for CI to pass here.

## Test plan

- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p riven-api` all clean, run against current `main`
- [x] New regression test `resolve_providers_skips_a_non_loopback_cleartext_issuer` — asserts the provider is skipped with zero network requests made
- [x] Deployed locally and confirmed PocketID (a real `https://` issuer) still resolves and signs in correctly after this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * OIDC discovery now accepts HTTP only for loopback addresses.
  * Invalid or insecure issuer URLs are rejected before any network request.
  * Automatic HTTP redirects are disabled during discovery.
  * Added coverage to verify that non-loopback cleartext issuers are skipped safely.

* **Documentation**
  * Clarified Jellyfin authentication compatibility notes without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->