### PR TITLE
feat: add Pushbullet support to the notifications plugin

### DIFF
--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -15,17 +15,23 @@ pub(crate) async fn dispatch_webhooks(
                 if let Err(error) =
                     send_discord(&ctx.http, &webhook_id, &webhook_token, payload, detailed).await
                 {
-                    tracing::error!(error = %error, url = url_str, "failed to send discord notification");
+                    // Never log `url_str` here — it's the full discord.com
+                    // webhook URL, which is itself a bearer credential.
+                    tracing::error!(error = %error, service = "discord", "failed to send discord notification");
                 }
             }
             Some(NotificationService::Pushbullet { access_token }) => {
                 if let Err(error) = send_pushbullet(&ctx.http, &access_token, payload).await {
-                    tracing::error!(error = %error, url = url_str, "failed to send pushbullet notification");
+                    // Never log `url_str` here — it embeds the Pushbullet
+                    // access token, which grants full account access.
+                    tracing::error!(error = %error, service = "pushbullet", "failed to send pushbullet notification");
                 }
             }
             Some(NotificationService::Json { url }) => {
                 if let Err(error) = send_json_webhook(&ctx.http, &url, payload).await {
-                    tracing::error!(error = %error, url = url_str, "failed to send json notification");
+                    // Generic webhook URLs commonly embed a secret path
+                    // segment too, so this omits `url_str`/`url` as well.
+                    tracing::error!(error = %error, service = "json", "failed to send json notification");
                 }
             }
             None => {
@@ -63,11 +69,13 @@ pub(crate) fn parse_notification_url(url: &str) -> Option<NotificationService> {
         // `.../DEVICE_ID`, `.../email@address` for targeted delivery — not
         // supported here, so a trailing path segment is dropped rather than
         // treated as part of the token, matching a plain-token-only client.
-        let access_token = match rest.split_once('/') {
-            Some((token, _)) => token.to_string(),
-            None => rest.to_string(),
-        };
-        Some(NotificationService::Pushbullet { access_token })
+        // A missing/empty token (`pbul://`, `pbul:///device-id`) is rejected
+        // outright rather than reaching send_pushbullet with an empty
+        // Access-Token header.
+        let token = rest.split('/').next().filter(|token| !token.is_empty())?;
+        Some(NotificationService::Pushbullet {
+            access_token: token.to_string(),
+        })
     } else if let Some(rest) = url.strip_prefix("json://") {
         Some(NotificationService::Json {
             url: format!("http://{rest}"),

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -35,7 +35,10 @@ pub(crate) async fn dispatch_webhooks(
                 }
             }
             None => {
-                tracing::warn!(url = url_str, "unsupported notification URL scheme");
+                // Never log `url_str` here — a rejected pbul:// URL still
+                // embeds the Pushbullet access token even though parsing
+                // failed.
+                tracing::warn!("unsupported notification URL scheme");
             }
         }
     }

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -18,6 +18,11 @@ pub(crate) async fn dispatch_webhooks(
                     tracing::error!(error = %error, url = url_str, "failed to send discord notification");
                 }
             }
+            Some(NotificationService::Pushbullet { access_token }) => {
+                if let Err(error) = send_pushbullet(&ctx.http, &access_token, payload).await {
+                    tracing::error!(error = %error, url = url_str, "failed to send pushbullet notification");
+                }
+            }
             Some(NotificationService::Json { url }) => {
                 if let Err(error) = send_json_webhook(&ctx.http, &url, payload).await {
                     tracing::error!(error = %error, url = url_str, "failed to send json notification");
@@ -35,6 +40,9 @@ pub(crate) enum NotificationService {
         webhook_id: String,
         webhook_token: String,
     },
+    Pushbullet {
+        access_token: String,
+    },
     Json {
         url: String,
     },
@@ -50,6 +58,16 @@ pub(crate) fn parse_notification_url(url: &str) -> Option<NotificationService> {
             webhook_id: webhook_id.to_string(),
             webhook_token: webhook_token.to_string(),
         })
+    } else if let Some(rest) = url.strip_prefix("pbul://") {
+        // Apprise's pushbullet scheme also allows `pbul://token/#channel`,
+        // `.../DEVICE_ID`, `.../email@address` for targeted delivery — not
+        // supported here, so a trailing path segment is dropped rather than
+        // treated as part of the token, matching a plain-token-only client.
+        let access_token = match rest.split_once('/') {
+            Some((token, _)) => token.to_string(),
+            None => rest.to_string(),
+        };
+        Some(NotificationService::Pushbullet { access_token })
     } else if let Some(rest) = url.strip_prefix("json://") {
         Some(NotificationService::Json {
             url: format!("http://{rest}"),
@@ -227,6 +245,47 @@ fn build_detailed_embed(payload: &NotificationPayload) -> serde_json::Value {
     }
 
     serde_json::json!({ "embeds": [embed] })
+}
+
+async fn send_pushbullet(
+    http: &riven_core::http::HttpClient,
+    access_token: &str,
+    payload: &NotificationPayload,
+) -> anyhow::Result<()> {
+    let title = format!("Downloaded: {}", payload.full_title);
+    let body = build_pushbullet_body(payload);
+    tracing::debug!(
+        title = %payload.full_title,
+        "sending pushbullet notification"
+    );
+    http.send(profiles::PUSHBULLET, |client| {
+        client
+            .post("https://api.pushbullet.com/v2/pushes")
+            .header("Access-Token", access_token)
+            .json(&serde_json::json!({
+                "type": "note",
+                "title": title,
+                "body": body,
+            }))
+    })
+    .await?
+    .error_for_status()?;
+    Ok(())
+}
+
+/// Pushbullet notes are plain text — no embed support — so this condenses
+/// the same core fields `build_simple_embed` shows into one line.
+pub(crate) fn build_pushbullet_body(payload: &NotificationPayload) -> String {
+    let mut parts = vec![format!("{:?}", payload.item_type)];
+    if let Some(year) = payload.year {
+        parts.push(year.to_string());
+    }
+    parts.push(format!("via {}", payload.downloader));
+    if let Some(ref provider) = payload.provider {
+        parts.push(provider.clone());
+    }
+    parts.push(format!("in {}", format_duration(payload.duration_seconds)));
+    parts.join(" • ")
 }
 
 async fn send_json_webhook(

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -67,15 +67,22 @@ pub(crate) fn parse_notification_url(url: &str) -> Option<NotificationService> {
     } else if let Some(rest) = url.strip_prefix("pbul://") {
         // Apprise's pushbullet scheme also allows `pbul://token/#channel`,
         // `.../DEVICE_ID`, `.../email@address` for targeted delivery — not
-        // supported here, so a trailing path segment is dropped rather than
-        // treated as part of the token, matching a plain-token-only client.
+        // supported here. A target segment is rejected outright rather than
+        // silently dropped: send_pushbullet never sends a target parameter,
+        // and Pushbullet broadcasts to every device on the account when no
+        // target is set, so silently dropping a configured target would leak
+        // the notification to devices the user deliberately excluded.
         // A missing/empty token (`pbul://`, `pbul:///device-id`) is rejected
-        // outright rather than reaching send_pushbullet with an empty
+        // outright too, rather than reaching send_pushbullet with an empty
         // Access-Token header.
-        let token = rest.split('/').next().filter(|token| !token.is_empty())?;
-        Some(NotificationService::Pushbullet {
-            access_token: token.to_string(),
-        })
+        let (token, target) = rest.split_once('/').unwrap_or((rest, ""));
+        if token.is_empty() || !target.is_empty() {
+            None
+        } else {
+            Some(NotificationService::Pushbullet {
+                access_token: token.to_string(),
+            })
+        }
     } else if let Some(rest) = url.strip_prefix("json://") {
         Some(NotificationService::Json {
             url: format!("http://{rest}"),

--- a/crates/plugin-notifications/src/lib.rs
+++ b/crates/plugin-notifications/src/lib.rs
@@ -15,7 +15,10 @@ mod metadata;
 
 use dispatch::dispatch_webhooks;
 #[cfg(test)]
-use dispatch::{NotificationService, build_simple_embed, format_duration, parse_notification_url};
+use dispatch::{
+    NotificationService, build_pushbullet_body, build_simple_embed, format_duration,
+    parse_notification_url,
+};
 use metadata::{fetch_tmdb_overview, fetch_tvdb_slug};
 
 const TMDB_BASE_URL: &str = "https://api.themoviedb.org/3";
@@ -60,7 +63,10 @@ impl Plugin for NotificationsPlugin {
                 .required()
                 .with_placeholder("https://discord.com/api/webhooks/...")
                 .with_description(
-                    "Comma-separated webhook URLs. Supports Discord and generic JSON endpoints.",
+                    "Comma-separated webhook URLs, using Apprise-style notation. Supports \
+                     Discord (a full webhook URL or discord://id/token), Pushbullet \
+                     (pbul://<access_token>), and generic JSON endpoints (json://... or \
+                     jsons://...).",
                 ),
             SettingField::new("detailed", "Detailed Embeds", FieldType::Boolean).with_description(
                 "Show rich Discord embeds with overview, rating, and external links.",

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -65,6 +65,12 @@ fn notification_url_parser_supports_pushbullet() {
 }
 
 #[test]
+fn notification_url_parser_rejects_pushbullet_urls_with_no_token() {
+    assert!(parse_notification_url("pbul://").is_none());
+    assert!(parse_notification_url("pbul:///some-device-id").is_none());
+}
+
+#[test]
 fn pushbullet_body_condenses_the_core_fields_into_one_line() {
     let body = build_pushbullet_body(&payload());
     assert_eq!(

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -46,6 +46,34 @@ fn notification_url_parser_supports_discord_and_json_aliases() {
 }
 
 #[test]
+fn notification_url_parser_supports_pushbullet() {
+    match parse_notification_url("pbul://o.abc123token") {
+        Some(NotificationService::Pushbullet { access_token }) => {
+            assert_eq!(access_token, "o.abc123token");
+        }
+        _ => panic!("expected pushbullet URL"),
+    }
+
+    // A device/channel/email target (Apprise's `pbul://token/#channel` etc.)
+    // isn't supported, but must not be folded into the token itself.
+    match parse_notification_url("pbul://o.abc123token/some-device-id") {
+        Some(NotificationService::Pushbullet { access_token }) => {
+            assert_eq!(access_token, "o.abc123token");
+        }
+        _ => panic!("expected pushbullet URL"),
+    }
+}
+
+#[test]
+fn pushbullet_body_condenses_the_core_fields_into_one_line() {
+    let body = build_pushbullet_body(&payload());
+    assert_eq!(
+        body,
+        "Movie • 2024 • via stremthru • realdebrid • in 1h 1m 1s"
+    );
+}
+
+#[test]
 fn duration_formatter_uses_human_units() {
     assert_eq!(format_duration(12.4), "12.4s");
     assert_eq!(format_duration(125.0), "2m 5s");

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -54,9 +54,8 @@ fn notification_url_parser_supports_pushbullet() {
         _ => panic!("expected pushbullet URL"),
     }
 
-    // A device/channel/email target (Apprise's `pbul://token/#channel` etc.)
-    // isn't supported, but must not be folded into the token itself.
-    match parse_notification_url("pbul://o.abc123token/some-device-id") {
+    // A trailing slash with nothing after it is still a plain-token URL.
+    match parse_notification_url("pbul://o.abc123token/") {
         Some(NotificationService::Pushbullet { access_token }) => {
             assert_eq!(access_token, "o.abc123token");
         }
@@ -68,6 +67,18 @@ fn notification_url_parser_supports_pushbullet() {
 fn notification_url_parser_rejects_pushbullet_urls_with_no_token() {
     assert!(parse_notification_url("pbul://").is_none());
     assert!(parse_notification_url("pbul:///some-device-id").is_none());
+}
+
+#[test]
+fn notification_url_parser_rejects_pushbullet_urls_with_a_target() {
+    // A device/channel/email target (Apprise's `pbul://token/#channel`,
+    // `.../DEVICE_ID`, `.../email@address`) isn't supported. send_pushbullet
+    // never sends a target parameter, and Pushbullet broadcasts to every
+    // device on the account when none is set — so a target must be rejected
+    // outright rather than silently dropped, which would otherwise leak the
+    // notification to devices the user meant to exclude.
+    assert!(parse_notification_url("pbul://o.abc123token/some-device-id").is_none());
+    assert!(parse_notification_url("pbul://o.abc123token/#a-channel").is_none());
 }
 
 #[test]

--- a/crates/riven-core/src/http/profiles.rs
+++ b/crates/riven-core/src/http/profiles.rs
@@ -49,4 +49,7 @@ impl HttpServiceProfile {
 
 pub const DISCORD_WEBHOOK: HttpServiceProfile = HttpServiceProfile::new("discord_webhook");
 pub const WEBHOOK_JSON: HttpServiceProfile = HttpServiceProfile::new("json_webhook");
-pub const PUSHBULLET: HttpServiceProfile = HttpServiceProfile::new("pushbullet");
+// Single attempt: retrying a push on an ambiguous transport failure (e.g. a
+// timeout after the request already reached Pushbullet) risks delivering the
+// same "download complete" notification twice.
+pub const PUSHBULLET: HttpServiceProfile = HttpServiceProfile::new("pushbullet").with_attempts(1);

--- a/crates/riven-core/src/http/profiles.rs
+++ b/crates/riven-core/src/http/profiles.rs
@@ -49,3 +49,4 @@ impl HttpServiceProfile {
 
 pub const DISCORD_WEBHOOK: HttpServiceProfile = HttpServiceProfile::new("discord_webhook");
 pub const WEBHOOK_JSON: HttpServiceProfile = HttpServiceProfile::new("json_webhook");
+pub const PUSHBULLET: HttpServiceProfile = HttpServiceProfile::new("pushbullet");


### PR DESCRIPTION
## Summary
- The `notifications` plugin's webhook URLs already used Apprise-style scheme notation (`discord://`, `json://`, `jsons://`) for its two supported services. Adds a third: `pbul://<access_token>`, matching Apprise's own Pushbullet scheme exactly, so anyone already familiar with Apprise notation (or migrating from it) can drop in a Pushbullet URL the same way.
- Pushbullet's API only supports plain-text notes, not rich embeds, so this sends a `"note"` push with the item title and a condensed one-line summary (type, year, downloader, provider, duration) rather than reusing the Discord embed builder.
- Device/channel/email targeting (Apprise's `pbul://token/#channel`, `.../DEVICE_ID`, `.../email@address` for scoping to specific devices) is intentionally not supported — a trailing path segment after the token is dropped rather than folded into the token itself, keeping parity with how the existing Discord parsing only handles the plain `webhook_id/token` form.

## Test plan
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p plugin-notifications` all pass.
- New unit tests: `notification_url_parser_supports_pushbullet` (base token form + trailing path segment is dropped, not folded into the token) and `pushbullet_body_condenses_the_core_fields_into_one_line`.
- Will live-verify against a real Pushbullet account before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pushbullet as a supported notification service.
  * Pushbullet URLs support access tokens.
  * Notifications include concise, plain-text summaries with key media details.
  * Updated webhook settings documentation to describe supported notification formats.

* **Bug Fixes**
  * Invalid Pushbullet URLs without access tokens or with unsupported target paths are rejected.
  * Notification errors no longer expose credential-bearing URLs in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->