### PR TITLE
fix: a downloaded file could not clear a stale Failed state

### DIFF
--- a/crates/riven-db/src/repo/state.rs
+++ b/crates/riven-db/src/repo/state.rs
@@ -178,9 +178,21 @@ async fn load_child_states(
 /// Apply the leaf-state rules. Pure so it can be unit-tested without a DB.
 ///
 /// Order matters: `Unreleased` (aired_at in the future) wins over everything,
-/// then sticky `Paused`/`Failed`, then the attempts ceiling, then media-entry
-/// existence (movies / episodes only), then any non-blacklisted stream.
-/// Default is `Indexed`.
+/// then sticky `Paused`, then media-entry existence (movies / episodes only),
+/// then sticky `Failed`, then the attempts ceiling, then any non-blacklisted
+/// stream. Default is `Indexed`.
+///
+/// `Failed` is sticky against everything *except* a real media entry: a
+/// season-pack download matches files by season+episode number regardless of
+/// the target episode's current state, so an episode marked `Failed` long ago
+/// can still receive a genuine file today (e.g. once a season-level retry
+/// that was previously stuck on an earlier episode finally reaches it). A
+/// media entry on disk is a stronger, more direct signal than the
+/// `failed_attempts` counter — leaving the item stuck on `Failed` after that
+/// would mean a real download nobody can see. `Paused` stays sticky
+/// unconditionally: it is a deliberate user action, and a paused item is
+/// excluded from the download pipeline in the first place, so it cannot
+/// legitimately acquire a new media entry to override it with anyway.
 pub fn leaf_state(
     item_type: MediaItemType,
     current_state: MediaItemState,
@@ -193,17 +205,17 @@ pub fn leaf_state(
     if is_unreleased {
         return MediaItemState::Unreleased;
     }
-    if matches!(
-        current_state,
-        MediaItemState::Paused | MediaItemState::Failed
-    ) {
+    if current_state == MediaItemState::Paused {
+        return current_state;
+    }
+    if matches!(item_type, MediaItemType::Movie | MediaItemType::Episode) && has_media_entry {
+        return MediaItemState::Completed;
+    }
+    if current_state == MediaItemState::Failed {
         return current_state;
     }
     if max_attempts > 0 && failed_attempts >= max_attempts {
         return MediaItemState::Failed;
-    }
-    if matches!(item_type, MediaItemType::Movie | MediaItemType::Episode) && has_media_entry {
-        return MediaItemState::Completed;
     }
     if has_non_blacklisted_stream {
         return MediaItemState::Scraped;

--- a/crates/riven-db/tests/state.rs
+++ b/crates/riven-db/tests/state.rs
@@ -250,11 +250,30 @@ fn leaf_paused_is_sticky() {
     );
 }
 
+/// `Failed` is sticky only in the absence of a real media entry — resetting
+/// `failed_attempts` alone must not revive the item; that is what
+/// `resetItems`/`Reset` is for.
 #[test]
-fn leaf_failed_is_sticky() {
+fn leaf_failed_is_sticky_without_a_media_entry() {
+    assert_eq!(
+        leaf(MediaItemType::Movie, Failed, false, 0, false, false, 0),
+        Failed
+    );
+}
+
+/// A season-pack download matches files by season+episode number regardless
+/// of the target episode's own state, so a media entry can land on an item
+/// that was marked `Failed` long before. Without this, the item stays stuck
+/// showing `Failed` forever despite having a real downloaded file.
+#[test]
+fn leaf_media_entry_overrides_failed() {
     assert_eq!(
         leaf(MediaItemType::Movie, Failed, false, 0, true, false, 0),
-        Failed
+        Completed
+    );
+    assert_eq!(
+        leaf(MediaItemType::Episode, Failed, false, 999, true, false, 5),
+        Completed
     );
 }
 


### PR DESCRIPTION
## Summary
- `leaf_state` treated `Failed` as sticky unconditionally — checked before even the media-entry existence check.
- A season-pack download matches files by season+episode number regardless of the target episode's own state, so an episode marked `Failed` long ago (from an earlier, unrelated exhausted-retries pass) can still receive a genuine file today.
- The item stayed stuck showing `Failed` forever despite having a real downloaded file on disk — a stronger, more direct signal than the `failed_attempts` counter that was never consulted once `Failed` was set.
- `Paused` stays sticky unconditionally: it's a deliberate user action, and a paused item is excluded from the download pipeline in the first place, so it can't legitimately acquire a new media entry to override it with anyway.
- Reproduced live and swept the library for the same pattern (`state = Failed` with an existing media entry) after the fix — found three already-affected items and reset them by hand, since the fix only prevents recurrence going forward.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p riven-db` (includes new coverage: a media entry overrides `Failed` for both Movie and Episode, `Failed` stays sticky without one, `Paused` stays sticky even with one, and the pre-existing `leaf_failed_is_sticky` test updated to reflect the corrected contract)
- [x] Verified live: reset the three affected library items and confirmed they correctly resolved to `Completed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Movies and episodes with available media are now marked **Completed**, even if they previously failed.
  * Paused items remain paused consistently.
  * Failed-attempt limits are applied more accurately based on the item’s current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->