### PR TITLE
feat: season download progress, per-episode actions, manual blacklist

### DIFF
--- a/crates/riven-api/src/schema.rs
+++ b/crates/riven-api/src/schema.rs
@@ -132,6 +132,7 @@ mod tests {
         ("resetItems", "ResetItems"),
         ("removeItems", "DeleteItems"),
         ("deleteFilesystemEntry", "DeleteItems"),
+        ("blacklistFilesystemEntry", "DeleteItems"),
         // Finding and committing a release.
         ("scrapeItem", "ScrapeItems"),
         ("scrapeMediaItem", "ScrapeItems"),

--- a/crates/riven-api/src/schema/discovery.rs
+++ b/crates/riven-api/src/schema/discovery.rs
@@ -17,6 +17,7 @@ use super::types::DiscoveredStream;
 pub struct DiscoveryTarget {
     pub item_type: MediaItemType,
     pub season_number: Option<i32>,
+    pub episode_number: Option<i32>,
     pub scrape_title: String,
     pub parse_ctx: ParseContext,
 }
@@ -95,6 +96,7 @@ pub fn build_discovery_targets(
     requested_title: &str,
     indexed: &IndexedMediaItem,
     seasons: Option<&[i32]>,
+    episode_number: Option<i32>,
     profiles: Vec<(String, riven_rank::RankSettings)>,
     dubbed_anime_only: bool,
 ) -> Result<Vec<DiscoveryTarget>> {
@@ -108,6 +110,7 @@ pub fn build_discovery_targets(
         MediaItemType::Movie => Ok(vec![DiscoveryTarget {
             item_type: MediaItemType::Movie,
             season_number: None,
+            episode_number: None,
             scrape_title: correct_title.clone(),
             parse_ctx: ParseContext {
                 item_type: MediaItemType::Movie,
@@ -144,6 +147,54 @@ pub fn build_discovery_targets(
                 return Err(Error::new("Select at least one season to find streams"));
             }
 
+            if let Some(episode_number) = episode_number {
+                // Single-episode discovery: exactly one season in scope, and the
+                // target is that specific episode rather than the whole season.
+                let &number = selected.first().ok_or_else(|| {
+                    Error::new("A season is required to find streams for one episode")
+                })?;
+                let season = all_seasons
+                    .iter()
+                    .find(|season| season.number == number)
+                    .ok_or_else(|| {
+                        Error::new(format!("Season {number} is not available from index data"))
+                    })?;
+                let absolute_number = season
+                    .episodes
+                    .iter()
+                    .find(|episode| episode.number == episode_number)
+                    .and_then(|episode| episode.absolute_number);
+
+                return Ok(vec![DiscoveryTarget {
+                    item_type: MediaItemType::Episode,
+                    season_number: Some(number),
+                    episode_number: Some(episode_number),
+                    scrape_title: correct_title.clone(),
+                    parse_ctx: ParseContext {
+                        item_type: MediaItemType::Episode,
+                        season_number: Some(number),
+                        episode_number: Some(episode_number),
+                        absolute_number,
+                        item_year: None,
+                        parent_year: indexed.year,
+                        item_country: indexed.country.clone(),
+                        season_episodes: season
+                            .episodes
+                            .iter()
+                            .map(|episode| (episode.number, episode.absolute_number))
+                            .collect(),
+                        show_season_numbers: vec![],
+                        show_status: indexed.status,
+                        item_title: correct_title.clone(),
+                        item_aired_at: None,
+                        correct_title,
+                        aliases,
+                        profiles,
+                        dubbed_anime_only,
+                    },
+                }]);
+            }
+
             let mut targets = Vec::new();
             for number in selected {
                 let season = all_seasons
@@ -156,6 +207,7 @@ pub fn build_discovery_targets(
                 targets.push(DiscoveryTarget {
                     item_type: MediaItemType::Season,
                     season_number: Some(number),
+                    episode_number: None,
                     scrape_title: correct_title.clone(),
                     parse_ctx: ParseContext {
                         item_type: MediaItemType::Season,
@@ -195,6 +247,7 @@ pub async fn discover_streams(
     tmdb_id: Option<&str>,
     tvdb_id: Option<&str>,
     seasons: Option<&[i32]>,
+    episode_number: Option<i32>,
     cached_only: bool,
 ) -> Result<Vec<DiscoveredStream>> {
     let indexed = run_index_discovery(registry, item_type, imdb_id, tmdb_id, tvdb_id).await?;
@@ -208,6 +261,7 @@ pub async fn discover_streams(
         title,
         &indexed,
         seasons,
+        episode_number,
         profiles,
         dubbed_anime_only,
     )?;
@@ -223,7 +277,7 @@ pub async fn discover_streams(
             tvdb_id,
             &target.scrape_title,
             target.season_number,
-            None,
+            target.episode_number,
         )
         .await;
         let ranked = tokio::task::spawn_blocking({
@@ -235,8 +289,9 @@ pub async fn discover_streams(
 
         discovered.extend(ranked.into_iter().map(|candidate| DiscoveredStream {
             key: format!(
-                "{}:{}",
+                "{}:{}:{}",
                 target.season_number.unwrap_or(0),
+                target.episode_number.unwrap_or(0),
                 candidate.info_hash.to_lowercase()
             ),
             title: candidate.title,
@@ -248,6 +303,7 @@ pub async fn discover_streams(
             is_cached: false,
             item_type: target.item_type,
             season_number: target.season_number,
+            episode_number: target.episode_number,
         }));
     }
 
@@ -424,6 +480,7 @@ pub async fn ensure_download_target(
     tmdb_id: Option<&str>,
     tvdb_id: Option<&str>,
     season_number: Option<i32>,
+    episode_number: Option<i32>,
 ) -> Result<MediaItem> {
     match item_type {
         MediaItemType::Movie => {
@@ -485,6 +542,36 @@ pub async fn ensure_download_target(
                     ))
                 })
         }
-        _ => Err(Error::new("Only movie and season downloads are supported")),
+        MediaItemType::Episode => {
+            let episode_number =
+                episode_number.ok_or_else(|| Error::new("Episode number is required"))?;
+            // Recurse to get the prepared (indexed, episode-populated) season,
+            // then pick the one episode out of it — boxed since an async fn
+            // can't otherwise call itself (the future would be infinite-sized).
+            let season = Box::pin(ensure_download_target(
+                registry,
+                MediaItemType::Season,
+                title,
+                imdb_id,
+                tmdb_id,
+                tvdb_id,
+                season_number,
+                None,
+            ))
+            .await?;
+
+            repo::list_episodes(season.id)
+                .await?
+                .into_iter()
+                .find(|episode| episode.episode_number == Some(episode_number))
+                .ok_or_else(|| {
+                    Error::new(format!(
+                        "Episode {episode_number} not found after preparation"
+                    ))
+                })
+        }
+        _ => Err(Error::new(
+            "Only movie, season, and episode downloads are supported",
+        )),
     }
 }

--- a/crates/riven-api/src/schema/discovery.rs
+++ b/crates/riven-api/src/schema/discovery.rs
@@ -150,20 +150,37 @@ pub fn build_discovery_targets(
             if let Some(episode_number) = episode_number {
                 // Single-episode discovery: exactly one season in scope, and the
                 // target is that specific episode rather than the whole season.
-                let &number = selected.first().ok_or_else(|| {
-                    Error::new("A season is required to find streams for one episode")
-                })?;
+                // Ambiguous (zero or multiple) season selection is rejected
+                // outright rather than silently taking `selected.first()` — a
+                // caller that got the season wrong deserves an error, not a
+                // discovery pass against the wrong episode.
+                if selected.len() != 1 {
+                    return Err(Error::new(
+                        "Exactly one season is required to find streams for one episode",
+                    ));
+                }
+                let number = selected[0];
                 let season = all_seasons
                     .iter()
                     .find(|season| season.number == number)
                     .ok_or_else(|| {
                         Error::new(format!("Season {number} is not available from index data"))
                     })?;
-                let absolute_number = season
+                // A missing indexed episode must fail loudly too: silently
+                // continuing with `absolute_number: None` would let discovery
+                // run against a target the index data doesn't actually know
+                // about, rather than surfacing that the episode number is
+                // wrong or not yet indexed.
+                let episode = season
                     .episodes
                     .iter()
                     .find(|episode| episode.number == episode_number)
-                    .and_then(|episode| episode.absolute_number);
+                    .ok_or_else(|| {
+                        Error::new(format!(
+                            "Episode {episode_number} is not available in season {number}"
+                        ))
+                    })?;
+                let absolute_number = episode.absolute_number;
 
                 return Ok(vec![DiscoveryTarget {
                     item_type: MediaItemType::Episode,

--- a/crates/riven-api/src/schema/mutations/library.rs
+++ b/crates/riven-api/src/schema/mutations/library.rs
@@ -23,6 +23,16 @@ impl LibraryMutations {
         Ok(deleted)
     }
 
+    /// Reject a downloaded file: permanently blacklist the release behind it
+    /// and remove its tracked entry, then clear the owning item's retry
+    /// backoff so a replacement is searched for on the next scheduler pass.
+    /// Use when a download turned out wrong — mismatched title, bad quality,
+    /// wrong language, etc.
+    async fn blacklist_filesystem_entry(&self, ctx: &Context<'_>, id: i64) -> Result<bool> {
+        require(ctx, Capability::DeleteItems)?;
+        Ok(repo::blacklist_and_remove_filesystem_entry(id).await?)
+    }
+
     async fn reset_library(&self, ctx: &Context<'_>) -> Result<i64> {
         require_settings_access(ctx)?;
         Ok(repo::reset_library().await? as i64)

--- a/crates/riven-api/src/schema/mutations/media_item.rs
+++ b/crates/riven-api/src/schema/mutations/media_item.rs
@@ -1,6 +1,6 @@
 use async_graphql::*;
 use riven_core::events::RivenEvent;
-use riven_core::types::{MediaItemState, build_magnet_uri};
+use riven_core::types::{MediaItemState, MediaItemType, build_magnet_uri};
 use riven_db::repo;
 use riven_queue::JobQueue;
 use riven_queue::application::download::{
@@ -145,6 +145,21 @@ impl MediaItemMutations {
             .count();
 
         let parse_ctx = build_parse_item_context(fresh.clone()).await;
+        // For Episode/Season items `fresh.tvdb_id` is that item's own TVDB
+        // record (an episode's individual id, or empty for a season), not
+        // the show's series id the frontend's details link expects — see
+        // `riven_queue::context::notification_tvdb_id` for the same fix
+        // applied on the queue side.
+        let notify_tvdb_id = match parse_ctx.item_type {
+            MediaItemType::Episode | MediaItemType::Season => {
+                repo::get_media_item_hierarchy(input.id)
+                    .await
+                    .ok()
+                    .flatten()
+                    .and_then(|h| h.resolved_show_tvdb_id)
+            }
+            _ => fresh.tvdb_id.clone(),
+        };
         if new_streams_count == 0 {
             if let Err(err) = repo::increment_failed_attempts(input.id).await {
                 tracing::warn!(id = input.id, %err, "failed to increment failed_attempts");
@@ -154,6 +169,8 @@ impl MediaItemMutations {
                     id: input.id,
                     title: parse_ctx.item_title,
                     item_type: parse_ctx.item_type,
+                    tmdb_id: fresh.tmdb_id.clone(),
+                    tvdb_id: notify_tvdb_id.clone(),
                 })
                 .await;
 
@@ -176,6 +193,8 @@ impl MediaItemMutations {
                 title: parse_ctx.item_title,
                 item_type: parse_ctx.item_type,
                 stream_count: new_streams_count,
+                tmdb_id: fresh.tmdb_id.clone(),
+                tvdb_id: notify_tvdb_id,
             })
             .await;
 

--- a/crates/riven-api/src/schema/mutations/streams.rs
+++ b/crates/riven-api/src/schema/mutations/streams.rs
@@ -26,6 +26,7 @@ impl StreamsMutations {
         tmdb_id: Option<String>,
         tvdb_id: Option<String>,
         seasons: Option<Vec<i32>>,
+        episode_number: Option<i32>,
         cached_only: Option<bool>,
     ) -> Result<Vec<DiscoveredStream>> {
         require(ctx, Capability::ScrapeItems)?;
@@ -39,6 +40,7 @@ impl StreamsMutations {
             tmdb_id.as_deref(),
             tvdb_id.as_deref(),
             seasons.as_deref(),
+            episode_number,
             cached_only.unwrap_or(false),
         )
         .await
@@ -59,6 +61,7 @@ impl StreamsMutations {
         tmdb_id: Option<String>,
         tvdb_id: Option<String>,
         season_number: Option<i32>,
+        episode_number: Option<i32>,
         seasons: Option<Vec<i32>>,
         info_hash: String,
         magnet: String,
@@ -78,6 +81,19 @@ impl StreamsMutations {
                 tmdb_id.as_deref(),
                 tvdb_id.as_deref(),
                 None,
+                None,
+            )
+            .await?
+        } else if item_type == MediaItemType::Episode {
+            ensure_download_target(
+                registry.as_ref(),
+                MediaItemType::Episode,
+                &title,
+                imdb_id.as_deref(),
+                tmdb_id.as_deref(),
+                tvdb_id.as_deref(),
+                season_number,
+                episode_number,
             )
             .await?
         } else {
@@ -94,6 +110,7 @@ impl StreamsMutations {
                         tmdb_id.as_deref(),
                         tvdb_id.as_deref(),
                         Some(*single),
+                        None,
                     )
                     .await?
                 }

--- a/crates/riven-api/src/schema/queries/media.rs
+++ b/crates/riven-api/src/schema/queries/media.rs
@@ -53,6 +53,22 @@ async fn load_show_tree(
     Ok((seasons, episodes_by_season))
 }
 
+/// Generous upper bound for the batched library-status lookups — a carousel
+/// row is a couple dozen cards at most, so this is headroom for that, not a
+/// tuned limit. Guards against one request building an arbitrarily large
+/// `IN (...)` list rather than actually protecting real usage.
+const MAX_BULK_STATUS_IDS: usize = 500;
+
+fn check_bulk_ids_len(ids: &[String]) -> Result<()> {
+    if ids.len() > MAX_BULK_STATUS_IDS {
+        return Err(Error::new(format!(
+            "too many ids in one request: {} (max {MAX_BULK_STATUS_IDS})",
+            ids.len()
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Default)]
 pub struct MediaQuery;
 
@@ -152,6 +168,7 @@ impl MediaQuery {
         _ctx: &Context<'_>,
         tmdb_ids: Vec<String>,
     ) -> Result<Vec<MediaItemStatus>> {
+        check_bulk_ids_len(&tmdb_ids)?;
         Ok(repo::list_media_items_by_tmdb_ids(&tmdb_ids)
             .await?
             .into_iter()
@@ -166,6 +183,7 @@ impl MediaQuery {
         _ctx: &Context<'_>,
         tvdb_ids: Vec<String>,
     ) -> Result<Vec<MediaItemStatus>> {
+        check_bulk_ids_len(&tvdb_ids)?;
         Ok(repo::list_media_items_by_tvdb_ids(&tvdb_ids)
             .await?
             .into_iter()

--- a/crates/riven-api/src/schema/queries/media.rs
+++ b/crates/riven-api/src/schema/queries/media.rs
@@ -143,6 +143,36 @@ impl MediaQuery {
         self.media_item_state_for(item).await
     }
 
+    /// Bulk library-status lookup for a set of TMDB ids: one round trip for
+    /// a whole suggested-content carousel row instead of one query per card.
+    /// Ids not found in the library are simply absent from the result — the
+    /// caller treats "no matching entry" as "not yet requested".
+    async fn media_item_statuses_by_tmdb_ids(
+        &self,
+        _ctx: &Context<'_>,
+        tmdb_ids: Vec<String>,
+    ) -> Result<Vec<MediaItemStatus>> {
+        Ok(repo::list_media_items_by_tmdb_ids(&tmdb_ids)
+            .await?
+            .into_iter()
+            .map(MediaItemStatus::from)
+            .collect())
+    }
+
+    /// Bulk library-status lookup for a set of TVDB ids — the show-side
+    /// counterpart to `mediaItemStatusesByTmdbIds`, same batching rationale.
+    async fn media_item_statuses_by_tvdb_ids(
+        &self,
+        _ctx: &Context<'_>,
+        tvdb_ids: Vec<String>,
+    ) -> Result<Vec<MediaItemStatus>> {
+        Ok(repo::list_media_items_by_tvdb_ids(&tvdb_ids)
+            .await?
+            .into_iter()
+            .map(MediaItemStatus::from)
+            .collect())
+    }
+
     async fn movies(&self, _ctx: &Context<'_>) -> Result<Vec<MediaItem>> {
         Ok(repo::list_movies().await?)
     }

--- a/crates/riven-api/src/schema/types.rs
+++ b/crates/riven-api/src/schema/types.rs
@@ -122,4 +122,5 @@ pub struct DiscoveredStream {
     pub is_cached: bool,
     pub item_type: MediaItemType,
     pub season_number: Option<i32>,
+    pub episode_number: Option<i32>,
 }

--- a/crates/riven-api/src/schema/types.rs
+++ b/crates/riven-api/src/schema/types.rs
@@ -60,6 +60,32 @@ pub struct MediaItemStateTree {
     pub seasons: Vec<SeasonState>,
 }
 
+/// Minimal per-item library status: just enough to render a "Request" vs
+/// "current state" button on a suggested-content card without paying for a
+/// full season/episode tree (unlike `MediaItemStateTree`, which
+/// `apply_indexed_media_item`-style callers need for shows but a poster card
+/// never does). Returned in bulk by the `mediaItemStatusesBy*Ids` batch
+/// queries so a whole carousel row resolves in one round trip instead of one
+/// query per card.
+#[derive(SimpleObject)]
+pub struct MediaItemStatus {
+    pub id: i64,
+    pub state: MediaItemState,
+    pub tmdb_id: Option<String>,
+    pub tvdb_id: Option<String>,
+}
+
+impl From<MediaItem> for MediaItemStatus {
+    fn from(item: MediaItem) -> Self {
+        Self {
+            id: item.id,
+            state: item.state,
+            tmdb_id: item.tmdb_id,
+            tvdb_id: item.tvdb_id,
+        }
+    }
+}
+
 #[derive(SimpleObject)]
 pub struct ItemsPage {
     pub items: Vec<MediaItemListRow>,

--- a/crates/riven-core/src/events/event.rs
+++ b/crates/riven-core/src/events/event.rs
@@ -62,12 +62,25 @@ pub enum RivenEvent {
         title: String,
         item_type: MediaItemType,
         stream_count: usize,
+        /// So the UI notification for this event can link to the item's
+        /// detail page. Movies are usually TMDB-matched; shows/seasons/
+        /// episodes are frequently TVDB-only (no TMDB match at all) — the
+        /// UI needs whichever one is actually populated.
+        tmdb_id: Option<String>,
+        tvdb_id: Option<String>,
     },
     #[serde(rename = "riven.media-item.scrape.error")]
     MediaItemScrapeError {
         id: i64,
         title: String,
+        item_type: MediaItemType,
         error: String,
+        /// So the UI notification for this event can link to the item's
+        /// detail page. Movies are usually TMDB-matched; shows/seasons/
+        /// episodes are frequently TVDB-only (no TMDB match at all) — the
+        /// UI needs whichever one is actually populated.
+        tmdb_id: Option<String>,
+        tvdb_id: Option<String>,
     },
     #[serde(rename = "riven.media-item.scrape.error.incorrect-state")]
     MediaItemScrapeErrorIncorrectState { id: i64 },
@@ -76,6 +89,12 @@ pub enum RivenEvent {
         id: i64,
         title: String,
         item_type: MediaItemType,
+        /// So the UI notification for this event can link to the item's
+        /// detail page. Movies are usually TMDB-matched; shows/seasons/
+        /// episodes are frequently TVDB-only (no TMDB match at all) — the
+        /// UI needs whichever one is actually populated.
+        tmdb_id: Option<String>,
+        tvdb_id: Option<String>,
     },
     #[serde(rename = "riven.media-item.download.requested")]
     MediaItemDownloadRequested {
@@ -107,7 +126,14 @@ pub enum RivenEvent {
     MediaItemDownloadError {
         id: i64,
         title: String,
+        item_type: MediaItemType,
         error: String,
+        /// So the UI notification for this event can link to the item's
+        /// detail page. Movies are usually TMDB-matched; shows/seasons/
+        /// episodes are frequently TVDB-only (no TMDB match at all) — the
+        /// UI needs whichever one is actually populated.
+        tmdb_id: Option<String>,
+        tvdb_id: Option<String>,
     },
     #[serde(rename = "riven.media-item.download.error.incorrect-state")]
     MediaItemDownloadErrorIncorrectState { id: i64 },
@@ -124,6 +150,12 @@ pub enum RivenEvent {
         year: Option<i32>,
         imdb_id: Option<String>,
         tmdb_id: Option<String>,
+        /// Movies are usually TMDB-matched; shows/seasons/episodes are
+        /// frequently TVDB-only (no TMDB match at all) — the UI notification
+        /// for this event needs whichever one is actually populated to link
+        /// to the item's detail page.
+        #[serde(default)]
+        tvdb_id: Option<String>,
         poster_path: Option<String>,
         plugin_name: String,
         provider: Option<String>,

--- a/crates/riven-core/src/plugin/traits.rs
+++ b/crates/riven-core/src/plugin/traits.rs
@@ -280,6 +280,7 @@ pub trait Plugin: Send + Sync + 'static {
                 plugin_name,
                 provider,
                 duration_seconds,
+                ..
             } => {
                 let info = DownloadSuccessInfo {
                     id: *id,

--- a/crates/riven-db/src/repo/media.rs
+++ b/crates/riven-db/src/repo/media.rs
@@ -105,6 +105,34 @@ pub async fn get_media_item_by_tvdb(id: &str) -> Result<Option<MediaItem>> {
     find_one_by(media_items::Column::TvdbId, id).await
 }
 
+/// Batch form of [`get_media_item_by_tmdb`]/[`get_media_item_by_tvdb`]: one
+/// query for a whole set of external ids rather than one round trip per id.
+/// Used to resolve a suggested-content carousel row's library status without
+/// N+1 queries. Restricted to top-level items since a season/episode never
+/// carries its own tmdb/tvdb id independent of its show's.
+async fn list_top_level_by_external_ids(
+    column: media_items::Column,
+    ids: &[String],
+) -> Result<Vec<MediaItem>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    Ok(media_items::Entity::find()
+        .filter(column.is_in(ids.iter().cloned()))
+        .filter(media_items::Column::ItemType.is_in([MediaItemType::Movie, MediaItemType::Show]))
+        .into_model::<MediaItem>()
+        .all(orm())
+        .await?)
+}
+
+pub async fn list_media_items_by_tmdb_ids(ids: &[String]) -> Result<Vec<MediaItem>> {
+    list_top_level_by_external_ids(media_items::Column::TmdbId, ids).await
+}
+
+pub async fn list_media_items_by_tvdb_ids(ids: &[String]) -> Result<Vec<MediaItem>> {
+    list_top_level_by_external_ids(media_items::Column::TvdbId, ids).await
+}
+
 async fn list_by_type(item_type: MediaItemType) -> Result<Vec<MediaItem>> {
     Ok(media_items::Entity::find()
         .filter(media_items::Column::ItemType.eq(item_type))

--- a/crates/riven-db/src/repo/streams.rs
+++ b/crates/riven-db/src/repo/streams.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use riven_core::entities::{
-    filesystem_entries, media_item_blacklisted_streams, media_item_streams, streams,
+    filesystem_entries, media_item_blacklisted_streams, media_item_streams, media_items, streams,
 };
 use riven_core::types::FileSystemEntryType;
 use sea_orm::ActiveValue::{Set, Unchanged};
@@ -712,21 +712,108 @@ pub async fn get_downloaded_profile_names(media_item_id: i64) -> Result<Vec<Stri
     Ok(rows.into_iter().flatten().collect())
 }
 
-/// For a Season item, return profile names that have been downloaded for at
-/// least one episode in that season.
+/// For a Season item, return profile names that every *expected* episode
+/// (requested, and not still `unreleased`) already has a downloaded entry
+/// for — i.e. a profile genuinely has nothing left to grab for this season,
+/// not just "at least one episode happens to have it".
+///
+/// The distinction matters because the season-level download loop treats a
+/// profile in this list as fully satisfied and skips it entirely on every
+/// future pass. Reporting a profile "done" as soon as *any* episode has it
+/// (the previous behavior) meant a season that downloaded its first couple
+/// of episodes at a given quality would never be revisited for the rest —
+/// every later episode's matching stream sat unblacklisted and unused
+/// forever, since the profile that would have driven the download attempt
+/// toward it was already considered finished.
+///
+/// Raw SQL: the "every expected episode has this profile" comparison is a
+/// `HAVING count(...) >= (subquery)` the query builder can't express.
 pub async fn get_downloaded_profile_names_for_season(season_id: i64) -> Result<Vec<String>> {
-    let rows: Vec<Option<String>> = filesystem_entries::Entity::find()
-        .inner_join(riven_core::entities::media_items::Entity)
-        .filter(riven_core::entities::media_items::Column::ParentId.eq(season_id))
-        .filter(filesystem_entries::Column::EntryType.eq(FileSystemEntryType::Media))
-        .filter(filesystem_entries::Column::RankingProfileName.is_not_null())
-        .select_only()
-        .column(filesystem_entries::Column::RankingProfileName)
-        .distinct()
-        .into_tuple()
-        .all(orm())
+    let rows = orm()
+        .query_all_raw(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT fe.ranking_profile_name AS profile_name
+             FROM filesystem_entries fe
+             JOIN media_items ep ON ep.id = fe.media_item_id
+             WHERE ep.parent_id = $1
+               AND fe.entry_type = 'media'
+               AND fe.ranking_profile_name IS NOT NULL
+             GROUP BY fe.ranking_profile_name
+             HAVING COUNT(DISTINCT fe.media_item_id) >= (
+                 SELECT COUNT(*) FROM media_items expected
+                 WHERE expected.parent_id = $1
+                   AND expected.is_requested = true
+                   AND expected.state <> 'unreleased'
+             )",
+            [season_id.into()],
+        ))
         .await?;
-    Ok(rows.into_iter().flatten().collect())
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| row.try_get::<String>("", "profile_name").ok())
+        .collect())
+}
+
+/// Episode ids under a season that already have an entry for the given
+/// ranking profile.
+///
+/// A season-pack (or single-episode) stream frequently covers a mix of
+/// already-satisfied and still-missing episodes — e.g. the same release
+/// group posts one file per episode, and the top-ranked one by tie-break
+/// happens to be an episode already downloaded. Persisting into an
+/// already-satisfied episode is harmless on its own (it just upserts the
+/// same row), but if the caller counts that as "this stream made progress"
+/// it stops trying further candidates — permanently starving every other
+/// missing episode, since the same top-ranked-but-already-done stream wins
+/// the tie-break on every future retry too. Callers use this set to skip
+/// persisting into episodes that don't need it, so a stream that only
+/// touches already-done episodes is correctly reported as making no
+/// progress.
+pub async fn get_episode_ids_with_profile_for_season(
+    season_id: i64,
+    profile_name: &str,
+) -> Result<HashSet<i64>> {
+    let rows = orm()
+        .query_all_raw(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT DISTINCT fe.media_item_id AS episode_id
+             FROM filesystem_entries fe
+             JOIN media_items ep ON ep.id = fe.media_item_id
+             WHERE ep.parent_id = $1
+               AND fe.entry_type = 'media'
+               AND fe.ranking_profile_name = $2",
+            [season_id.into(), profile_name.into()],
+        ))
+        .await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| row.try_get::<i64>("", "episode_id").ok())
+        .collect())
+}
+
+/// Same as [`get_episode_ids_with_profile_for_season`], but for a multi-season
+/// pack matched against a whole show.
+pub async fn get_episode_ids_with_profile_for_show(
+    show_id: i64,
+    profile_name: &str,
+) -> Result<HashSet<i64>> {
+    let rows = orm()
+        .query_all_raw(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            "SELECT DISTINCT fe.media_item_id AS episode_id
+             FROM filesystem_entries fe
+             JOIN media_items ep ON ep.id = fe.media_item_id
+             JOIN media_items season ON season.id = ep.parent_id
+             WHERE season.parent_id = $1
+               AND fe.entry_type = 'media'
+               AND fe.ranking_profile_name = $2",
+            [show_id.into(), profile_name.into()],
+        ))
+        .await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| row.try_get::<i64>("", "episode_id").ok())
+        .collect())
 }
 
 /// Upsert a media filesystem entry, replacing the former SELECT + INSERT/UPDATE
@@ -959,6 +1046,42 @@ pub async fn delete_orphaned_usenet_metas(info_hashes: &[String]) -> Result<u64>
 pub async fn delete_filesystem_entry(entry_id: i64) -> Result<(bool, Option<i64>)> {
     let media_item_id = delete_filesystem_entries(&[entry_id]).await?.pop();
     Ok((media_item_id.is_some(), media_item_id))
+}
+
+/// Reject a downloaded file outright: permanently blacklist the release
+/// behind it (so the next retry can't re-select the exact same wrong-title or
+/// bad-quality stream) and remove its tracked entry, then clear the owning
+/// item's retry backoff so the search for a replacement runs on the next
+/// scheduler pass instead of waiting out whatever cooldown it had
+/// accumulated.
+///
+/// Returns `false` if the entry didn't exist; blacklisting a stream that
+/// somehow has no linked `streams` row (shouldn't happen, but not fatal) is
+/// skipped rather than failing the whole removal.
+pub async fn blacklist_and_remove_filesystem_entry(entry_id: i64) -> Result<bool> {
+    let Some(entry) = get_media_entry_by_id(entry_id).await? else {
+        return Ok(false);
+    };
+
+    if let Some(stream_id) = entry.stream_id
+        && let Some(stream) = streams::Entity::find_by_id(stream_id).one(orm()).await?
+    {
+        blacklist_stream_permanent_by_hash(entry.media_item_id, &stream.info_hash).await?;
+    }
+
+    let (deleted, media_item_id) = delete_filesystem_entry(entry_id).await?;
+    if let Some(media_item_id) = media_item_id {
+        media_items::Entity::update_many()
+            .col_expr(media_items::Column::FailedAttempts, Expr::value(0))
+            .col_expr(media_items::Column::LastScrapeAttemptAt, Expr::cust("NULL"))
+            .col_expr(media_items::Column::UpdatedAt, Expr::cust("NOW()"))
+            .filter(media_items::Column::Id.eq(media_item_id))
+            .exec(orm())
+            .await?;
+        super::state::recompute(&[media_item_id]).await?;
+    }
+
+    Ok(deleted)
 }
 
 /// Batch form of [`delete_filesystem_entry`] — one DELETE for the whole set

--- a/crates/riven-db/src/repo/streams.rs
+++ b/crates/riven-db/src/repo/streams.rs
@@ -736,6 +736,8 @@ pub async fn get_downloaded_profile_names_for_season(season_id: i64) -> Result<V
              FROM filesystem_entries fe
              JOIN media_items ep ON ep.id = fe.media_item_id
              WHERE ep.parent_id = $1
+               AND ep.is_requested = true
+               AND ep.state <> 'unreleased'
                AND fe.entry_type = 'media'
                AND fe.ranking_profile_name IS NOT NULL
              GROUP BY fe.ranking_profile_name
@@ -1067,6 +1069,25 @@ pub async fn blacklist_and_remove_filesystem_entry(entry_id: i64) -> Result<bool
         && let Some(stream) = streams::Entity::find_by_id(stream_id).one(orm()).await?
     {
         blacklist_stream_permanent_by_hash(entry.media_item_id, &stream.info_hash).await?;
+
+        // A season/show-pack release is linked to (and selected as a
+        // candidate against) the *season's or show's* own media_item_id —
+        // persist matches its files to individual episodes, but the
+        // candidate query that picks the stream in the first place runs at
+        // whichever level the download job targets. Blacklisting only the
+        // episode leaves the exact same pack fully eligible on the next
+        // season- or show-level regrab, since that query never looks at the
+        // episode's blacklist rows at all.
+        if let Ok(Some(hierarchy)) =
+            super::hierarchy::get_media_item_hierarchy(entry.media_item_id).await
+        {
+            if let Some(season_id) = hierarchy.resolved_season_id {
+                blacklist_stream_permanent_by_hash(season_id, &stream.info_hash).await?;
+            }
+            if let Some(show_id) = hierarchy.resolved_show_id {
+                blacklist_stream_permanent_by_hash(show_id, &stream.info_hash).await?;
+            }
+        }
     }
 
     let (deleted, media_item_id) = delete_filesystem_entry(entry_id).await?;

--- a/crates/riven-db/src/repo/streams.rs
+++ b/crates/riven-db/src/repo/streams.rs
@@ -1078,8 +1078,8 @@ pub async fn blacklist_and_remove_filesystem_entry(entry_id: i64) -> Result<bool
         // episode leaves the exact same pack fully eligible on the next
         // season- or show-level regrab, since that query never looks at the
         // episode's blacklist rows at all.
-        if let Ok(Some(hierarchy)) =
-            super::hierarchy::get_media_item_hierarchy(entry.media_item_id).await
+        if let Some(hierarchy) =
+            super::hierarchy::get_media_item_hierarchy(entry.media_item_id).await?
         {
             if let Some(season_id) = hierarchy.resolved_season_id {
                 blacklist_stream_permanent_by_hash(season_id, &stream.info_hash).await?;

--- a/crates/riven-queue/src/application/download.rs
+++ b/crates/riven-queue/src/application/download.rs
@@ -15,7 +15,9 @@ use riven_db::repo;
 use riven_rank::RankSettings;
 use serde::Deserialize;
 
-use crate::context::{DownloadHierarchyContext, load_download_hierarchy_context};
+use crate::context::{
+    DownloadHierarchyContext, load_download_hierarchy_context, notification_tvdb_id,
+};
 use crate::discovery::load_active_profiles;
 use crate::{DownloadJob, JobQueue, RankStreamsJob};
 
@@ -298,7 +300,10 @@ pub async fn run(id: i64, job: &DownloadJob, queue: &JobQueue) {
             .notify(RivenEvent::MediaItemDownloadError {
                 id,
                 title: item.title.clone(),
+                item_type: item.item_type,
                 error: "no streams available for download".into(),
+                tmdb_id: item.tmdb_id.clone(),
+                tvdb_id: notification_tvdb_id(&item, hierarchy.as_ref()),
             })
             .await;
         return;
@@ -548,7 +553,10 @@ async fn run_preferred_stream(
             .notify(RivenEvent::MediaItemDownloadError {
                 id,
                 title: item.title.clone(),
+                item_type: item.item_type,
                 error: "selected stream is not linked to this item".into(),
+                tmdb_id: item.tmdb_id.clone(),
+                tvdb_id: notification_tvdb_id(item, hierarchy),
             })
             .await;
         return false;
@@ -578,9 +586,11 @@ async fn run_preferred_stream(
         .await
         {
             DownloadAttemptOutcome::Failed => continue,
-            DownloadAttemptOutcome::TerminalHandled => return true,
+            DownloadAttemptOutcome::TerminalHandled | DownloadAttemptOutcome::Progressed => {
+                return true;
+            }
             DownloadAttemptOutcome::Succeeded => {
-                finalize_download_success(id, item, queue, start_time, None, None).await;
+                finalize_download_success(id, item, queue, start_time, None, None, hierarchy).await;
                 return true;
             }
         }
@@ -597,7 +607,10 @@ async fn run_preferred_stream(
         .notify(RivenEvent::MediaItemDownloadError {
             id,
             title: item.title.clone(),
+            item_type: item.item_type,
             error: "selected stream could not be downloaded from any provider".into(),
+            tmdb_id: item.tmdb_id.clone(),
+            tvdb_id: notification_tvdb_id(item, hierarchy),
         })
         .await;
     false
@@ -735,7 +748,35 @@ async fn run_downloads(
                         profile_done = true;
                         continue 'streams;
                     }
+                    DownloadAttemptOutcome::Progressed => {
+                        // Season/Show made progress but isn't fully done —
+                        // keep going with the next candidate stream instead
+                        // of stopping, so this pass can fill every episode a
+                        // good release exists for right now.
+                        any_success = true;
+                        continue 'streams;
+                    }
                 }
+            }
+
+            // Every configured (plugin, provider) combination was either not
+            // cached or failed outright — this release doesn't work.
+            // Blacklist it permanently: `clear_blacklisted_streams` wipes
+            // non-permanent entries at the start of the item's very next
+            // scrape (its normal job is letting a fresh scrape re-evaluate
+            // previously-rejected streams), which runs constantly on the
+            // retry cycle — a temporary entry here would be undone before it
+            // ever stopped this stream from being re-selected, defeating the
+            // point of blacklisting it at all.
+            if let Err(err) = repo::blacklist_stream_permanent_by_hash(id, &stream.info_hash).await
+            {
+                tracing::warn!(
+                    id,
+                    info_hash = %stream.info_hash,
+                    title = %item.title,
+                    %err,
+                    "download: could not blacklist an unusable stream, it may be reselected next cycle"
+                );
             }
         }
     }
@@ -753,7 +794,10 @@ async fn run_downloads(
             .notify(RivenEvent::MediaItemDownloadError {
                 id,
                 title: item.title.clone(),
+                item_type: item.item_type,
                 error: "no valid torrent found after trying cached candidates".into(),
+                tmdb_id: item.tmdb_id.clone(),
+                tvdb_id: notification_tvdb_id(item, hierarchy),
             })
             .await;
         return false;
@@ -782,7 +826,7 @@ async fn run_downloads(
             .await;
     }
 
-    finalize_download_success(id, item, queue, start_time, None, None).await;
+    finalize_download_success(id, item, queue, start_time, None, None, hierarchy).await;
     true
 }
 

--- a/crates/riven-queue/src/application/download/execute.rs
+++ b/crates/riven-queue/src/application/download/execute.rs
@@ -16,6 +16,14 @@ use crate::context::DownloadHierarchyContext;
 pub enum DownloadAttemptOutcome {
     Failed,
     Succeeded,
+    /// Season/Show only: this stream filled in at least one still-missing
+    /// episode, but the item isn't fully complete yet — unlike
+    /// `TerminalHandled`, the caller should keep trying further candidates
+    /// for the same profile instead of stopping, so a single download pass
+    /// can fill every episode a good release exists for rather than one per
+    /// retry cycle (which, for an item with a large `failed_attempts`
+    /// count, can be a day apart under the escalating backoff).
+    Progressed,
     TerminalHandled,
 }
 
@@ -262,14 +270,23 @@ pub async fn attempt_download(
             )
             .await
             {
-                SeasonPersistOutcome::Complete | SeasonPersistOutcome::Partial => {
+                SeasonPersistOutcome::Complete => {
                     tracing::debug!(
                         id,
                         info_hash,
                         raw_title,
-                        "download: season pack processed, matching episodes saved"
+                        "download: season pack processed, season fully complete"
                     );
                     DownloadAttemptOutcome::TerminalHandled
+                }
+                SeasonPersistOutcome::Partial => {
+                    tracing::debug!(
+                        id,
+                        info_hash,
+                        raw_title,
+                        "download: season pack processed, matching episodes saved (season still incomplete)"
+                    );
+                    DownloadAttemptOutcome::Progressed
                 }
                 SeasonPersistOutcome::Failed => {
                     tracing::debug!(

--- a/crates/riven-queue/src/application/download/execute.rs
+++ b/crates/riven-queue/src/application/download/execute.rs
@@ -313,14 +313,23 @@ pub async fn attempt_download(
             )
             .await
             {
-                SeasonPersistOutcome::Complete | SeasonPersistOutcome::Partial => {
+                SeasonPersistOutcome::Complete => {
                     tracing::debug!(
                         id,
                         info_hash,
                         raw_title,
-                        "download: show pack processed, matching episodes saved"
+                        "download: show pack processed, show fully complete"
                     );
                     DownloadAttemptOutcome::TerminalHandled
+                }
+                SeasonPersistOutcome::Partial => {
+                    tracing::debug!(
+                        id,
+                        info_hash,
+                        raw_title,
+                        "download: show pack processed, matching episodes saved (show still incomplete)"
+                    );
+                    DownloadAttemptOutcome::Progressed
                 }
                 SeasonPersistOutcome::Failed => {
                     tracing::debug!(

--- a/crates/riven-queue/src/application/download/persist.rs
+++ b/crates/riven-queue/src/application/download/persist.rs
@@ -108,6 +108,7 @@ pub async fn finalize_download_success(
     start_time: Instant,
     provider: Option<String>,
     plugin_name: Option<String>,
+    hierarchy: Option<&DownloadHierarchyContext>,
 ) {
     sync_item_request_state(item).await;
 
@@ -125,6 +126,7 @@ pub async fn finalize_download_success(
             year: item.year,
             imdb_id: item.imdb_id.clone(),
             tmdb_id: item.tmdb_id.clone(),
+            tvdb_id: crate::context::notification_tvdb_id(item, hierarchy),
             poster_path: item.poster_path.clone(),
             plugin_name: plugin_name.unwrap_or_default(),
             provider,

--- a/crates/riven-queue/src/application/download/persist/packs.rs
+++ b/crates/riven-queue/src/application/download/persist/packs.rs
@@ -469,6 +469,28 @@ pub async fn persist_show(
     }
 
     sync_item_request_state(item).await;
+
+    // The filesystem_entries inserts above already recomputed state for each
+    // episode (via the repo layer), and the recompute cascade walked them up
+    // through their seasons to the show. Read the now-current show state
+    // rather than assuming "some episodes got created" means "the whole show
+    // is done" — a show pack that only fills some of its seasons must report
+    // Partial so the caller keeps trying further candidates, the same as a
+    // season pack already does; treating it as terminal here would starve
+    // the rest of the show exactly like the season-level version of this bug.
+    let show_complete = repo::get_media_item(id)
+        .await
+        .ok()
+        .flatten()
+        .is_some_and(|i| i.state == MediaItemState::Completed);
+
+    if !show_complete {
+        queue
+            .notify(RivenEvent::MediaItemDownloadPartialSuccess { id })
+            .await;
+        return SeasonPersistOutcome::Partial;
+    }
+
     queue
         .filesystem_settings_revision
         .fetch_add(1, Ordering::SeqCst);

--- a/crates/riven-queue/src/application/download/persist/packs.rs
+++ b/crates/riven-queue/src/application/download/persist/packs.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::*;
 
 /// Persist a season (pack) download result.
@@ -25,7 +27,10 @@ pub async fn persist_season(
                 .notify(RivenEvent::MediaItemDownloadError {
                     id,
                     title: item.title.clone(),
+                    item_type: item.item_type,
                     error: "season has no parent show".into(),
+                    tmdb_id: item.tmdb_id.clone(),
+                    tvdb_id: crate::context::notification_tvdb_id(item, Some(hierarchy)),
                 })
                 .await;
             return SeasonPersistOutcome::Failed;
@@ -48,7 +53,10 @@ pub async fn persist_season(
                 .notify(RivenEvent::MediaItemDownloadError {
                     id,
                     title: item.title.clone(),
+                    item_type: item.item_type,
                     error: format!("failed to load parent show: {error}"),
+                    tmdb_id: item.tmdb_id.clone(),
+                    tvdb_id: crate::context::notification_tvdb_id(item, Some(hierarchy)),
                 })
                 .await;
             return SeasonPersistOutcome::Failed;
@@ -62,7 +70,10 @@ pub async fn persist_season(
                 .notify(RivenEvent::MediaItemDownloadError {
                     id,
                     title: item.title.clone(),
+                    item_type: item.item_type,
                     error: e.to_string(),
+                    tmdb_id: item.tmdb_id.clone(),
+                    tvdb_id: crate::context::notification_tvdb_id(item, Some(hierarchy)),
                 })
                 .await;
             return SeasonPersistOutcome::Failed;
@@ -183,9 +194,25 @@ pub async fn persist_season(
         episode_matches = by_ep;
     }
 
+    // Episodes that already have this profile: a release that only touches
+    // these must not read as progress, or the season-level download loop
+    // (which stops trying further candidates the moment one "succeeds")
+    // would get stuck forever re-persisting the same already-done episode
+    // that keeps winning the rank tie-break, never reaching the streams for
+    // episodes that are actually still missing.
+    let already_satisfied: HashSet<i64> = match profile_name {
+        Some(name) => repo::get_episode_ids_with_profile_for_season(id, name)
+            .await
+            .unwrap_or_default(),
+        None => HashSet::new(),
+    };
+
     let mut completed_episode_ids: Vec<i64> = Vec::new();
 
     for (ep, matched) in &episode_matches {
+        if already_satisfied.contains(&ep.id) {
+            continue;
+        }
         let episode_number = ep.episode_number.unwrap_or(1);
         for (file, part) in select_episode_files(matched) {
             let path = episode_vfs_path(&show_name, season_number, episode_number, part, path_tag);
@@ -265,6 +292,7 @@ pub async fn persist_season(
             year: item.year,
             imdb_id: item.imdb_id.clone(),
             tmdb_id: item.tmdb_id.clone(),
+            tvdb_id: crate::context::notification_tvdb_id(item, Some(hierarchy)),
             poster_path: item.poster_path.clone(),
             plugin_name: dl.plugin_name,
             provider: dl.provider,
@@ -308,7 +336,10 @@ pub async fn persist_show(
                 .notify(RivenEvent::MediaItemDownloadError {
                     id,
                     title: item.title.clone(),
+                    item_type: item.item_type,
                     error: e.to_string(),
+                    tmdb_id: item.tmdb_id.clone(),
+                    tvdb_id: item.tvdb_id.clone(),
                 })
                 .await;
             return SeasonPersistOutcome::Failed;
@@ -331,6 +362,15 @@ pub async fn persist_show(
         .map(|f| (f, parse_file_path(&f.filename)))
         .collect();
 
+    // See the equivalent lookup in `persist_season` for why episodes already
+    // holding this profile must be excluded rather than just re-persisted.
+    let already_satisfied: HashSet<i64> = match profile_name {
+        Some(name) => repo::get_episode_ids_with_profile_for_show(id, name)
+            .await
+            .unwrap_or_default(),
+        None => HashSet::new(),
+    };
+
     let mut completed_episode_ids: Vec<i64> = Vec::new();
 
     // One query for every season's episodes rather than one per season.
@@ -346,7 +386,10 @@ pub async fn persist_show(
                 .notify(RivenEvent::MediaItemDownloadError {
                     id,
                     title: item.title.clone(),
+                    item_type: item.item_type,
                     error: e.to_string(),
+                    tmdb_id: item.tmdb_id.clone(),
+                    tvdb_id: item.tvdb_id.clone(),
                 })
                 .await;
             return SeasonPersistOutcome::Failed;
@@ -360,6 +403,9 @@ pub async fn persist_show(
         };
 
         for ep in episodes {
+            if already_satisfied.contains(&ep.id) {
+                continue;
+            }
             let episode_number = ep.episode_number.unwrap_or(1);
             let matched: Vec<(&DownloadFile, riven_rank::ParsedData)> = parsed_video_files
                 .iter()
@@ -437,6 +483,7 @@ pub async fn persist_show(
             year: item.year,
             imdb_id: item.imdb_id.clone(),
             tmdb_id: item.tmdb_id.clone(),
+            tvdb_id: item.tvdb_id.clone(),
             poster_path: item.poster_path.clone(),
             plugin_name: dl.plugin_name,
             provider: dl.provider,

--- a/crates/riven-queue/src/application/download/persist/single.rs
+++ b/crates/riven-queue/src/application/download/persist/single.rs
@@ -127,7 +127,10 @@ pub async fn persist_movie(
             .notify(RivenEvent::MediaItemDownloadError {
                 id,
                 title: item.title.clone(),
+                item_type: item.item_type,
                 error: e.to_string(),
+                tmdb_id: item.tmdb_id.clone(),
+                tvdb_id: item.tvdb_id.clone(),
             })
             .await;
         return false;
@@ -160,7 +163,10 @@ pub async fn persist_episode(
                 .notify(RivenEvent::MediaItemDownloadError {
                     id,
                     title: item.title.clone(),
+                    item_type: item.item_type,
                     error: "episode has no parent season".into(),
+                    tmdb_id: item.tmdb_id.clone(),
+                    tvdb_id: crate::context::notification_tvdb_id(item, Some(hierarchy)),
                 })
                 .await;
             return false;
@@ -302,7 +308,10 @@ pub async fn persist_episode(
                 .notify(RivenEvent::MediaItemDownloadError {
                     id,
                     title: item.title.clone(),
+                    item_type: item.item_type,
                     error: e.to_string(),
+                    tmdb_id: item.tmdb_id.clone(),
+                    tvdb_id: crate::context::notification_tvdb_id(item, Some(hierarchy)),
                 })
                 .await;
             return false;

--- a/crates/riven-queue/src/application/download/persist/supplied.rs
+++ b/crates/riven-queue/src/application/download/persist/supplied.rs
@@ -33,6 +33,7 @@ pub async fn persist_supplied_download(
                 start_time,
                 download.provider.clone(),
                 Some(download.plugin_name.clone()),
+                None,
             )
             .await;
         }
@@ -63,6 +64,7 @@ pub async fn persist_supplied_download(
                 start_time,
                 download.provider.clone(),
                 Some(download.plugin_name.clone()),
+                Some(&hierarchy),
             )
             .await;
         }
@@ -231,6 +233,7 @@ async fn persist_supplied_show_download(
             start_time,
             download.provider.clone(),
             Some(download.plugin_name.clone()),
+            None,
         )
         .await;
     } else {

--- a/crates/riven-queue/src/application/scrape.rs
+++ b/crates/riven-queue/src/application/scrape.rs
@@ -194,6 +194,15 @@ pub async fn start(id: i64, job: &ScrapeJob, queue: &JobQueue) {
                 id,
                 title: item_title,
                 item_type: item.item_type,
+                tmdb_id: item.tmdb_id.clone(),
+                // `job.tvdb_id` is already the resolved show's id for
+                // Episode/Season (set by `ScrapeJob::for_episode_or_season`);
+                // `item.tvdb_id` would be the episode's own TVDB record
+                // instead, which the frontend's show-details link can't use.
+                tvdb_id: match item.item_type {
+                    MediaItemType::Episode | MediaItemType::Season => job.tvdb_id.clone(),
+                    _ => item.tvdb_id.clone(),
+                },
             })
             .await;
         return;
@@ -318,17 +327,42 @@ pub async fn parse_results(id: i64, job: &ParseScrapeResultsJob, queue: &JobQueu
     }
 
     if new_stream_count == 0 {
-        tracing::info!(
-            id,
-            title = %item_title,
-            "parse: no new streams, everything the scrapers returned was already known or rejected"
-        );
-        record_scrape_failure(&item).await;
+        // "No new streams" isn't the same as "nothing to download": the item
+        // may already be holding a perfectly good, unblacklisted candidate
+        // from an earlier scrape that never got a download attempt (or one
+        // that failed without moving the item forward). Retrying forever
+        // only on the appearance of something new would leave that candidate
+        // untouched — and since providers keep re-surfacing the same known
+        // releases, "new" may never happen again for this item at all.
+        // `push_download_from_best_stream` both checks for and enqueues a
+        // candidate, so a `true` here means one exists and a download attempt
+        // is now in flight — don't count that as a failure.
+        if queue.push_download_from_best_stream(id).await {
+            tracing::info!(
+                id,
+                title = %item_title,
+                "parse: no new streams, but a usable candidate already exists — attempting download instead of recording a failure"
+            );
+        } else {
+            tracing::info!(
+                id,
+                title = %item_title,
+                "parse: no new streams, everything the scrapers returned was already known or rejected"
+            );
+            record_scrape_failure(&item).await;
+        }
         queue
             .notify(RivenEvent::MediaItemScrapeErrorNoNewStreams {
                 id,
                 title: item_title,
                 item_type,
+                tmdb_id: item.tmdb_id.clone(),
+                tvdb_id: match item_type {
+                    MediaItemType::Episode | MediaItemType::Season => hierarchy
+                        .as_ref()
+                        .and_then(|h| h.resolved_show_tvdb_id.clone()),
+                    _ => item.tvdb_id.clone(),
+                },
             })
             .await;
     } else {
@@ -351,6 +385,13 @@ pub async fn parse_results(id: i64, job: &ParseScrapeResultsJob, queue: &JobQueu
                 title: item_title,
                 item_type,
                 stream_count: new_stream_count,
+                tmdb_id: item.tmdb_id.clone(),
+                tvdb_id: match item_type {
+                    MediaItemType::Episode | MediaItemType::Season => hierarchy
+                        .as_ref()
+                        .and_then(|h| h.resolved_show_tvdb_id.clone()),
+                    _ => item.tvdb_id.clone(),
+                },
             })
             .await;
     }

--- a/crates/riven-queue/src/context.rs
+++ b/crates/riven-queue/src/context.rs
@@ -41,6 +41,27 @@ pub struct DownloadHierarchyContext {
     pub show_is_anime: bool,
 }
 
+/// The tvdb_id to expose on a `RivenEvent` for notification click-through.
+///
+/// For a Movie or Show item, `item.tvdb_id` already is the right id. For an
+/// Episode or Season item it is *not*: TVDB gives every episode its own
+/// record id, distinct from the show's series id, and seasons frequently
+/// carry no tvdb_id of their own at all — so `item.tvdb_id` there is either
+/// the wrong resource type or empty. The frontend's `/details/media/{id}/tv`
+/// route expects a series id, so Episode/Season notifications need the
+/// resolved show's tvdb_id instead, or the link 404s against TVDB.
+pub fn notification_tvdb_id(
+    item: &MediaItem,
+    hierarchy: Option<&DownloadHierarchyContext>,
+) -> Option<String> {
+    match item.item_type {
+        MediaItemType::Episode | MediaItemType::Season => {
+            hierarchy.and_then(|h| h.show_tvdb_id.clone())
+        }
+        _ => item.tvdb_id.clone(),
+    }
+}
+
 /// Unwrap a repo lookup's `Result<Option<T>>`, logging why it came up empty.
 fn log_lookup<T, E: std::fmt::Display>(
     id: i64,
@@ -100,7 +121,13 @@ pub async fn load_media_item_or_download_error(
                 .notify(RivenEvent::MediaItemDownloadError {
                     id,
                     title: String::new(),
+                    // The item couldn't even be loaded, so there's nothing to
+                    // read a real type/tmdb_id/tvdb_id from — `Movie` matches
+                    // the frontend's own fallback for an unmapped item type.
+                    item_type: MediaItemType::Movie,
                     error: error_msg.into(),
+                    tmdb_id: None,
+                    tvdb_id: None,
                 })
                 .await;
             None

--- a/crates/riven-queue/src/main_orchestrator.rs
+++ b/crates/riven-queue/src/main_orchestrator.rs
@@ -192,15 +192,23 @@ impl MainOrchestrator {
                 // A show only gets season rows once its initial index
                 // actually completes (`apply_indexed_media_item` creates
                 // them). If a show is stuck in `Indexed` with zero seasons
-                // at all, its original `IndexJob` was lost before that ever
+                // and was never actually indexed (`indexed_at` still null),
+                // its original `IndexJob` was lost before that ever
                 // happened — e.g. dropped off the event bus — and
                 // `push_requested_seasons` fanning out over an empty list is
                 // a silent no-op: the retry sweep would "retry" this show
                 // every cycle forever without ever doing anything. Re-index
                 // it instead so it actually gets metadata (title, poster,
                 // seasons/episodes) at least once.
+                //
+                // `indexed_at` gates this specifically so a show that HAS
+                // completed indexing but genuinely has no season data (a bad
+                // upstream metadata entry, not a lost job) doesn't get
+                // reindexed every sweep forever with no backoff — that case
+                // falls through to the harmless no-op below instead, same as
+                // before this fix existed.
                 match repo::list_seasons(item.id).await {
-                    Ok(seasons) if seasons.is_empty() => {
+                    Ok(seasons) if seasons.is_empty() && item.indexed_at.is_none() => {
                         self.queue.push_index(IndexJob::from_item(item)).await;
                     }
                     Ok(_) => {

--- a/crates/riven-queue/src/main_orchestrator.rs
+++ b/crates/riven-queue/src/main_orchestrator.rs
@@ -189,7 +189,31 @@ impl MainOrchestrator {
         }
         match item.item_type {
             MediaItemType::Show => {
-                push_requested_seasons(item.id, &self.queue).await;
+                // A show only gets season rows once its initial index
+                // actually completes (`apply_indexed_media_item` creates
+                // them). If a show is stuck in `Indexed` with zero seasons
+                // at all, its original `IndexJob` was lost before that ever
+                // happened — e.g. dropped off the event bus — and
+                // `push_requested_seasons` fanning out over an empty list is
+                // a silent no-op: the retry sweep would "retry" this show
+                // every cycle forever without ever doing anything. Re-index
+                // it instead so it actually gets metadata (title, poster,
+                // seasons/episodes) at least once.
+                match repo::list_seasons(item.id).await {
+                    Ok(seasons) if seasons.is_empty() => {
+                        self.queue.push_index(IndexJob::from_item(item)).await;
+                    }
+                    Ok(_) => {
+                        push_requested_seasons(item.id, &self.queue).await;
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            id = item.id,
+                            %error,
+                            "library sweep: could not check for existing seasons, skipping this show's retry this pass"
+                        );
+                    }
+                }
             }
             _ => {
                 self.queue

--- a/frontend/src/lib/components/list-item.svelte
+++ b/frontend/src/lib/components/list-item.svelte
@@ -66,9 +66,20 @@
     // lookup/link/mutation actually uses. `undefined` here just means "not
     // applicable" (missing id, or a type this feature doesn't cover, e.g.
     // person/company) — distinct from the store's own `"pending"`.
-    const resolved = $derived.by(() => {
-        if (!requestSource || !requestExternalId || !requestMediaType) return undefined;
-        return getResolvedLibraryId(requestSource, requestExternalId, requestMediaType);
+    //
+    // This has to be plain $state updated from $effect, not $derived: the
+    // store's resolver writes to its own cache as a side effect (to record
+    // "pending" / cache the eventual result), and Svelte 5 throws
+    // (`state_unsafe_mutation`) on a $state write reachable from inside a
+    // $derived's evaluation — derived values must be pure. $effect is the
+    // rune meant for exactly this "reading triggers a side effect" shape.
+    let resolved = $state<ReturnType<typeof getResolvedLibraryId> | undefined>(undefined);
+    $effect(() => {
+        if (!requestSource || !requestExternalId || !requestMediaType) {
+            resolved = undefined;
+            return;
+        }
+        resolved = getResolvedLibraryId(requestSource, requestExternalId, requestMediaType);
     });
 
     let mediaURL = $derived.by(() => {
@@ -212,8 +223,18 @@
                             mediaType={requestMediaType}
                             externalId={resolved.id}
                             onSuccess={(itemId) => {
-                                if (itemId != null) {
-                                    markLibraryStatusRequested(resolved.indexer, resolved.id, itemId);
+                                // Captured by value: by the time this async
+                                // callback runs, the reactive `resolved`
+                                // binding could have moved on to a different
+                                // value, which is why TS won't narrow it
+                                // in-place here the way it does above.
+                                const requestedId = resolved;
+                                if (itemId != null && requestedId && requestedId !== "pending") {
+                                    markLibraryStatusRequested(
+                                        requestedId.indexer,
+                                        requestedId.id,
+                                        itemId
+                                    );
                                 }
                             }}>
                             Request

--- a/frontend/src/lib/components/list-item.svelte
+++ b/frontend/src/lib/components/list-item.svelte
@@ -5,7 +5,11 @@
     import { Badge } from "$lib/components/ui/badge/index.js";
     import { cn } from "$lib/utils";
     import { resolve } from "$app/paths";
-    import { getLibraryStatus, markLibraryStatusRequested } from "$lib/stores/library-status.svelte";
+    import {
+        getLibraryStatus,
+        markLibraryStatusRequested,
+        getResolvedLibraryId
+    } from "$lib/stores/library-status.svelte";
 
     const badgeVariantClasses: Record<string, string> = {
         success: "bg-green-600/90 text-white border-0",
@@ -26,10 +30,45 @@
     let normalizedType = $derived.by(() => {
         let t = type;
         if (indexer === "anilist" && !t) t = data.media_type;
+        if (indexer === "anilist" && t) {
+            // Anilist's raw MediaFormat enum (TV, TV_SHORT, MOVIE, SPECIAL,
+            // OVA, ONA, MUSIC, ...) has no movie/tv split of its own — Riven
+            // only distinguishes Movie vs Show, and everything that isn't a
+            // standalone MOVIE is episodic/serialized content, which maps to
+            // a Show. Passed straight through from the raw GraphQL response
+            // (see lists-cache.svelte.ts), so it's uppercase, not "tv"/"movie".
+            t = t.toUpperCase() === "MOVIE" ? "movie" : "tv";
+        }
         if ((indexer === "tvdb" || indexer === "tmdb") && t === "show") t = "tv";
         // Ensure type is set if only in data
         if (!t && data.media_type) t = data.media_type;
         return t;
+    });
+
+    // Mirrors the fallback used elsewhere in this component: an absent
+    // indexer has always meant "assume tmdb" for link-building (the
+    // SearchStore-backed trending pages never tag their raw TMDB results
+    // with one at all).
+    const requestSource = $derived.by<"tmdb" | "tvdb" | "anilist" | null>(() => {
+        if (indexer === "tmdb" || indexer === "tvdb" || indexer === "anilist") return indexer;
+        if (indexer === undefined) return "tmdb";
+        return null;
+    });
+    const requestMediaType = $derived.by<"movie" | "tv" | null>(() => {
+        if (normalizedType === "movie" || normalizedType === "tv") return normalizedType;
+        return null;
+    });
+    const requestExternalId = $derived(data.id != null ? String(data.id) : null);
+
+    // Riven's library is keyed by tmdb-movie/tvdb-show ids only. A TMDB
+    // *show* id and every Anilist id aren't usable directly and resolve
+    // through the store first; `resolved` is the identity every downstream
+    // lookup/link/mutation actually uses. `undefined` here just means "not
+    // applicable" (missing id, or a type this feature doesn't cover, e.g.
+    // person/company) — distinct from the store's own `"pending"`.
+    const resolved = $derived.by(() => {
+        if (!requestSource || !requestExternalId || !requestMediaType) return undefined;
+        return getResolvedLibraryId(requestSource, requestExternalId, requestMediaType);
     });
 
     let mediaURL = $derived.by(() => {
@@ -53,6 +92,18 @@
             // If indexer is undefined, assume tmdb behavior for now as default
             return `/details/media/${data.id}/${normalizedType}${queryParam}`;
         }
+
+        if (indexer === "anilist" && (normalizedType === "movie" || normalizedType === "tv")) {
+            // There is no /details/anilist/... route — Anilist ids aren't
+            // ones the details page understands at all. Resolve to the
+            // equivalent TMDB/TVDB id first (same resolution the button
+            // below uses) rather than link to a guaranteed 404; while
+            // that's in flight, no link is better than a broken one.
+            if (!resolved || resolved === "pending") return null;
+            const queryParam = resolved.indexer === "tvdb" ? "?indexer=tvdb" : "";
+            return `/details/media/${resolved.id}/${normalizedType}${queryParam}`;
+        }
+
         return `/details/${indexer}${normalizedType ? `/${normalizedType}` : ""}/${data.id}`;
     });
     let subtitle = $derived.by(() => {
@@ -67,38 +118,21 @@
         return parts.join(" • ") || null;
     });
 
-    // The Request/status button only makes sense for a movie/show sourced
-    // from an external indexer with a usable id — "riven" (already-resolved
-    // library items) and "anilist" (no tmdb/tvdb id available at all) can't
-    // be requested or status-checked this way, and person/company results
-    // aren't requestable content in the first place.
-    const requestMediaType = $derived.by<"movie" | "tv" | null>(() => {
-        if (normalizedType === "movie" || normalizedType === "tv") return normalizedType;
-        return null;
-    });
-    // Mirrors `mediaURL`'s own fallback below: some result sources (the raw
-    // TMDB search/discover results behind the dedicated trending pages, via
-    // SearchStore) never tag their items with an `indexer` at all, and an
-    // absent indexer has always meant "assume tmdb" for this component's own
-    // link-building — treating it any differently here just means the button
-    // silently never renders for those pages instead of erroring loudly.
-    const requestIndexer = $derived.by<"tmdb" | "tvdb" | null>(() => {
-        if (indexer === "tmdb" || indexer === "tvdb") return indexer;
-        if (indexer === undefined) return "tmdb";
-        return null;
-    });
-    const requestExternalId = $derived(data.id != null ? String(data.id) : null);
-    const requestEligible = $derived(
-        !!requestMediaType && !!requestIndexer && !!requestExternalId
-    );
+    // The Request/status button only makes sense for a movie/show with a
+    // resolvable identity in Riven's own library id-space — "riven"
+    // (already-resolved library items, e.g. Recently Added) and
+    // person/company results aren't requestable content in the first place,
+    // and `resolved === null` means an Anilist/TMDB-show id that genuinely
+    // couldn't be matched to anything.
+    const requestEligible = $derived(!!resolved && resolved !== "pending");
 
     let statusEntry = $state<ReturnType<typeof getLibraryStatus> | null>(null);
     $effect(() => {
-        if (!requestEligible || !requestIndexer || !requestExternalId || !requestMediaType) {
+        if (!requestSource || !requestExternalId || !requestMediaType) {
             statusEntry = null;
             return;
         }
-        statusEntry = getLibraryStatus(requestIndexer, requestExternalId, requestMediaType);
+        statusEntry = getLibraryStatus(requestSource, requestExternalId, requestMediaType);
     });
 
     // The footer's Request button/status pill lives inside the card's own <a>
@@ -162,7 +196,7 @@
             {/if}
         {/snippet}
         {#snippet footer()}
-            {#if requestEligible && requestIndexer && requestExternalId && requestMediaType}
+            {#if requestEligible && resolved && resolved !== "pending" && requestMediaType}
                 {#if statusEntry === null || statusEntry.status === "loading"}
                     <span
                         class="inline-flex h-6 w-20 animate-pulse rounded-full bg-white/10 backdrop-blur-md"
@@ -176,15 +210,10 @@
                             title={data.title}
                             ids={[]}
                             mediaType={requestMediaType}
-                            externalId={requestExternalId}
+                            externalId={resolved.id}
                             onSuccess={(itemId) => {
                                 if (itemId != null) {
-                                    markLibraryStatusRequested(
-                                        requestIndexer,
-                                        requestExternalId,
-                                        requestMediaType,
-                                        itemId
-                                    );
+                                    markLibraryStatusRequested(resolved.indexer, resolved.id, itemId);
                                 }
                             }}>
                             Request

--- a/frontend/src/lib/components/list-item.svelte
+++ b/frontend/src/lib/components/list-item.svelte
@@ -75,8 +75,15 @@
         if (normalizedType === "movie" || normalizedType === "tv") return normalizedType;
         return null;
     });
+    // Mirrors `mediaURL`'s own fallback below: some result sources (the raw
+    // TMDB search/discover results behind the dedicated trending pages, via
+    // SearchStore) never tag their items with an `indexer` at all, and an
+    // absent indexer has always meant "assume tmdb" for this component's own
+    // link-building — treating it any differently here just means the button
+    // silently never renders for those pages instead of erroring loudly.
     const requestIndexer = $derived.by<"tmdb" | "tvdb" | null>(() => {
         if (indexer === "tmdb" || indexer === "tvdb") return indexer;
+        if (indexer === undefined) return "tmdb";
         return null;
     });
     const requestExternalId = $derived(data.id != null ? String(data.id) : null);

--- a/frontend/src/lib/components/list-item.svelte
+++ b/frontend/src/lib/components/list-item.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import PortraitCard from "$lib/components/media/portrait-card.svelte";
     import ItemRequest from "$lib/components/media/riven/item-request.svelte";
+    import StatusBadge from "$lib/components/media/status-badge.svelte";
     import { Badge } from "$lib/components/ui/badge/index.js";
     import { cn } from "$lib/utils";
     import { resolve } from "$app/paths";
@@ -190,15 +191,7 @@
                         </ItemRequest>
                     </div>
                 {:else}
-                    <span
-                        class={cn(
-                            "inline-flex h-6 items-center justify-center rounded-full px-3 text-[10px] font-semibold shadow-sm backdrop-blur-md",
-                            statusEntry.state === "Failed"
-                                ? "bg-red-600/80 text-red-50"
-                                : "bg-blue-600/80 text-blue-50"
-                        )}>
-                        {statusEntry.state}
-                    </span>
+                    <StatusBadge state={statusEntry.state} size="sm" class="border-white/10 border" />
                 {/if}
             {/if}
         {/snippet}

--- a/frontend/src/lib/components/list-item.svelte
+++ b/frontend/src/lib/components/list-item.svelte
@@ -163,8 +163,8 @@
                     <div data-card-footer-action>
                         <ItemRequest
                             size="sm"
-                            variant="ghost"
-                            class="h-6 rounded-full border-0 bg-green-600/80 px-3 text-[10px] font-semibold text-emerald-50 shadow-sm backdrop-blur-md hover:bg-green-600/70 hover:text-emerald-50"
+                            variant="secondary"
+                            class="border-primary/50 text-primary hover:bg-primary/10 hover:text-primary hover:border-primary h-6 rounded-full border bg-black/40 px-3 text-[10px] font-semibold shadow-sm backdrop-blur-md"
                             title={data.title}
                             ids={[]}
                             mediaType={requestMediaType}

--- a/frontend/src/lib/components/list-item.svelte
+++ b/frontend/src/lib/components/list-item.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
     import PortraitCard from "$lib/components/media/portrait-card.svelte";
+    import ItemRequest from "$lib/components/media/riven/item-request.svelte";
     import { Badge } from "$lib/components/ui/badge/index.js";
     import { cn } from "$lib/utils";
     import { resolve } from "$app/paths";
+    import { getLibraryStatus, markLibraryStatusRequested } from "$lib/stores/library-status.svelte";
 
     const badgeVariantClasses: Record<string, string> = {
         success: "bg-green-600/90 text-white border-0",
@@ -64,6 +66,46 @@
         return parts.join(" • ") || null;
     });
 
+    // The Request/status button only makes sense for a movie/show sourced
+    // from an external indexer with a usable id — "riven" (already-resolved
+    // library items) and "anilist" (no tmdb/tvdb id available at all) can't
+    // be requested or status-checked this way, and person/company results
+    // aren't requestable content in the first place.
+    const requestMediaType = $derived.by<"movie" | "tv" | null>(() => {
+        if (normalizedType === "movie" || normalizedType === "tv") return normalizedType;
+        return null;
+    });
+    const requestIndexer = $derived.by<"tmdb" | "tvdb" | null>(() => {
+        if (indexer === "tmdb" || indexer === "tvdb") return indexer;
+        return null;
+    });
+    const requestExternalId = $derived(data.id != null ? String(data.id) : null);
+    const requestEligible = $derived(
+        !!requestMediaType && !!requestIndexer && !!requestExternalId
+    );
+
+    let statusEntry = $state<ReturnType<typeof getLibraryStatus> | null>(null);
+    $effect(() => {
+        if (!requestEligible || !requestIndexer || !requestExternalId || !requestMediaType) {
+            statusEntry = null;
+            return;
+        }
+        statusEntry = getLibraryStatus(requestIndexer, requestExternalId, requestMediaType);
+    });
+
+    // The footer's Request button/status pill lives inside the card's own <a>
+    // (so it stays visually anchored to the poster), so a click on it would
+    // otherwise also navigate to the details page. Rather than attach a click
+    // handler to a non-interactive wrapper around it (which needs its own
+    // keyboard handling and ARIA role to be accessible), the check lives on
+    // the anchor itself — already a properly interactive element — and just
+    // looks at whether the click originated inside the marked footer region.
+    function handleCardClick(e: MouseEvent) {
+        if ((e.target as HTMLElement | null)?.closest("[data-card-footer-action]")) {
+            e.preventDefault();
+        }
+    }
+
     // Default container classes (w-full allows grid to control width)
     // Merged with passed className
     const containerClasses = $derived(
@@ -111,11 +153,53 @@
                     )}>{data.badge.text}</Badge>
             {/if}
         {/snippet}
+        {#snippet footer()}
+            {#if requestEligible && requestIndexer && requestExternalId && requestMediaType}
+                {#if statusEntry === null || statusEntry.status === "loading"}
+                    <span
+                        class="inline-flex h-6 w-20 animate-pulse rounded-full bg-white/10 backdrop-blur-md"
+                        aria-hidden="true"></span>
+                {:else if statusEntry.status === "not_found"}
+                    <div data-card-footer-action>
+                        <ItemRequest
+                            size="sm"
+                            variant="ghost"
+                            class="h-6 rounded-full border-0 bg-green-600/80 px-3 text-[10px] font-semibold text-emerald-50 shadow-sm backdrop-blur-md hover:bg-green-600/70 hover:text-emerald-50"
+                            title={data.title}
+                            ids={[]}
+                            mediaType={requestMediaType}
+                            externalId={requestExternalId}
+                            onSuccess={(itemId) => {
+                                if (itemId != null) {
+                                    markLibraryStatusRequested(
+                                        requestIndexer,
+                                        requestExternalId,
+                                        requestMediaType,
+                                        itemId
+                                    );
+                                }
+                            }}>
+                            Request
+                        </ItemRequest>
+                    </div>
+                {:else}
+                    <span
+                        class={cn(
+                            "inline-flex h-6 items-center justify-center rounded-full px-3 text-[10px] font-semibold shadow-sm backdrop-blur-md",
+                            statusEntry.state === "Failed"
+                                ? "bg-red-600/80 text-red-50"
+                                : "bg-blue-600/80 text-blue-50"
+                        )}>
+                        {statusEntry.state}
+                    </span>
+                {/if}
+            {/if}
+        {/snippet}
     </PortraitCard>
 {/snippet}
 
 {#if mediaURL}
-    <a href={getMediaHref(mediaURL)} class={containerClasses}>
+    <a href={getMediaHref(mediaURL)} class={containerClasses} onclick={handleCardClick}>
         {@render cardContent()}
     </a>
 {:else}

--- a/frontend/src/lib/components/media/portrait-card.svelte
+++ b/frontend/src/lib/components/media/portrait-card.svelte
@@ -13,6 +13,7 @@
         onSelectToggle?: () => void;
         class?: string;
         topRight?: Snippet;
+        footer?: Snippet;
         showContent?: boolean;
     }
 
@@ -26,6 +27,7 @@
         onSelectToggle,
         class: className,
         topRight,
+        footer,
         showContent = true
     }: Props = $props();
 </script>
@@ -100,6 +102,11 @@
                 <p class="mt-1 line-clamp-1 text-xs font-medium text-zinc-300/90">
                     {subtitle}
                 </p>
+            {/if}
+            {#if footer}
+                <div class="mt-2">
+                    {@render footer()}
+                </div>
             {/if}
         </div>
     {/if}

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -27,6 +27,10 @@
         size?: "default" | "sm" | "lg" | "icon" | "icon-sm" | "icon-lg";
         class?: string;
         seasons?: SeasonInfo[];
+        /** Scopes the whole dialog to one episode: no season picker, every
+         * search and download targets exactly this season+episode. */
+        episodeNumber?: number | null;
+        seasonNumber?: number | null;
         children?: Snippet;
     }
 
@@ -45,8 +49,9 @@
         rank?: number | null;
         fileSizeBytes?: number | null;
         isCached: boolean;
-        itemType: "MOVIE" | "SEASON";
+        itemType: "MOVIE" | "SEASON" | "EPISODE";
         seasonNumber?: number | null;
+        episodeNumber?: number | null;
     }
 
     /**
@@ -61,8 +66,8 @@
         open = false;
     }
 
-    const DISCOVER_STREAMS_MUTATION = `mutation($itemType: MediaItemType!, $title: String!, $imdbId: String, $tmdbId: String, $tvdbId: String, $seasons: [Int!], $cachedOnly: Boolean) {
-        discoverStreams(itemType: $itemType, title: $title, imdbId: $imdbId, tmdbId: $tmdbId, tvdbId: $tvdbId, seasons: $seasons, cachedOnly: $cachedOnly) {
+    const DISCOVER_STREAMS_MUTATION = `mutation($itemType: MediaItemType!, $title: String!, $imdbId: String, $tmdbId: String, $tvdbId: String, $seasons: [Int!], $episodeNumber: Int, $cachedOnly: Boolean) {
+        discoverStreams(itemType: $itemType, title: $title, imdbId: $imdbId, tmdbId: $tmdbId, tvdbId: $tvdbId, seasons: $seasons, episodeNumber: $episodeNumber, cachedOnly: $cachedOnly) {
             key
             title
             infoHash
@@ -73,11 +78,12 @@
             isCached
             itemType
             seasonNumber
+            episodeNumber
         }
     }`;
 
-    const DOWNLOAD_DISCOVERED_STREAM_MUTATION = `mutation($itemType: MediaItemType!, $title: String!, $imdbId: String, $tmdbId: String, $tvdbId: String, $seasonNumber: Int, $seasons: [Int!], $infoHash: String!, $magnet: String!, $parsedData: JSON, $rank: Int) {
-        downloadDiscoveredStream(itemType: $itemType, title: $title, imdbId: $imdbId, tmdbId: $tmdbId, tvdbId: $tvdbId, seasonNumber: $seasonNumber, seasons: $seasons, infoHash: $infoHash, magnet: $magnet, parsedData: $parsedData, rank: $rank)
+    const DOWNLOAD_DISCOVERED_STREAM_MUTATION = `mutation($itemType: MediaItemType!, $title: String!, $imdbId: String, $tmdbId: String, $tvdbId: String, $seasonNumber: Int, $episodeNumber: Int, $seasons: [Int!], $infoHash: String!, $magnet: String!, $parsedData: JSON, $rank: Int) {
+        downloadDiscoveredStream(itemType: $itemType, title: $title, imdbId: $imdbId, tmdbId: $tmdbId, tvdbId: $tvdbId, seasonNumber: $seasonNumber, episodeNumber: $episodeNumber, seasons: $seasons, infoHash: $infoHash, magnet: $magnet, parsedData: $parsedData, rank: $rank)
     }`;
 
     let {
@@ -88,6 +94,8 @@
         variant = "ghost",
         size = "sm",
         seasons = [],
+        episodeNumber = null,
+        seasonNumber = null,
         children,
         ...restProps
     }: Props = $props();
@@ -104,7 +112,10 @@
     let streams = $state<StreamCandidate[]>([]);
     let downloadingKey = $state<string | null>(null);
 
-    const hasSeasonSelector = $derived(mediaType === "tv" && seasons.length > 0);
+    const isEpisodeMode = $derived(mediaType === "tv" && episodeNumber != null);
+    const hasSeasonSelector = $derived(
+        mediaType === "tv" && seasons.length > 0 && !isEpisodeMode
+    );
     const visibleStreams = $derived(
         cachedOnly ? streams.filter((stream) => stream.isCached) : streams
     );
@@ -169,8 +180,9 @@
     async function submitDownload(
         key: string,
         vars: {
-            itemType: "MOVIE" | "SEASON";
+            itemType: "MOVIE" | "SEASON" | "EPISODE";
             seasonNumber: number | null;
+            episodeNumber?: number | null;
             seasons?: number[] | null;
             infoHash: string;
             magnet: string;
@@ -191,6 +203,7 @@
                     tmdbId: resolvedTmdbId,
                     tvdbId: resolvedTvdbId,
                     seasonNumber: vars.seasonNumber,
+                    episodeNumber: vars.episodeNumber ?? null,
                     seasons: vars.seasons ?? null,
                     infoHash: vars.infoHash,
                     magnet: vars.magnet,
@@ -227,7 +240,12 @@
                     imdbId: null,
                     tmdbId: resolvedTmdbId,
                     tvdbId: resolvedTvdbId,
-                    seasons: hasSeasonSelector ? selectedSeasons : null,
+                    seasons: hasSeasonSelector
+                        ? selectedSeasons
+                        : isEpisodeMode && seasonNumber != null
+                          ? [seasonNumber]
+                          : null,
+                    episodeNumber: isEpisodeMode ? episodeNumber : null,
                     cachedOnly
                 }
             );
@@ -244,11 +262,16 @@
 
     function downloadStream(stream: StreamCandidate) {
         // A pack that parses to multiple seasons fills every one it contains;
-        // the backend links it to the show rather than a single season.
-        const packSeasons = stream.parsedData?.seasons?.filter((n) => n > 0) ?? [];
+        // the backend links it to the show rather than a single season. Not
+        // relevant in episode mode: every result there is already scoped to
+        // the one season+episode the dialog was opened for.
+        const packSeasons = isEpisodeMode
+            ? []
+            : (stream.parsedData?.seasons?.filter((n) => n > 0) ?? []);
         return submitDownload(stream.key, {
             itemType: stream.itemType,
             seasonNumber: stream.seasonNumber ?? null,
+            episodeNumber: stream.episodeNumber ?? null,
             seasons: packSeasons.length ? packSeasons : null,
             infoHash: stream.infoHash,
             magnet: stream.magnet,
@@ -261,6 +284,23 @@
         if (!cleanedHash) {
             error = "Enter a valid 40-char info hash or paste a magnet link";
             return;
+        }
+
+        if (isEpisodeMode) {
+            if (seasonNumber == null) {
+                error = "No season number available for this episode";
+                toast.error(error);
+                return;
+            }
+            return submitDownload(`manual:${cleanedHash}`, {
+                itemType: "EPISODE",
+                seasonNumber,
+                episodeNumber,
+                seasons: null,
+                infoHash: cleanedHash,
+                magnet: `magnet:?xt=urn:btih:${cleanedHash}`,
+                parsedData: null
+            });
         }
 
         if (mediaType === "tv" && selectedSeasons.length === 0) {
@@ -322,7 +362,9 @@
                                 <p class="text-xs text-zinc-400">
                                     {mediaType === "movie"
                                         ? "Movie discovery"
-                                        : "Season pack discovery"}
+                                        : isEpisodeMode
+                                          ? `Episode ${episodeNumber} discovery`
+                                          : "Season pack discovery"}
                                 </p>
                                 <button
                                     type="button"
@@ -465,6 +507,10 @@
                                                         {#if stream.seasonNumber != null}
                                                             <Badge variant="outline"
                                                                 >Season {stream.seasonNumber}</Badge>
+                                                        {/if}
+                                                        {#if stream.episodeNumber != null}
+                                                            <Badge variant="outline"
+                                                                >Episode {stream.episodeNumber}</Badge>
                                                         {/if}
                                                         <Badge
                                                             variant={stream.isCached

--- a/frontend/src/lib/components/notification-center.svelte
+++ b/frontend/src/lib/components/notification-center.svelte
@@ -269,7 +269,8 @@
                                                 onclick={(event) => {
                                                     event.stopPropagation();
                                                     handleMarkAsRead(notification.id);
-                                                }}>
+                                                }}
+                                                onkeydown={(event) => event.stopPropagation()}>
                                                 <Check class="size-3" />
                                             </Button>
                                         {/snippet}
@@ -287,7 +288,8 @@
                                             onclick={(event) => {
                                                 event.stopPropagation();
                                                 handleRemove(notification.id);
-                                            }}>
+                                            }}
+                                            onkeydown={(event) => event.stopPropagation()}>
                                             <Trash2 class="size-3" />
                                         </Button>
                                     {/snippet}

--- a/frontend/src/lib/components/notification-center.svelte
+++ b/frontend/src/lib/components/notification-center.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import { notificationStore, type Notification } from "$lib/stores/notifications.svelte";
     import { onMount, onDestroy } from "svelte";
+    import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
     import * as Popover from "$lib/components/ui/popover/index.js";
     import { Button } from "$lib/components/ui/button/index.js";
     import { Badge } from "$lib/components/ui/badge/index.js";
@@ -10,6 +12,7 @@
     import Check from "@lucide/svelte/icons/check";
     import CheckCheck from "@lucide/svelte/icons/check-check";
     import Trash2 from "@lucide/svelte/icons/trash-2";
+    import X from "@lucide/svelte/icons/x";
     import Tooltip from "./tooltip.svelte";
     import { toast } from "svelte-sonner";
     import { cn } from "$lib/utils";
@@ -73,6 +76,34 @@
         }
     }
 
+    // TMDB has no separate "episode" root id — a season/episode notification's
+    // tmdbId is already the id of the show it belongs to, so every type maps
+    // to a `/details/media/{tmdbId}/{mediaType}` link, "show"/"season"/
+    // "episode" all landing on the same show page "movie" would.
+    function detailsHref(notification: Notification): string | null {
+        const mediaType = notification.type === "movie" ? "movie" : "tv";
+        if (notification.tmdbId) {
+            return resolve(`/details/media/${notification.tmdbId}/${mediaType}`);
+        }
+        // Shows/seasons/episodes are frequently TVDB-only — no TMDB match at
+        // all — so tmdbId alone would leave most TV notifications
+        // unclickable. `?indexer=tvdb` tells the details route to resolve
+        // the id as a TVDB id instead, same as the rest of the app does for
+        // TVDB-sourced content (see list-item.svelte).
+        if (notification.tvdbId) {
+            return resolve(`/details/media/${notification.tvdbId}/${mediaType}?indexer=tvdb`);
+        }
+        return null;
+    }
+
+    function handleNotificationClick(notification: Notification) {
+        const href = detailsHref(notification);
+        if (!href) return;
+        if (!notification.read) notificationStore.markAsRead(notification.id);
+        open = false;
+        goto(href);
+    }
+
     function handleMarkAsRead(id: string) {
         notificationStore.markAsRead(id);
     }
@@ -85,6 +116,10 @@
     function handleClearAll() {
         notificationStore.clear();
         toast.success("All notifications cleared");
+    }
+
+    function handleClose() {
+        open = false;
     }
 
     function handleRemove(id: string) {
@@ -163,11 +198,25 @@
                             {/snippet}
                         </Tooltip>
                     {/if}
+                    <Tooltip>
+                        {#snippet trigger()}
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                class="text-muted-foreground hover:text-foreground h-7 w-7"
+                                onclick={handleClose}>
+                                <X class="size-3.5" />
+                            </Button>
+                        {/snippet}
+                        {#snippet content()}
+                            <p>Close</p>
+                        {/snippet}
+                    </Tooltip>
                 </div>
             </div>
             <Separator />
 
-            <div class="max-h-100 overflow-y-auto">
+            <div class="notification-scroll max-h-100 overflow-y-auto">
                 {#if notificationStore.notifications.length === 0}
                     <div class="flex flex-col items-center justify-center p-8 text-center">
                         <div
@@ -180,74 +229,103 @@
                         </p>
                     </div>
                 {:else}
-                    {#each notificationStore.notifications as notification (notification.id)}
-                        <div
-                            class="border-border/50 hover:bg-muted/30 border-b p-3 transition-colors {!notification.read
-                                ? 'bg-muted/10'
-                                : ''}">
-                            <div class="flex items-start justify-between gap-2">
-                                <div class="flex-1 space-y-1">
-                                    <div class="flex items-center gap-2">
-                                        <Badge
-                                            variant="secondary"
-                                            class="{getTypeColor(notification.type)} text-[10px]">
-                                            {notification.type}
-                                        </Badge>
-                                        {#if notification.count > 1}
-                                            <span
-                                                class="bg-muted text-muted-foreground rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums">
-                                                ×{notification.count}
-                                            </span>
-                                        {/if}
-                                        {#if !notification.read}
-                                            <div class="size-2 rounded-full bg-blue-500"></div>
-                                        {/if}
-                                    </div>
-                                    <p class="text-sm leading-none font-medium">
-                                        {notification.title}
-                                    </p>
-                                    <p class="text-muted-foreground text-xs">
-                                        {notification.message}
-                                    </p>
-                                    <p class="text-muted-foreground/70 text-xs">
-                                        {formatTimestamp(notification.timestamp)}
-                                    </p>
-                                </div>
-                                <div class="flex flex-col gap-1">
-                                    {#if !notification.read}
-                                        <Tooltip>
-                                            {#snippet trigger()}
-                                                <Button
-                                                    variant="ghost"
-                                                    size="icon"
-                                                    class="text-muted-foreground hover:text-primary size-6"
-                                                    onclick={() =>
-                                                        handleMarkAsRead(notification.id)}>
-                                                    <Check class="size-3" />
-                                                </Button>
-                                            {/snippet}
-                                            {#snippet content()}
-                                                <p>Mark as read</p>
-                                            {/snippet}
-                                        </Tooltip>
+                    {#snippet notificationBody(notification: Notification)}
+                        <div class="flex items-start justify-between gap-2">
+                            <div class="flex-1 space-y-1">
+                                <div class="flex items-center gap-2">
+                                    <Badge
+                                        variant="secondary"
+                                        class="{getTypeColor(notification.type)} text-[10px]">
+                                        {notification.type}
+                                    </Badge>
+                                    {#if notification.count > 1}
+                                        <span
+                                            class="bg-muted text-muted-foreground rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums">
+                                            ×{notification.count}
+                                        </span>
                                     {/if}
+                                    {#if !notification.read}
+                                        <div class="size-2 rounded-full bg-blue-500"></div>
+                                    {/if}
+                                </div>
+                                <p class="text-sm leading-none font-medium">
+                                    {notification.title}
+                                </p>
+                                <p class="text-muted-foreground text-xs">
+                                    {notification.message}
+                                </p>
+                                <p class="text-muted-foreground/70 text-xs">
+                                    {formatTimestamp(notification.timestamp)}
+                                </p>
+                            </div>
+                            <div class="flex flex-col gap-1">
+                                {#if !notification.read}
                                     <Tooltip>
                                         {#snippet trigger()}
                                             <Button
                                                 variant="ghost"
                                                 size="icon"
-                                                class="text-muted-foreground hover:text-destructive size-6"
-                                                onclick={() => handleRemove(notification.id)}>
-                                                <Trash2 class="size-3" />
+                                                class="text-muted-foreground hover:text-primary size-6"
+                                                onclick={(event) => {
+                                                    event.stopPropagation();
+                                                    handleMarkAsRead(notification.id);
+                                                }}>
+                                                <Check class="size-3" />
                                             </Button>
                                         {/snippet}
                                         {#snippet content()}
-                                            <p>Remove</p>
+                                            <p>Mark as read</p>
                                         {/snippet}
                                     </Tooltip>
-                                </div>
+                                {/if}
+                                <Tooltip>
+                                    {#snippet trigger()}
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            class="text-muted-foreground hover:text-destructive size-6"
+                                            onclick={(event) => {
+                                                event.stopPropagation();
+                                                handleRemove(notification.id);
+                                            }}>
+                                            <Trash2 class="size-3" />
+                                        </Button>
+                                    {/snippet}
+                                    {#snippet content()}
+                                        <p>Remove</p>
+                                    {/snippet}
+                                </Tooltip>
                             </div>
                         </div>
+                    {/snippet}
+
+                    {#each notificationStore.notifications as notification (notification.id)}
+                        {@const href = detailsHref(notification)}
+                        {#if href}
+                            <!-- biome-ignore lint/a11y/useSemanticElements: notificationBody renders its own <button>s (mark-as-read, remove) for the row's per-item actions — nesting a <button> inside a <button> is invalid HTML, so this can't be a real button and still contain those. -->
+                            <div
+                                class="border-border/50 hover:bg-muted/30 border-b p-3 transition-colors {!notification.read
+                                    ? 'bg-muted/10'
+                                    : ''} cursor-pointer"
+                                role="button"
+                                tabindex={0}
+                                onclick={() => handleNotificationClick(notification)}
+                                onkeydown={(event) => {
+                                    if (event.key === "Enter" || event.key === " ") {
+                                        event.preventDefault();
+                                        handleNotificationClick(notification);
+                                    }
+                                }}>
+                                {@render notificationBody(notification)}
+                            </div>
+                        {:else}
+                            <div
+                                class="border-border/50 hover:bg-muted/30 border-b p-3 transition-colors {!notification.read
+                                    ? 'bg-muted/10'
+                                    : ''}">
+                                {@render notificationBody(notification)}
+                            </div>
+                        {/if}
                     {/each}
                 {/if}
             </div>
@@ -269,3 +347,32 @@
         </div>
     </Popover.Content>
 </Popover.Root>
+
+<style>
+    /* app.css hides scrollbars globally (`::-webkit-scrollbar { display:
+       none }` with no scoping selector) — fine for drag/wheel-scrolled
+       carousels elsewhere, but this list needs a visible indicator that
+       there's more to scroll to. Overridden here rather than in app.css so
+       the global behavior elsewhere is untouched. */
+    .notification-scroll {
+        scrollbar-width: thin;
+    }
+
+    .notification-scroll::-webkit-scrollbar {
+        display: block;
+        width: 6px;
+    }
+
+    .notification-scroll::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    .notification-scroll::-webkit-scrollbar-thumb {
+        background-color: rgb(255 255 255 / 15%);
+        border-radius: 3px;
+    }
+
+    .notification-scroll::-webkit-scrollbar-thumb:hover {
+        background-color: rgb(255 255 255 / 25%);
+    }
+</style>

--- a/frontend/src/lib/gql/schema.ts
+++ b/frontend/src/lib/gql/schema.ts
@@ -173,6 +173,7 @@ export type DebridUserInfo = {
 };
 
 export type DiscoveredStream = {
+  episodeNumber?: Maybe<Scalars['Int']['output']>;
   fileSizeBytes?: Maybe<Scalars['Int']['output']>;
   infoHash: Scalars['String']['output'];
   isCached: Scalars['Boolean']['output'];
@@ -900,6 +901,14 @@ export type MutationRoot = {
    * If omitted, all non-special seasons are requested.
    */
   addItem: MediaItem;
+  /**
+   * Reject a downloaded file: permanently blacklist the release behind it
+   * and remove its tracked entry, then clear the owning item's retry
+   * backoff so a replacement is searched for on the next scheduler pass.
+   * Use when a download turned out wrong — mismatched title, bad quality,
+   * wrong language, etc.
+   */
+  blacklistFilesystemEntry: Scalars['Boolean']['output'];
   /** Mark the instance-wide first-run setup flow as completed. */
   completeInitialSetup: Scalars['Boolean']['output'];
   /** Delete a custom ranking profile by ID. Built-in profiles cannot be deleted. */
@@ -1062,6 +1071,11 @@ export type MutationRootAddItemArgs = {
 };
 
 
+export type MutationRootBlacklistFilesystemEntryArgs = {
+  id: Scalars['Int']['input'];
+};
+
+
 export type MutationRootDeleteCustomProfileArgs = {
   id: Scalars['Int']['input'];
 };
@@ -1084,6 +1098,7 @@ export type MutationRootDiscoverItemArgs = {
 
 export type MutationRootDiscoverStreamsArgs = {
   cachedOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  episodeNumber?: InputMaybe<Scalars['Int']['input']>;
   imdbId?: InputMaybe<Scalars['String']['input']>;
   itemType: MediaItemType;
   seasons?: InputMaybe<Array<Scalars['Int']['input']>>;
@@ -1094,6 +1109,7 @@ export type MutationRootDiscoverStreamsArgs = {
 
 
 export type MutationRootDownloadDiscoveredStreamArgs = {
+  episodeNumber?: InputMaybe<Scalars['Int']['input']>;
   imdbId?: InputMaybe<Scalars['String']['input']>;
   infoHash: Scalars['String']['input'];
   itemType: MediaItemType;

--- a/frontend/src/lib/gql/schema.ts
+++ b/frontend/src/lib/gql/schema.ts
@@ -783,6 +783,22 @@ export type MediaItemStateTree = {
   tvdbId?: Maybe<Scalars['String']['output']>;
 };
 
+/**
+ * Minimal per-item library status: just enough to render a "Request" vs
+ * "current state" button on a suggested-content card without paying for a
+ * full season/episode tree (unlike `MediaItemStateTree`, which
+ * `apply_indexed_media_item`-style callers need for shows but a poster card
+ * never does). Returned in bulk by the `mediaItemStatusesBy*Ids` batch
+ * queries so a whole carousel row resolves in one round trip instead of one
+ * query per card.
+ */
+export type MediaItemStatus = {
+  id: Scalars['Int']['output'];
+  state: MediaItemState;
+  tmdbId?: Maybe<Scalars['String']['output']>;
+  tvdbId?: Maybe<Scalars['String']['output']>;
+};
+
 export type MediaItemType =
   | 'EPISODE'
   | 'MOVIE'
@@ -1401,6 +1417,18 @@ export type QueryRoot = {
   mediaItemFullByTvdb?: Maybe<MediaItemFull>;
   mediaItemStateByTmdb?: Maybe<MediaItemStateTree>;
   mediaItemStateByTvdb?: Maybe<MediaItemStateTree>;
+  /**
+   * Bulk library-status lookup for a set of TMDB ids: one round trip for
+   * a whole suggested-content carousel row instead of one query per card.
+   * Ids not found in the library are simply absent from the result — the
+   * caller treats "no matching entry" as "not yet requested".
+   */
+  mediaItemStatusesByTmdbIds: Array<MediaItemStatus>;
+  /**
+   * Bulk library-status lookup for a set of TVDB ids — the show-side
+   * counterpart to `mediaItemStatusesByTmdbIds`, same batching rationale.
+   */
+  mediaItemStatusesByTvdbIds: Array<MediaItemStatus>;
   mediaItems: Array<MediaItemUnion>;
   /**
    * Everything the movie detail page renders, in one shape shared with
@@ -1594,6 +1622,16 @@ export type QueryRootMediaItemStateByTmdbArgs = {
 
 export type QueryRootMediaItemStateByTvdbArgs = {
   tvdbId: Scalars['String']['input'];
+};
+
+
+export type QueryRootMediaItemStatusesByTmdbIdsArgs = {
+  tmdbIds: Array<Scalars['String']['input']>;
+};
+
+
+export type QueryRootMediaItemStatusesByTvdbIdsArgs = {
+  tvdbIds: Array<Scalars['String']['input']>;
 };
 
 

--- a/frontend/src/lib/services/riven-media.ts
+++ b/frontend/src/lib/services/riven-media.ts
@@ -46,7 +46,7 @@ export type GqlFilesystemEntry = Pick<
 	| "mediaMetadata"
 >;
 
-export type GqlEpisodeFull = Pick<EpisodeFull, "episodeNumber" | "state"> & {
+export type GqlEpisodeFull = Pick<EpisodeFull, "id" | "episodeNumber" | "state"> & {
 	filesystemEntry?: GqlFilesystemEntry | null;
 	filesystemEntries?: GqlFilesystemEntry[];
 };
@@ -118,7 +118,7 @@ const MEDIA_ITEM_FULL_FIELDS = `
     seasons {
         seasonNumber state isRequested
         episodes {
-            episodeNumber state
+            id episodeNumber state
             filesystemEntry {
                 ${FILESYSTEM_ENTRY_FIELDS}
             }

--- a/frontend/src/lib/stores/library-status.svelte.ts
+++ b/frontend/src/lib/stores/library-status.svelte.ts
@@ -20,6 +20,7 @@ export type LibraryStatusEntry =
 
 type Indexer = "tmdb" | "tvdb";
 type MediaKind = "movie" | "tv";
+export type ResolvableSource = Indexer | "anilist";
 
 const cache = $state<Record<string, LibraryStatusEntry>>({});
 
@@ -117,66 +118,95 @@ function queueFetch(indexer: Indexer, id: string): Promise<LibraryStatusEntry> {
 	return promise;
 }
 
-// TMDB has no independent notion of a TV show's *Riven* identity — every show
-// in this app is keyed by TVDB id (see the tmdb->tvdb resolution the details
-// page's +page.ts does before it will even fetch show metadata). A TMDB-
-// sourced TV card therefore has to resolve to a TVDB id first before its
-// library status can be looked up at all. Deduped per id so the same show
-// appearing in multiple rows doesn't re-resolve repeatedly.
-const tvResolutionCache = new Map<string, Promise<string | null>>();
-function resolveTmdbTvToTvdb(tmdbId: string): Promise<string | null> {
-	let pending = tvResolutionCache.get(tmdbId);
+export type ResolvedId = { indexer: Indexer; id: string };
+
+/**
+ * Resolve an id from a source id-space to the id-space Riven's own library
+ * actually keys that content by (movies by TMDB id, shows by TVDB id — never
+ * TMDB, see the details page's own `+page.ts` resolution for the same
+ * reason). Two sources need this: Anilist ids aren't TMDB/TVDB ids at all, and
+ * a TMDB-sourced *TV show* result still needs translating since shows are
+ * keyed by TVDB id regardless of where the search result came from. A TMDB
+ * *movie* or a TVDB result is already in the right space and resolves
+ * instantly with no network call.
+ *
+ * Cached and deduped per (source, mediaType, id) — the same title showing up
+ * in multiple rows only ever resolves once.
+ */
+const idResolutionCache = new Map<string, Promise<ResolvedId | null>>();
+
+function resolutionCacheKey(source: ResolvableSource, externalId: string, mediaType: MediaKind): string {
+	return `${source}:${mediaType}:${externalId}`;
+}
+
+function resolveToLibraryId(
+	source: ResolvableSource,
+	externalId: string,
+	mediaType: MediaKind
+): Promise<ResolvedId | null> {
+	const target: Indexer = mediaType === "tv" ? "tvdb" : "tmdb";
+	if (source === target) {
+		return Promise.resolve({ indexer: target, id: externalId });
+	}
+	const cacheKey = resolutionCacheKey(source, externalId, mediaType);
+	let pending = idResolutionCache.get(cacheKey);
 	if (!pending) {
-		pending = resolveExternalId({ from: "tmdb", to: "tvdb", id: tmdbId, mediaType: "tv" })
-			.then((r) => (r.resolved ? r.id : null))
+		pending = resolveExternalId({ from: source, to: target, id: externalId, mediaType })
+			.then((r) => (r.resolved ? { indexer: target, id: r.id } : null))
 			.catch(() => null);
-		tvResolutionCache.set(tmdbId, pending);
+		idResolutionCache.set(cacheKey, pending);
 	}
 	return pending;
 }
 
+const resolvedIdState = $state<Record<string, ResolvedId | null | "pending">>({});
+
 /**
- * Reactive read of a suggested item's library status. First call for a given
- * (indexer, externalId) kicks off the batched fetch (or, for a TMDB-sourced
- * TV show, a resolve-to-TVDB step first) and returns `{status: "loading"}`;
- * once the result lands, the returned entry updates in place (the backing
- * store is `$state`, so callers reading this inside a component re-render).
+ * Reactive read of a source id's resolved (tmdb-movie or tvdb-show) identity
+ * in Riven's own library id-space. Used both to build a working details-page
+ * link for a source whose raw id Riven never uses directly (Anilist), and by
+ * `getLibraryStatus` internally for the same sources.
+ *
+ * Returns `"pending"` while the resolution is in flight, `null` if the id
+ * could not be resolved at all (e.g. an anime with no TMDB/TVDB match yet).
+ */
+export function getResolvedLibraryId(
+	source: ResolvableSource,
+	externalId: string,
+	mediaType: MediaKind
+): ResolvedId | null | "pending" {
+	const key = resolutionCacheKey(source, externalId, mediaType);
+	const existing = resolvedIdState[key];
+	if (existing !== undefined) return existing;
+
+	resolvedIdState[key] = "pending";
+	resolveToLibraryId(source, externalId, mediaType).then((result) => {
+		resolvedIdState[key] = result;
+	});
+	return resolvedIdState[key];
+}
+
+/**
+ * Reactive read of a suggested item's library status. Sources whose ids
+ * aren't already in Riven's own id-space (Anilist always; TMDB for a TV
+ * show) resolve first via `getResolvedLibraryId`, then join the same batched
+ * lookup as everything else.
  */
 export function getLibraryStatus(
-	indexer: Indexer,
+	source: ResolvableSource,
 	externalId: string,
 	mediaType: MediaKind
 ): LibraryStatusEntry {
-	if (indexer === "tmdb" && mediaType === "tv") {
-		const resolveKey = `tmdb-tv:${externalId}`;
-		const existing = cache[resolveKey];
-		if (existing) return existing;
+	const resolved = getResolvedLibraryId(source, externalId, mediaType);
+	if (resolved === "pending") return { status: "loading" };
+	if (resolved === null) return { status: "not_found" };
 
-		cache[resolveKey] = { status: "loading" };
-		resolveTmdbTvToTvdb(externalId)
-			.then((tvdbId) => {
-				if (!tvdbId) {
-					cache[resolveKey] = { status: "not_found" };
-					return undefined;
-				}
-				return queueFetch("tvdb", tvdbId).then((entry) => {
-					cache[resolveKey] = entry;
-					cache[keyFor("tvdb", tvdbId)] = entry;
-				});
-			})
-			.catch(() => {
-				cache[resolveKey] = { status: "not_found" };
-			});
-		return cache[resolveKey];
-	}
-
-	const effectiveIndexer: Indexer = indexer === "tvdb" ? "tvdb" : "tmdb";
-	const key = keyFor(effectiveIndexer, externalId);
+	const key = keyFor(resolved.indexer, resolved.id);
 	const existing = cache[key];
 	if (existing) return existing;
 
 	cache[key] = { status: "loading" };
-	queueFetch(effectiveIndexer, externalId).then((entry) => {
+	queueFetch(resolved.indexer, resolved.id).then((entry) => {
 		cache[key] = entry;
 	});
 	return cache[key];
@@ -185,18 +215,10 @@ export function getLibraryStatus(
 /**
  * Optimistically flip a card from "Request" to a status pill right after a
  * successful request mutation, instead of waiting on a fresh network round
- * trip to notice the newly-created item.
+ * trip to notice the newly-created item. Callers pass the *resolved*
+ * (tmdb-movie or tvdb-show) identity — the same one the request mutation
+ * itself was actually sent with.
  */
-export function markLibraryStatusRequested(
-	indexer: Indexer,
-	externalId: string,
-	mediaType: MediaKind,
-	itemId: number
-) {
-	const entry: LibraryStatusEntry = { status: "found", id: itemId, state: "Indexed" };
-	if (indexer === "tmdb" && mediaType === "tv") {
-		cache[`tmdb-tv:${externalId}`] = entry;
-		return;
-	}
-	cache[keyFor(indexer === "tvdb" ? "tvdb" : "tmdb", externalId)] = entry;
+export function markLibraryStatusRequested(indexer: Indexer, externalId: string, itemId: number) {
+	cache[keyFor(indexer, externalId)] = { status: "found", id: itemId, state: "Indexed" };
 }

--- a/frontend/src/lib/stores/library-status.svelte.ts
+++ b/frontend/src/lib/stores/library-status.svelte.ts
@@ -1,0 +1,202 @@
+/**
+ * Reactive, auto-batching lookup of "is this suggested item already in my
+ * Riven library, and what's its state" — used by the Request/status button
+ * on suggested-content cards (homepage rows, explore grid, trending grids).
+ *
+ * A single carousel row can render 20+ cards at once; querying each one's
+ * status individually would be N+1 network round trips. Instead, every call
+ * to `getLibraryStatus` within the same tick is coalesced into one batched
+ * `mediaItemStatusesByTmdbIds`/`ByTvdbIds` query via a microtask-scheduled
+ * flush, so a whole row resolves in one (or two, tmdb+tvdb) request.
+ */
+
+import { gqlClient } from "$lib/graphql-client";
+import { resolveExternalId } from "$lib/services/backend-metadata";
+
+export type LibraryStatusEntry =
+	| { status: "loading" }
+	| { status: "not_found" }
+	| { status: "found"; id: number; state: string };
+
+type Indexer = "tmdb" | "tvdb";
+type MediaKind = "movie" | "tv";
+
+const cache = $state<Record<string, LibraryStatusEntry>>({});
+
+function keyFor(indexer: Indexer, externalId: string): string {
+	return `${indexer}:${externalId}`;
+}
+
+type MediaItemStatusRow = {
+	id: number;
+	state: string;
+	tmdbId: string | null;
+	tvdbId: string | null;
+};
+
+type PendingBatch = {
+	ids: Set<string>;
+	resolvers: Map<string, ((entry: LibraryStatusEntry) => void)[]>;
+};
+
+function emptyBatch(): PendingBatch {
+	return { ids: new Set(), resolvers: new Map() };
+}
+
+const batches: Record<Indexer, PendingBatch> = {
+	tmdb: emptyBatch(),
+	tvdb: emptyBatch()
+};
+
+let flushScheduled = false;
+
+function scheduleFlush() {
+	if (flushScheduled) return;
+	flushScheduled = true;
+	queueMicrotask(runFlush);
+}
+
+async function runFlush() {
+	flushScheduled = false;
+	await Promise.all([flushBatch("tmdb"), flushBatch("tvdb")]);
+}
+
+const BATCH_QUERIES: Record<Indexer, string> = {
+	tmdb: `query($ids: [String!]!) {
+        mediaItemStatusesByTmdbIds(tmdbIds: $ids) { id state tmdbId tvdbId }
+    }`,
+	tvdb: `query($ids: [String!]!) {
+        mediaItemStatusesByTvdbIds(tvdbIds: $ids) { id state tmdbId tvdbId }
+    }`
+};
+
+async function flushBatch(indexer: Indexer) {
+	const batch = batches[indexer];
+	if (batch.ids.size === 0) return;
+
+	const ids = Array.from(batch.ids);
+	const resolvers = batch.resolvers;
+	batches[indexer] = emptyBatch();
+
+	let rows: MediaItemStatusRow[] = [];
+	try {
+		const field = indexer === "tmdb" ? "mediaItemStatusesByTmdbIds" : "mediaItemStatusesByTvdbIds";
+		const result = await gqlClient<Record<string, MediaItemStatusRow[]>>(BATCH_QUERIES[indexer], {
+			ids
+		});
+		rows = result[field] ?? [];
+	} catch {
+		// A failed batch shouldn't leave every card spinning forever — treat
+		// as "unknown" (rendered the same as "not in library") rather than
+		// retrying in a loop.
+		rows = [];
+	}
+
+	const byExternalId = new Map<string, LibraryStatusEntry>();
+	for (const row of rows) {
+		const extId = indexer === "tmdb" ? row.tmdbId : row.tvdbId;
+		if (extId) byExternalId.set(extId, { status: "found", id: row.id, state: row.state });
+	}
+
+	for (const id of ids) {
+		const entry = byExternalId.get(id) ?? { status: "not_found" };
+		cache[keyFor(indexer, id)] = entry;
+		for (const resolve of resolvers.get(id) ?? []) resolve(entry);
+	}
+}
+
+function queueFetch(indexer: Indexer, id: string): Promise<LibraryStatusEntry> {
+	const batch = batches[indexer];
+	batch.ids.add(id);
+	const promise = new Promise<LibraryStatusEntry>((resolve) => {
+		const list = batch.resolvers.get(id) ?? [];
+		list.push(resolve);
+		batch.resolvers.set(id, list);
+	});
+	scheduleFlush();
+	return promise;
+}
+
+// TMDB has no independent notion of a TV show's *Riven* identity — every show
+// in this app is keyed by TVDB id (see the tmdb->tvdb resolution the details
+// page's +page.ts does before it will even fetch show metadata). A TMDB-
+// sourced TV card therefore has to resolve to a TVDB id first before its
+// library status can be looked up at all. Deduped per id so the same show
+// appearing in multiple rows doesn't re-resolve repeatedly.
+const tvResolutionCache = new Map<string, Promise<string | null>>();
+function resolveTmdbTvToTvdb(tmdbId: string): Promise<string | null> {
+	let pending = tvResolutionCache.get(tmdbId);
+	if (!pending) {
+		pending = resolveExternalId({ from: "tmdb", to: "tvdb", id: tmdbId, mediaType: "tv" })
+			.then((r) => (r.resolved ? r.id : null))
+			.catch(() => null);
+		tvResolutionCache.set(tmdbId, pending);
+	}
+	return pending;
+}
+
+/**
+ * Reactive read of a suggested item's library status. First call for a given
+ * (indexer, externalId) kicks off the batched fetch (or, for a TMDB-sourced
+ * TV show, a resolve-to-TVDB step first) and returns `{status: "loading"}`;
+ * once the result lands, the returned entry updates in place (the backing
+ * store is `$state`, so callers reading this inside a component re-render).
+ */
+export function getLibraryStatus(
+	indexer: Indexer,
+	externalId: string,
+	mediaType: MediaKind
+): LibraryStatusEntry {
+	if (indexer === "tmdb" && mediaType === "tv") {
+		const resolveKey = `tmdb-tv:${externalId}`;
+		const existing = cache[resolveKey];
+		if (existing) return existing;
+
+		cache[resolveKey] = { status: "loading" };
+		resolveTmdbTvToTvdb(externalId)
+			.then((tvdbId) => {
+				if (!tvdbId) {
+					cache[resolveKey] = { status: "not_found" };
+					return undefined;
+				}
+				return queueFetch("tvdb", tvdbId).then((entry) => {
+					cache[resolveKey] = entry;
+					cache[keyFor("tvdb", tvdbId)] = entry;
+				});
+			})
+			.catch(() => {
+				cache[resolveKey] = { status: "not_found" };
+			});
+		return cache[resolveKey];
+	}
+
+	const effectiveIndexer: Indexer = indexer === "tvdb" ? "tvdb" : "tmdb";
+	const key = keyFor(effectiveIndexer, externalId);
+	const existing = cache[key];
+	if (existing) return existing;
+
+	cache[key] = { status: "loading" };
+	queueFetch(effectiveIndexer, externalId).then((entry) => {
+		cache[key] = entry;
+	});
+	return cache[key];
+}
+
+/**
+ * Optimistically flip a card from "Request" to a status pill right after a
+ * successful request mutation, instead of waiting on a fresh network round
+ * trip to notice the newly-created item.
+ */
+export function markLibraryStatusRequested(
+	indexer: Indexer,
+	externalId: string,
+	mediaType: MediaKind,
+	itemId: number
+) {
+	const entry: LibraryStatusEntry = { status: "found", id: itemId, state: "Indexed" };
+	if (indexer === "tmdb" && mediaType === "tv") {
+		cache[`tmdb-tv:${externalId}`] = entry;
+		return;
+	}
+	cache[keyFor(indexer === "tvdb" ? "tvdb" : "tmdb", externalId)] = entry;
+}

--- a/frontend/src/lib/stores/library-status.svelte.ts
+++ b/frontend/src/lib/stores/library-status.svelte.ts
@@ -35,9 +35,17 @@ type MediaItemStatusRow = {
 	tvdbId: string | null;
 };
 
+type ResolvedFetch = {
+	entry: LibraryStatusEntry;
+	// False when the batch request itself failed (network error, GraphQL
+	// error): the caller still needs an answer to stop spinning, but must
+	// not treat it as a confirmed result to persist.
+	cacheable: boolean;
+};
+
 type PendingBatch = {
 	ids: Set<string>;
-	resolvers: Map<string, ((entry: LibraryStatusEntry) => void)[]>;
+	resolvers: Map<string, ((result: ResolvedFetch) => void)[]>;
 };
 
 function emptyBatch(): PendingBatch {
@@ -80,6 +88,7 @@ async function flushBatch(indexer: Indexer) {
 	batches[indexer] = emptyBatch();
 
 	let rows: MediaItemStatusRow[] = [];
+	let failed = false;
 	try {
 		const field = indexer === "tmdb" ? "mediaItemStatusesByTmdbIds" : "mediaItemStatusesByTvdbIds";
 		const result = await gqlClient<Record<string, MediaItemStatusRow[]>>(BATCH_QUERIES[indexer], {
@@ -87,10 +96,13 @@ async function flushBatch(indexer: Indexer) {
 		});
 		rows = result[field] ?? [];
 	} catch {
-		// A failed batch shouldn't leave every card spinning forever — treat
-		// as "unknown" (rendered the same as "not in library") rather than
-		// retrying in a loop.
-		rows = [];
+		// A failed batch shouldn't leave every card spinning forever, so
+		// resolvers still get an answer — but that answer must not be
+		// cached as "not_found": caching a transient network failure as
+		// "confirmed absent from the library" would permanently show
+		// "Request" for an item that's actually already there, for the
+		// rest of the session, until a full reload clears the cache.
+		failed = true;
 	}
 
 	const byExternalId = new Map<string, LibraryStatusEntry>();
@@ -101,15 +113,19 @@ async function flushBatch(indexer: Indexer) {
 
 	for (const id of ids) {
 		const entry = byExternalId.get(id) ?? { status: "not_found" };
-		cache[keyFor(indexer, id)] = entry;
-		for (const resolve of resolvers.get(id) ?? []) resolve(entry);
+		if (failed) {
+			delete cache[keyFor(indexer, id)];
+		} else {
+			cache[keyFor(indexer, id)] = entry;
+		}
+		for (const resolve of resolvers.get(id) ?? []) resolve({ entry, cacheable: !failed });
 	}
 }
 
-function queueFetch(indexer: Indexer, id: string): Promise<LibraryStatusEntry> {
+function queueFetch(indexer: Indexer, id: string): Promise<ResolvedFetch> {
 	const batch = batches[indexer];
 	batch.ids.add(id);
-	const promise = new Promise<LibraryStatusEntry>((resolve) => {
+	const promise = new Promise<ResolvedFetch>((resolve) => {
 		const list = batch.resolvers.get(id) ?? [];
 		list.push(resolve);
 		batch.resolvers.set(id, list);
@@ -133,7 +149,9 @@ export type ResolvedId = { indexer: Indexer; id: string };
  * Cached and deduped per (source, mediaType, id) — the same title showing up
  * in multiple rows only ever resolves once.
  */
-const idResolutionCache = new Map<string, Promise<ResolvedId | null>>();
+type ResolvedFetchId = { result: ResolvedId | null; cacheable: boolean };
+
+const idResolutionCache = new Map<string, Promise<ResolvedFetchId>>();
 
 function resolutionCacheKey(source: ResolvableSource, externalId: string, mediaType: MediaKind): string {
 	return `${source}:${mediaType}:${externalId}`;
@@ -143,19 +161,31 @@ function resolveToLibraryId(
 	source: ResolvableSource,
 	externalId: string,
 	mediaType: MediaKind
-): Promise<ResolvedId | null> {
+): Promise<ResolvedFetchId> {
 	const target: Indexer = mediaType === "tv" ? "tvdb" : "tmdb";
 	if (source === target) {
-		return Promise.resolve({ indexer: target, id: externalId });
+		return Promise.resolve({ result: { indexer: target, id: externalId }, cacheable: true });
 	}
 	const cacheKey = resolutionCacheKey(source, externalId, mediaType);
-	let pending = idResolutionCache.get(cacheKey);
-	if (!pending) {
-		pending = resolveExternalId({ from: source, to: target, id: externalId, mediaType })
-			.then((r) => (r.resolved ? { indexer: target, id: r.id } : null))
-			.catch(() => null);
-		idResolutionCache.set(cacheKey, pending);
-	}
+	const cached = idResolutionCache.get(cacheKey);
+	if (cached) return cached;
+
+	const pending = resolveExternalId({ from: source, to: target, id: externalId, mediaType })
+		.then((r) => ({
+			result: r.resolved ? { indexer: target, id: r.id } : null,
+			cacheable: true
+		}))
+		.catch(() => {
+			// A request failure isn't a real "no match" answer — don't leave
+			// it memoized, or a transient network error would permanently
+			// look identical to "this id genuinely doesn't resolve" for the
+			// rest of the session.
+			idResolutionCache.delete(cacheKey);
+			return { result: null, cacheable: false };
+		});
+	// Set eagerly (before the request settles) so concurrent callers for the
+	// same id within the request window dedupe onto this one promise.
+	idResolutionCache.set(cacheKey, pending);
 	return pending;
 }
 
@@ -180,8 +210,12 @@ export function getResolvedLibraryId(
 	if (existing !== undefined) return existing;
 
 	resolvedIdState[key] = "pending";
-	resolveToLibraryId(source, externalId, mediaType).then((result) => {
-		resolvedIdState[key] = result;
+	resolveToLibraryId(source, externalId, mediaType).then(({ result, cacheable }) => {
+		if (cacheable) {
+			resolvedIdState[key] = result;
+		} else {
+			delete resolvedIdState[key];
+		}
 	});
 	return resolvedIdState[key];
 }
@@ -206,8 +240,12 @@ export function getLibraryStatus(
 	if (existing) return existing;
 
 	cache[key] = { status: "loading" };
-	queueFetch(resolved.indexer, resolved.id).then((entry) => {
-		cache[key] = entry;
+	queueFetch(resolved.indexer, resolved.id).then(({ entry, cacheable }) => {
+		if (cacheable) {
+			cache[key] = entry;
+		} else {
+			delete cache[key];
+		}
 	});
 	return cache[key];
 }

--- a/frontend/src/lib/stores/notifications.svelte.ts
+++ b/frontend/src/lib/stores/notifications.svelte.ts
@@ -14,6 +14,14 @@ export type Notification = {
 	year?: number;
 	duration?: number;
 	imdb_id?: string;
+	// TMDB's own id namespace has no separate "episode" root — an
+	// episode/season row's tmdbId is the id of the show it belongs to, so
+	// this is always safe to use for a `/details/media/{tmdbId}/{mediaType}`
+	// link regardless of `type`. Shows/seasons/episodes are frequently
+	// TVDB-only (no TMDB match at all) — tvdbId is the fallback for those,
+	// linked via `?indexer=tvdb`.
+	tmdbId?: string;
+	tvdbId?: string;
 	read: boolean;
 	count: number;
 	dedupeKey: string | null;
@@ -92,6 +100,8 @@ function rivenNotificationToNotification(
 					? Math.round(event.durationSeconds / 60)
 					: undefined,
 				imdb_id: event.imdbId ?? undefined,
+				tmdbId: event.tmdbId ?? undefined,
+				tvdbId: event.tvdbId ?? undefined,
 				dedupeKey,
 			};
 
@@ -102,6 +112,8 @@ function rivenNotificationToNotification(
 				severity: "success",
 				timestamp: ts,
 				type: mapItemType(event.itemType),
+				tmdbId: event.tmdbId ?? undefined,
+				tvdbId: event.tvdbId ?? undefined,
 				dedupeKey,
 			};
 
@@ -112,6 +124,8 @@ function rivenNotificationToNotification(
 				severity: "success",
 				timestamp: ts,
 				type: mapItemType(event.itemType),
+				tmdbId: event.tmdbId ?? undefined,
+				tvdbId: event.tvdbId ?? undefined,
 				dedupeKey,
 			};
 
@@ -131,7 +145,9 @@ function rivenNotificationToNotification(
 				message: event.error ?? "An error occurred",
 				severity: "error",
 				timestamp: ts,
-				type: "movie",
+				type: mapItemType(event.itemType),
+				tmdbId: event.tmdbId ?? undefined,
+				tvdbId: event.tvdbId ?? undefined,
 				dedupeKey: null,
 			};
 
@@ -141,7 +157,9 @@ function rivenNotificationToNotification(
 				message: event.error ?? "An error occurred",
 				severity: "error",
 				timestamp: ts,
-				type: "movie",
+				type: mapItemType(event.itemType),
+				tmdbId: event.tmdbId ?? undefined,
+				tvdbId: event.tvdbId ?? undefined,
 				dedupeKey: null,
 			};
 
@@ -152,6 +170,8 @@ function rivenNotificationToNotification(
 				severity: "warning",
 				timestamp: ts,
 				type: mapItemType(event.itemType),
+				tmdbId: event.tmdbId ?? undefined,
+				tvdbId: event.tvdbId ?? undefined,
 				dedupeKey,
 			};
 

--- a/frontend/src/routes/(protected)/details/media/[id]/[mediaType]/+page.svelte
+++ b/frontend/src/routes/(protected)/details/media/[id]/[mediaType]/+page.svelte
@@ -239,6 +239,13 @@
                 { id }
             );
             selectedMovieVersionIdx = 0;
+            // Blacklisting usually moves the item off Completed, at which
+            // point completedDetailsSignature() returns "" and
+            // hydrateCompletedDetails never re-runs — so without resetting
+            // these, getMovieEntries() keeps reading the stale hydratedRiven
+            // snapshot that still has the just-deleted entry in it.
+            hydratedRiven = undefined;
+            lastHydratedCompletedKey = "";
             toast.success(`"${label}" blacklisted — searching for a replacement`);
             await hydrateInitialState();
         } catch {

--- a/frontend/src/routes/(protected)/details/media/[id]/[mediaType]/+page.svelte
+++ b/frontend/src/routes/(protected)/details/media/[id]/[mediaType]/+page.svelte
@@ -226,6 +226,26 @@
         }
     }
 
+    async function blacklistFilesystemEntry(id: number, label: string) {
+        if (
+            !confirm(
+                `Blacklist "${label}"? This permanently excludes this exact release so it is never selected again, removes the tracked file entry, and searches for a replacement.`
+            )
+        )
+            return;
+        try {
+            await gqlClient<{ blacklistFilesystemEntry: boolean }>(
+                `mutation BlacklistFilesystemEntry($id: Int!) { blacklistFilesystemEntry(id: $id) }`,
+                { id }
+            );
+            selectedMovieVersionIdx = 0;
+            toast.success(`"${label}" blacklisted — searching for a replacement`);
+            await hydrateInitialState();
+        } catch {
+            toast.error("Failed to blacklist version");
+        }
+    }
+
     async function handleRequestSuccess() {
         if (rivenPending) {
             return;
@@ -1145,7 +1165,11 @@
                             stateByEpisodeNumber={selectedRivenEpisodesByNumber}
                             detailsByEpisodeNumber={selectedHydratedEpisodesByNumber}
                             {formatSize}
-                            onDeleteFilesystemEntry={deleteFilesystemEntry} />
+                            onDeleteFilesystemEntry={deleteFilesystemEntry}
+                            onBlacklistFilesystemEntry={blacklistFilesystemEntry}
+                            onItemActionSuccess={hydrateInitialState}
+                            showItemId={rivenId ? rivenId.toString() : null}
+                            showExternalId={data.mediaDetails?.details?.id?.toString() ?? ""} />
                     </section>
                 {/if}
 
@@ -1586,6 +1610,25 @@
                                                     );
                                                 }}>
                                                 Remove this version
+                                            </button>
+                                        {/if}
+
+                                        <!-- Blacklist wrong/bad version -->
+                                        {#if fs?.id}
+                                            <button
+                                                type="button"
+                                                class="text-destructive/70 hover:text-destructive border-destructive/30 hover:border-destructive/70 mt-2 rounded-md border px-3 py-1.5 text-xs transition-colors"
+                                                onclick={() => {
+                                                    if (fs.id == null) return;
+                                                    blacklistFilesystemEntry(
+                                                        fs.id,
+                                                        getFilesystemEntryLabel(
+                                                            fs,
+                                                            `Version ${selectedMovieVersionIdx + 1}`
+                                                        )
+                                                    );
+                                                }}>
+                                                Blacklist this release
                                             </button>
                                         {/if}
                                     </div>

--- a/frontend/src/routes/(protected)/details/media/[id]/[mediaType]/live-episodes.svelte
+++ b/frontend/src/routes/(protected)/details/media/[id]/[mediaType]/live-episodes.svelte
@@ -4,21 +4,33 @@
     import * as Sheet from "$lib/components/ui/sheet/index.js";
     import LandscapeCard from "$lib/components/media/landscape-card.svelte";
     import StatusBadge from "$lib/components/media/status-badge.svelte";
+    import ItemAction from "$lib/components/media/riven/item-action.svelte";
+    import ItemManualScrape from "$lib/components/media/riven/item-manual-scrape.svelte";
     import { IsMobile } from "$lib/hooks/is-mobile.svelte";
     import type { EpisodeSummary } from "$lib/gql/schema";
     import type { MediaMetadata, Maybe } from "$lib/gql/schema";
     import type { GqlEpisodeFull, GqlFilesystemEntry } from "$lib/services/riven-media";
     import { untrack } from "svelte";
+    import RotateCcw from "@lucide/svelte/icons/rotate-ccw";
+    import RefreshCw from "@lucide/svelte/icons/refresh-cw";
+    import Search from "@lucide/svelte/icons/search";
 
     interface Props {
         episodes: EpisodeSummary[];
         selectedSeason?: string;
         selectedEpisode?: string;
         showTitle?: string | null;
-        stateByEpisodeNumber: Map<number, Pick<GqlEpisodeFull, "episodeNumber" | "state">>;
+        stateByEpisodeNumber: Map<number, Pick<GqlEpisodeFull, "id" | "episodeNumber" | "state">>;
         detailsByEpisodeNumber: Map<number, GqlEpisodeFull>;
         formatSize: (bytes: number) => string;
         onDeleteFilesystemEntry: (id: number, label: string) => void | Promise<void>;
+        onBlacklistFilesystemEntry: (id: number, label: string) => void | Promise<void>;
+        onItemActionSuccess?: () => void | Promise<void>;
+        /** The show's own riven item id / external (TMDB or TVDB) id — manual
+         * scrape resolves the episode target itself, so these are the show's
+         * identity, not any particular episode's. */
+        showItemId?: string | null;
+        showExternalId?: string;
     }
 
     let {
@@ -29,7 +41,11 @@
         stateByEpisodeNumber,
         detailsByEpisodeNumber,
         formatSize,
-        onDeleteFilesystemEntry
+        onDeleteFilesystemEntry,
+        onBlacklistFilesystemEntry,
+        onItemActionSuccess,
+        showItemId = null,
+        showExternalId = ""
     }: Props = $props();
 
     const isMobile = new IsMobile();
@@ -137,6 +153,42 @@
         {/if}
         {#if rivenEpisode}
             <StatusBadge class="text-xs" state={rivenEpisode.state} />
+        {/if}
+        {#if episode.number != null && showExternalId}
+            <ItemManualScrape
+                size="sm"
+                variant="secondary"
+                class="border-border text-muted-foreground hover:bg-muted hover:text-foreground border bg-transparent px-2"
+                title={episode.name}
+                itemId={showItemId}
+                externalId={showExternalId}
+                mediaType="tv"
+                seasonNumber={episode.seasonNumber}
+                episodeNumber={episode.number}>
+                <Search class="h-3.5 w-3.5" />
+            </ItemManualScrape>
+        {/if}
+        {#if rivenEpisode?.id != null}
+            <ItemAction
+                kind="reset"
+                size="sm"
+                variant="secondary"
+                class="border-border text-muted-foreground hover:bg-muted hover:text-foreground border bg-transparent px-2"
+                title={episode.name}
+                ids={[rivenEpisode.id.toString()]}
+                onSuccess={onItemActionSuccess}>
+                <RotateCcw class="h-3.5 w-3.5" />
+            </ItemAction>
+            <ItemAction
+                kind="retry"
+                size="sm"
+                variant="secondary"
+                class="border-border text-muted-foreground hover:bg-muted hover:text-foreground border bg-transparent px-2"
+                title={episode.name}
+                ids={[rivenEpisode.id.toString()]}
+                onSuccess={onItemActionSuccess}>
+                <RefreshCw class="h-3.5 w-3.5" />
+            </ItemAction>
         {/if}
     </div>
 {/snippet}
@@ -379,6 +431,16 @@
                     }}>
                     Remove this version
                 </button>
+                <button
+                    type="button"
+                    class="text-destructive/70 hover:text-destructive border-destructive/30 hover:border-destructive/70 mt-2 rounded-md border px-3 py-1.5 text-xs transition-colors"
+                    onclick={() => {
+                        if (fs.id == null) return;
+                        if (episodeNumber != null) selectedVersionIdxByEpisode[episodeNumber] = 0;
+                        onBlacklistFilesystemEntry(fs.id, getFsLabel(fs, episodeNumber));
+                    }}>
+                    Blacklist this release
+                </button>
             {/if}
         </div>
     </div>
@@ -436,9 +498,9 @@
                 <Drawer.Trigger class="group w-full text-left">
                     {@render episodeTrigger(episode, rivenEpisode)}
                 </Drawer.Trigger>
-                <Drawer.Content class="max-h-[85vh] outline-none">
-                    <div class="mx-auto w-full max-w-4xl px-4 pb-6 md:px-6">
-                        <Drawer.Header class="px-0 pt-2 pb-0 text-left">
+                <Drawer.Content class="max-h-[85vh] overflow-hidden outline-none">
+                    <div class="mx-auto flex w-full min-h-0 max-w-4xl flex-1 flex-col px-4 pb-6 md:px-6">
+                        <Drawer.Header class="shrink-0 px-0 pt-2 pb-0 text-left">
                             <Drawer.Title class="font-heading text-2xl font-bold tracking-tight">
                                 S{episode.seasonNumber}E{episode.number} - {episode.name}
                             </Drawer.Title>

--- a/schema.graphql
+++ b/schema.graphql
@@ -175,6 +175,7 @@ type DiscoveredStream {
 	isCached: Boolean!
 	itemType: MediaItemType!
 	seasonNumber: Int
+	episodeNumber: Int
 }
 
 input DownloadMediaItemMutationInput {
@@ -1056,6 +1057,14 @@ type MutationRoot {
 	`filesystem_entries` recomputes the owning item's state automatically.
 	"""
 	deleteFilesystemEntry(id: Int!): Boolean!
+	"""
+	Reject a downloaded file: permanently blacklist the release behind it
+	and remove its tracked entry, then clear the owning item's retry
+	backoff so a replacement is searched for on the next scheduler pass.
+	Use when a download turned out wrong — mismatched title, bad quality,
+	wrong language, etc.
+	"""
+	blacklistFilesystemEntry(id: Int!): Boolean!
 	resetLibrary: Int!
 	"""
 	Reset items to Indexed state and clear failed_attempts.
@@ -1096,7 +1105,7 @@ type MutationRoot {
 	"""
 	Discover stream candidates without creating or mutating media items.
 	"""
-	discoverStreams(itemType: MediaItemType!, title: String!, imdbId: String, tmdbId: String, tvdbId: String, seasons: [Int!], cachedOnly: Boolean): [DiscoveredStream!]!
+	discoverStreams(itemType: MediaItemType!, title: String!, imdbId: String, tmdbId: String, tvdbId: String, seasons: [Int!], episodeNumber: Int, cachedOnly: Boolean): [DiscoveredStream!]!
 	"""
 	Create or prepare the real target item only after the user picks a specific stream.
 	
@@ -1105,7 +1114,7 @@ type MutationRoot {
 	to that season; a multi-season pack links to the **show** so the download
 	flow can fill every season it contains.
 	"""
-	downloadDiscoveredStream(itemType: MediaItemType!, title: String!, imdbId: String, tmdbId: String, tvdbId: String, seasonNumber: Int, seasons: [Int!], infoHash: String!, magnet: String!, parsedData: JSON, rank: Int): String!
+	downloadDiscoveredStream(itemType: MediaItemType!, title: String!, imdbId: String, tmdbId: String, tvdbId: String, seasonNumber: Int, episodeNumber: Int, seasons: [Int!], infoHash: String!, magnet: String!, parsedData: JSON, rank: Int): String!
 	"""
 	Re-acquire a usenet title whose release is broken (missing data) or was
 	never ingested. The item is "completed" only because it still has a

--- a/schema.graphql
+++ b/schema.graphql
@@ -829,6 +829,22 @@ type MediaItemStateTree {
 	seasons: [SeasonState!]!
 }
 
+"""
+Minimal per-item library status: just enough to render a "Request" vs
+"current state" button on a suggested-content card without paying for a
+full season/episode tree (unlike `MediaItemStateTree`, which
+`apply_indexed_media_item`-style callers need for shows but a poster card
+never does). Returned in bulk by the `mediaItemStatusesBy*Ids` batch
+queries so a whole carousel row resolves in one round trip instead of one
+query per card.
+"""
+type MediaItemStatus {
+	id: Int!
+	state: MediaItemState!
+	tmdbId: String
+	tvdbId: String
+}
+
 enum MediaItemType {
 	MOVIE
 	SHOW
@@ -1278,6 +1294,18 @@ type QueryRoot {
 	mediaItemFull(id: Int!): MediaItemFull
 	mediaItemStateByTmdb(tmdbId: String!): MediaItemStateTree
 	mediaItemStateByTvdb(tvdbId: String!): MediaItemStateTree
+	"""
+	Bulk library-status lookup for a set of TMDB ids: one round trip for
+	a whole suggested-content carousel row instead of one query per card.
+	Ids not found in the library are simply absent from the result — the
+	caller treats "no matching entry" as "not yet requested".
+	"""
+	mediaItemStatusesByTmdbIds(tmdbIds: [String!]!): [MediaItemStatus!]!
+	"""
+	Bulk library-status lookup for a set of TVDB ids — the show-side
+	counterpart to `mediaItemStatusesByTmdbIds`, same batching rationale.
+	"""
+	mediaItemStatusesByTvdbIds(tvdbIds: [String!]!): [MediaItemStatus!]!
 	movies: [MediaItem!]!
 	shows: [MediaItem!]!
 	seasons(showId: Int!, includeSpecials: Boolean): [MediaItem!]!


### PR DESCRIPTION
## Summary

- Season/show downloads no longer stop after the first successful stream. A candidate that fills some but not all of a season's episodes is now tracked as "progressed" rather than terminal, so the same download pass keeps trying further candidates instead of waiting a full retry cycle (which, for an item with escalating backoff, can be a day) per episode. Episodes already satisfied by an earlier stream are skipped during persist, so a stream touching only already-done episodes correctly counts as no progress instead of starving the rest of the season. A stream no configured provider could actually download is now permanently blacklisted instead of silently retried forever.
- A scrape that parses zero *new* streams now attempts a download from the best existing unblacklisted candidate before recording a failure — some titles never produce a "new" stream again once providers have surfaced everything they have, which previously left a perfectly good already-known candidate untouched forever.
- In-app notifications carry `tmdbId`/`tvdbId` end to end (resolved to the parent show's id for Episode/Season events, since an episode's own tvdb id is a different resource and seasons often have none) and are now clickable, jumping to the relevant details page.
- Manual scrape can target a single episode instead of only whole seasons, and each episode gets its own Reset/Retry quick actions in the details drawer.
- New "Blacklist this release" action on movies and episodes: permanently blacklists the exact release (so it's never re-selected), removes the tracked file entry, clears the item's retry backoff, and lets the next scheduler pass search for a replacement. For downloads that turn out to be the wrong title, wrong quality, wrong language, etc.
- Fixed the mobile episode drawer not scrolling to its full content — a missing `min-h-0` down the flex ancestor chain kept the drawer body's existing `overflow-y-auto` from ever engaging.
- Fixed a show that lost its initial `IndexJob` (e.g. dropped off the shared event bus before it ran) getting stuck at the bare `Indexed` placeholder forever — no poster, no metadata, no seasons. The periodic retry sweep correctly picked these up every cycle, but for a `Show` it only re-queued *existing* season rows; a show with zero seasons at all silently did nothing, retried forever with no error or escalation. The retry path now falls back to a fresh `IndexJob` when a show has no seasons yet.

- Suggested-content cards (homepage rows, explore, and every trending grid — movies, TV, and anime) now show a "Request" button or the item's current library status right on the poster, so requesting no longer requires opening the details page first. The button matches the details page's own Request button styling; the status pill reuses `StatusBadge`'s existing per-state palette. Anilist-sourced cards resolve through the existing anilist→TMDB/TVDB backend lookup to get a real identity in Riven's own id-space (Anilist ids aren't usable directly) — this also fixes those cards' details-page link, which 404'd unconditionally before this change (no `/details/anilist/...` route has ever existed). A whole carousel row's library status resolves via a batched `mediaItemStatusesByTmdbIds`/`ByTvdbIds` lookup, one or two GraphQL round trips rather than one per card.

## Test plan

- [x] `cargo fmt --all --check` clean for every file this change touches (a pre-existing failure in `crates/riven-queue/src/dispatch.rs` is unrelated and untouched by this change)
- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes, 0 failures
- [x] `make schema-check` — `schema.graphql` and `frontend/src/lib/gql/schema.ts` regenerate byte-identical to what's committed
- [x] `pnpm run lint` / `pnpm run check` pass, 0 errors/warnings
- [x] Verified live against the real library: a season pack now fills every satisfiable episode in one download pass instead of one per retry cycle; per-episode manual scrape returns episode-scoped results only; the blacklist mutation removes the file, blacklists the release, and clears backoff; the mobile drawer scrolls to its full content; the notification bell links to the correct item's details page; a show that had been stuck at `Indexed` with no metadata for three weeks was fully indexed (poster, year, network, genres) on the first sweep after deploying the fix.
- [x] Verified live: the new `mediaItemStatusesByTmdbIds`/`ByTvdbIds` queries return correct data for real library items and correctly omit unknown ids (rather than erroring), matching what the frontend's batching store expects.
- [x] Verified live: `resolveExternalId(from: anilist, to: tvdb, id: 21, mediaType: tv)` correctly resolves Anilist's "ONE PIECE" to TVDB id 81797 (the real TVDB series id), and the button/status pill render correctly across the homepage, explore, and all three trending grids (movie/tv/anime) against the real library.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added episode-specific stream discovery, manual scraping, and downloads.
  * Added library status checks, request controls, and bulk TMDB/TVDB lookups.
  * Added “Blacklist this release” actions to remove unwanted files and trigger replacement searches.
  * Notifications now link directly to related media details using TMDB or TVDB identifiers.

* **Bug Fixes**
  * Improved partial season and show downloads so remaining episodes continue processing.
  * Avoided re-downloading episodes already covered by the selected profile.
  * Improved retry handling and validation for oversized bulk status requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->