### PR TITLE
fix: OIDC sign-in silently dropped the session cookie

### DIFF
--- a/crates/riven-api/src/server/authn/oauth.rs
+++ b/crates/riven-api/src/server/authn/oauth.rs
@@ -242,23 +242,42 @@ async fn callback_inner(
     let user = link_or_create_user(state, provider, &info, &token).await?;
     let token = create_session(&auth.db, &user.id, None).await?;
 
-    Ok((
-        StatusCode::FOUND,
-        [
-            (LOCATION, pending.callback_url),
-            (SET_COOKIE, session_cookie(auth.cookie_secure, &token)),
-            (
-                SET_COOKIE,
-                cookie(
-                    &cookie_name(STATE_COOKIE, auth.cookie_secure),
-                    "",
-                    0,
-                    auth.cookie_secure,
-                ),
-            ),
-        ],
-    )
-        .into_response())
+    // Two `Set-Cookie` headers, not one: axum's `[(K, V); N]` response impl
+    // calls `HeaderMap::insert` per entry, which — unlike every other
+    // header — is wrong for `Set-Cookie`, since a repeated `insert` replaces
+    // rather than adds and silently drops the first cookie. Building the
+    // `HeaderMap` directly and using `append` (what `Extend` uses internally)
+    // is what actually sends both.
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        LOCATION,
+        pending.callback_url.parse().map_err(|error| {
+            anyhow::anyhow!("callback URL is not a valid header value: {error}")
+        })?,
+    );
+    headers.append(
+        SET_COOKIE,
+        session_cookie(auth.cookie_secure, &token)
+            .parse()
+            .map_err(|error| {
+                anyhow::anyhow!("session cookie is not a valid header value: {error}")
+            })?,
+    );
+    headers.append(
+        SET_COOKIE,
+        cookie(
+            &cookie_name(STATE_COOKIE, auth.cookie_secure),
+            "",
+            0,
+            auth.cookie_secure,
+        )
+        .parse()
+        .map_err(|error| {
+            anyhow::anyhow!("state-clear cookie is not a valid header value: {error}")
+        })?,
+    );
+
+    Ok((StatusCode::FOUND, headers).into_response())
 }
 
 /// An existing `(provider, sub)` account row wins outright. Failing that, a


### PR DESCRIPTION
## Summary
- The OIDC callback's success response set two `Set-Cookie` headers (the session cookie, then an empty one clearing the temporary `oauth_state` cookie) via a plain `[(HeaderName, T); N]` array.
- axum-core's `IntoResponseParts` impl for that array type calls `HeaderMap::insert` per entry. Unlike every other header, `Set-Cookie` needs `append` — `insert` replaces rather than adds, so the second header silently dropped the first.
- The browser only ever received the (now-empty) cleared state cookie; the real session cookie never arrived, despite the callback returning a normal-looking `302` with no error logged.
- Fixed by building the response headers as a `HeaderMap` directly and using `.append()` (what `Extend` uses internally under the hood) for both `Set-Cookie` entries.

Confirmed live against a real PocketID instance: before the fix, `GET /auth/get-session` immediately after the callback returned `401`; after the fix, it returns `200` with the session body.

This is the only place in the auth module with this pattern — every other sign-in path (password, passkey) only ever sets one cookie at a time, so nothing else is affected.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p riven-api`
- [x] Verified live against a real PocketID instance (not just `cargo test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth sign-in redirects so session cookies are preserved correctly.
  * Ensured temporary authentication state is cleared after the callback.
  * Improved error messages when redirect or cookie headers cannot be processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->