### PR TITLE
fix: recover_stale_workers aborted the whole pass on an idle stale worker

### DIFF
--- a/crates/riven-queue/src/maintenance.rs
+++ b/crates/riven-queue/src/maintenance.rs
@@ -174,7 +174,15 @@ async fn rescue_workers(
         };
         let candidates: HashSet<String> = worker_jobs.into_iter().flatten().collect();
         let candidate_ids: Vec<String> = candidates.into_iter().collect();
-        let exists: Vec<bool> = {
+        // A stale worker with no jobs currently assigned to it (idle, just
+        // past the heartbeat threshold) leaves `candidate_ids` empty. Redis
+        // rejects a pipeline with zero queued commands ("empty command"), so
+        // this has to be skipped rather than sent — otherwise that one idle
+        // stale worker aborts recovery for every queue this pass, since the
+        // error propagates out of the whole function via `?`.
+        let exists: Vec<bool> = if candidate_ids.is_empty() {
+            Vec::new()
+        } else {
             let mut pipe = redis::pipe();
             for id in &candidate_ids {
                 pipe.cmd("HEXISTS").arg(config.job_data_hash()).arg(id);


### PR DESCRIPTION
## Summary
- `rescue_workers` built and sent a Redis pipeline unconditionally, even when `candidate_ids` was empty (an idle worker past the heartbeat threshold but with no jobs currently assigned).
- Redis rejects a zero-command pipeline ("empty command"), and that error propagates out of `rescue_workers` via `?` — so one idle stale worker aborted stale-worker recovery for every queue on that pass, not just its own.
- Guard the pipeline build/send with an emptiness check.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p riven-queue`
- [x] `cargo fmt --check` on the changed file specifically (the workspace-wide fmt-check has a pre-existing, unrelated failure in `dispatch.rs` already present on a clean `origin/main` checkout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale worker recovery by safely handling workers with no candidate jobs.
  * Prevented recovery attempts from failing due to an empty Redis operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->