### PR TITLE
fix: scrape gate skipped re-scraping based on stream existence, not fit

### DIFF
--- a/crates/riven-queue/src/application/download.rs
+++ b/crates/riven-queue/src/application/download.rs
@@ -345,6 +345,49 @@ pub async fn run(id: i64, job: &DownloadJob, queue: &JobQueue) {
     }
 }
 
+/// Whether the item currently has a stream that would actually pass
+/// title/year/quality-profile filtering for at least one active profile,
+/// i.e. a real download candidate exists right now — as opposed to merely
+/// "a non-blacklisted stream exists", which is all `get_best_stream` /
+/// `push_download_from_best_stream` check. Quality and title-match
+/// rejections at download time never blacklist the stream (only "no
+/// provider could fetch it" does), so an item whose scraped candidates are
+/// all wrong-title or wrong-quality releases would otherwise keep passing
+/// that cheaper check forever, letting `handle_scrape` skip re-scraping
+/// indefinitely instead of ever looking for a better release. Mirrors the
+/// hierarchy/profile/stream assembly `run` uses for a real download attempt.
+pub async fn has_realistic_download_candidate(item: &MediaItem, queue: &JobQueue) -> bool {
+    let hierarchy = match item.item_type {
+        MediaItemType::Episode | MediaItemType::Season | MediaItemType::Show => {
+            Some(load_download_hierarchy_context(item).await)
+        }
+        _ => None,
+    };
+
+    let ranks = queue.resolution_ranks.read().await.clone();
+    let streams = match repo::get_non_blacklisted_streams(item.id, &ranks).await {
+        Ok(streams) => streams,
+        Err(error) => {
+            tracing::warn!(
+                id = item.id,
+                title = %item.title,
+                %error,
+                "download: could not read this item's streams to check for a realistic candidate; assuming none"
+            );
+            return false;
+        }
+    };
+    if streams.is_empty() {
+        return false;
+    }
+
+    let active_profiles: Vec<(String, RankSettings)> = load_active_profiles().await;
+    let title_ctx = TitleMatchContext::new(item, hierarchy.as_ref());
+    active_profiles.iter().any(|(_, settings)| {
+        !rank_streams_for_profile(&streams, item, settings, &title_ctx).is_empty()
+    })
+}
+
 /// Load the media item; return `None` (without emitting a user-visible event)
 /// when it's gone
 async fn load_item_silently(id: i64, phase: &str) -> Option<MediaItem> {

--- a/crates/riven-queue/src/application/process_media_item.rs
+++ b/crates/riven-queue/src/application/process_media_item.rs
@@ -23,6 +23,7 @@ use riven_core::types::{MediaItemState, MediaItemType};
 use riven_db::entities::MediaItem;
 use riven_db::repo;
 
+use crate::application::download::has_realistic_download_candidate;
 use crate::context::load_show_context;
 use crate::{JobQueue, ProcessMediaItemJob, ProcessStep, ScrapeJob};
 
@@ -87,14 +88,23 @@ async fn handle_scrape(job: &ProcessMediaItemJob, item: &MediaItem, queue: &JobQ
         return;
     }
 
-    if item.state == MediaItemState::Scraped && queue.push_download_from_best_stream(item.id).await
-    {
-        tracing::debug!(
-            id = item.id,
-            title = %item.title,
-            "pipeline: already has untried streams from an earlier scrape, downloading one instead of scraping again"
-        );
-        return;
+    if item.state == MediaItemState::Scraped {
+        if has_realistic_download_candidate(item, queue).await {
+            if queue.push_download_from_best_stream(item.id).await {
+                tracing::debug!(
+                    id = item.id,
+                    title = %item.title,
+                    "pipeline: already has untried streams from an earlier scrape, downloading one instead of scraping again"
+                );
+                return;
+            }
+        } else {
+            tracing::debug!(
+                id = item.id,
+                title = %item.title,
+                "pipeline: has untried streams from an earlier scrape, but none would pass title/quality filtering; scraping again instead of retrying them"
+            );
+        }
     }
 
     match item.item_type {


### PR DESCRIPTION
## Summary
- `handle_scrape`'s "already scraped, try a download instead of re-scraping" shortcut only checked whether *any* non-blacklisted stream existed for the item. Quality-profile and title-mismatch rejections never blacklist a stream (only "no provider could actually fetch it" does), so an item whose scraped candidates were all wrong-title or wrong-quality releases would keep passing that check indefinitely — it would never actually re-scrape for a better release, cycling through the same known-bad candidates on an ever-growing backoff.
- Added `has_realistic_download_candidate()` (`application/download.rs`), which mirrors the real download flow's own candidate assembly (`load_download_hierarchy_context` + `load_active_profiles` + `get_non_blacklisted_streams`) and reuses `rank_streams_for_profile`/`TitleMatchContext` to check whether any current stream would actually pass title/quality filtering for at least one active profile.
- `handle_scrape` now only takes the "skip re-scrape, try existing streams" shortcut when that holds; otherwise it falls through to a genuine fresh scrape, same as if the item had no streams at all.

## Test plan
- `cargo fmt --all --check`, `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p riven-queue -p riven-db` all pass.
- No new unit test added: `process_media_item.rs`/`download.rs` are integration-only orchestration over already-unit-tested logic (`rank_streams_for_profile`'s title/quality filtering is covered by existing tests in `application/download/candidates.rs`), matching this codebase's existing convention of no DB-backed unit tests at this layer.
- Live-verified against a real stuck item: a movie had been sitting in `Scraped` state for days with 58 known-bad candidates (wrong title or wrong quality, none blacklisted), retrying the same download and failing every cycle. After deploying this fix and triggering `scrapeItem`, logs show it correctly hit the new "none would pass filtering, scraping again" path, ran a fresh scrape, found a genuinely new good-quality candidate, downloaded it, and the item reached `state=completed` with `failed_attempts` reset to 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download retries by selecting only streams that match the media title and requested quality.
  * Prevented retries for blacklisted or otherwise unsuitable streams.
  * When no viable untried stream is available, the system now returns to scraping to find better options.
  * Improved handling of empty results and lookup errors so processing can continue safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->