### PR TITLE
feat: add a toggle to reject releases with an unparseable quality tag

### DIFF
--- a/crates/riven-api/src/schema/queries/settings/ranking.rs
+++ b/crates/riven-api/src/schema/queries/settings/ranking.rs
@@ -138,6 +138,16 @@ pub(super) fn build_rank_settings_schema() -> Vec<SettingField> {
                     FieldType::Boolean,
                 ),
                 SettingField::new(
+                    "remove_unknown_quality",
+                    "Remove unknown quality",
+                    FieldType::Boolean,
+                )
+                .with_description(
+                    "Reject releases whose quality/source tag (WEB-DL, BluRay, etc.) \
+                     couldn't be identified from the title — often decoys or camrips \
+                     with unconventional filenames.",
+                ),
+                SettingField::new(
                     "allow_english_in_languages",
                     "Always allow English",
                     FieldType::Boolean,

--- a/crates/riven-rank/src/rank/fetch.rs
+++ b/crates/riven-rank/src/rank/fetch.rs
@@ -318,8 +318,7 @@ mod tests {
         let data = parse("SpiderMan-BrandNewDay-1080p-English.mp4");
         assert!(data.quality.is_none());
 
-        let mut permissive = RankSettings::default();
-        permissive.options.quality.remove_unknown_quality = false;
+        let permissive = RankSettings::default();
         let (ok, failed) = check_fetch(&data, &permissive);
         assert!(ok, "unknown quality should pass when the toggle is off");
         assert!(!failed.contains(&"unknown_quality".to_string()));

--- a/crates/riven-rank/src/rank/fetch.rs
+++ b/crates/riven-rank/src/rank/fetch.rs
@@ -156,6 +156,10 @@ fn fetch_resolution(data: &ParsedData, settings: &RankSettings, failed: &mut Vec
 
 fn fetch_quality(data: &ParsedData, settings: &RankSettings, failed: &mut Vec<String>) -> bool {
     let Some(q) = data.quality.as_deref() else {
+        if settings.options.quality.remove_unknown_quality {
+            failed.push("unknown_quality".into());
+            return false;
+        }
         return true;
     };
     if let Some(cr) = settings.custom_ranks.quality_rank(q)
@@ -297,4 +301,49 @@ pub fn check_fetch(data: &ParsedData, settings: &RankSettings) -> (bool, Vec<Str
         failed.is_empty() || required_matches(data, settings),
         failed,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse::parse;
+
+    /// Reproduces a real incident: "Spider-Man: Brand New Day" (still
+    /// theatrical-only) had a fake/camrip release accepted because its
+    /// filename had no recognizable quality tag (`SpiderMan-BrandNewDay-1080p-
+    /// English.mp4`), and an unparseable quality tag was treated as
+    /// automatically acceptable rather than suspicious.
+    #[test]
+    fn unknown_quality_passes_by_default_but_can_be_rejected() {
+        let data = parse("SpiderMan-BrandNewDay-1080p-English.mp4");
+        assert!(data.quality.is_none());
+
+        let mut permissive = RankSettings::default();
+        permissive.options.quality.remove_unknown_quality = false;
+        let (ok, failed) = check_fetch(&data, &permissive);
+        assert!(ok, "unknown quality should pass when the toggle is off");
+        assert!(!failed.contains(&"unknown_quality".to_string()));
+
+        let mut strict = RankSettings::default();
+        strict.options.quality.remove_unknown_quality = true;
+        let (ok, failed) = check_fetch(&data, &strict);
+        assert!(
+            !ok,
+            "unknown quality should be rejected when the toggle is on"
+        );
+        assert!(failed.contains(&"unknown_quality".to_string()));
+    }
+
+    /// A release with a recognized quality tag is unaffected by the toggle.
+    #[test]
+    fn known_quality_is_unaffected_by_the_unknown_quality_toggle() {
+        let data = parse("The.Odyssey.2026.1080p.WEB-DL.x264-GROUP.mkv");
+        assert_eq!(data.quality.as_deref(), Some("WEB-DL"));
+
+        let mut strict = RankSettings::default();
+        strict.options.quality.remove_unknown_quality = true;
+        let (ok, failed) = check_fetch(&data, &strict);
+        assert!(ok, "a recognized quality tag must not be rejected");
+        assert!(!failed.contains(&"unknown_quality".to_string()));
+    }
 }

--- a/crates/riven-rank/src/settings.rs
+++ b/crates/riven-rank/src/settings.rs
@@ -802,6 +802,8 @@ pub struct RankOptions {
     #[serde(flatten)]
     pub language: LanguageRankOptions,
     #[serde(flatten)]
+    pub quality: QualityRankOptions,
+    #[serde(flatten)]
     pub content: ContentRankOptions,
     /// When `true` (default), fetch checks fail as soon as one check fails.
     /// When `false`, all checks run and every failure is collected — useful for
@@ -817,6 +819,7 @@ impl Default for RankOptions {
             remove_ranks_under: -10000,
             trash: TrashOptions::default(),
             language: LanguageRankOptions::default(),
+            quality: QualityRankOptions::default(),
             content: ContentRankOptions::default(),
             fetch: FetchRankOptions::default(),
         }
@@ -854,6 +857,19 @@ impl Default for LanguageRankOptions {
             allow_english_in_languages: true,
         }
     }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct QualityRankOptions {
+    /// When `true`, reject any release whose quality/source tag (WEB-DL,
+    /// BluRay, etc.) could not be identified from its title, instead of
+    /// treating an unparseable tag as automatically acceptable. Off by
+    /// default to match prior behavior. Decoy uploads and camrips often use
+    /// filenames that don't fit recognized quality conventions, so this is
+    /// a useful extra guard for profiles that would rather miss a release
+    /// than risk one of those.
+    pub remove_unknown_quality: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- `fetch_quality` treated a release with no identifiable quality/source tag (WEB-DL, BluRay, etc.) as automatically acceptable, rather than suspicious. In practice this let bad releases through: two real downloads for still-theatrical movies turned out to be decoy uploads / illegal camrips whose filenames didn't fit any recognized quality convention, so they parsed with `quality: None` and sailed past the check that already rejects known-bad tags like CAM/TeleSync.
- Adds `RankSettings.options.remove_unknown_quality` (default `false`, matching the existing `remove_unknown_languages` precedent — opt-in, no change to existing profile behavior) and wires it into `fetch_quality`: when enabled, a release with no parseable quality tag is rejected (`unknown_quality`) instead of passed through.
- Exposed in the ranking profile settings schema as "Remove unknown quality" so it appears in the existing auto-generated settings UI toggle grid alongside `remove_unknown_languages`, `remove_all_trash`, etc. — no separate frontend work needed since that UI is schema-driven.

## Test plan
- `cargo fmt --all --check`, `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p riven-rank -p riven-api` all pass.
- New unit tests in `riven-rank`: `unknown_quality_passes_by_default_but_can_be_rejected` (reproduces the real incident's release filename) and `known_quality_is_unaffected_by_the_unknown_quality_toggle`.
- Live-verified: enabled the toggle on the `ultra_hd` profile via `updateProfileSettings`, confirmed it round-trips through `rankSettingsSchema`/`customProfiles`, then re-scraped a movie whose only 45 candidates were TeleSync/CAM releases plus one unknown-quality decoy that had previously slipped through and been auto-downloaded — every candidate was correctly rejected this time and the item stayed in `Scraped` state instead of downloading fake content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ranking option to reject releases with unknown quality or source tags.
  * The option is disabled by default and can be enabled in ranking settings.

* **Bug Fixes**
  * Improved release filtering so recognized quality tags continue to follow existing custom ranking rules.
  * Added coverage for both enabled and disabled filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->