### PR TITLE
feat: custom notification title/body templates for movies and shows

### DIFF
--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -15,17 +15,23 @@ pub(crate) async fn dispatch_webhooks(
                 if let Err(error) =
                     send_discord(&ctx.http, &webhook_id, &webhook_token, payload, detailed).await
                 {
-                    tracing::error!(error = %error, url = url_str, "failed to send discord notification");
+                    // Never log `url_str` here — it's the full discord.com
+                    // webhook URL, which is itself a bearer credential.
+                    tracing::error!(error = %error, service = "discord", "failed to send discord notification");
                 }
             }
             Some(NotificationService::Pushbullet { access_token }) => {
                 if let Err(error) = send_pushbullet(&ctx.http, &access_token, payload).await {
-                    tracing::error!(error = %error, url = url_str, "failed to send pushbullet notification");
+                    // Never log `url_str` here — it embeds the Pushbullet
+                    // access token, which grants full account access.
+                    tracing::error!(error = %error, service = "pushbullet", "failed to send pushbullet notification");
                 }
             }
             Some(NotificationService::Json { url }) => {
                 if let Err(error) = send_json_webhook(&ctx.http, &url, payload).await {
-                    tracing::error!(error = %error, url = url_str, "failed to send json notification");
+                    // Generic webhook URLs commonly embed a secret path
+                    // segment too, so this omits `url_str`/`url` as well.
+                    tracing::error!(error = %error, service = "json", "failed to send json notification");
                 }
             }
             None => {
@@ -63,11 +69,13 @@ pub(crate) fn parse_notification_url(url: &str) -> Option<NotificationService> {
         // `.../DEVICE_ID`, `.../email@address` for targeted delivery — not
         // supported here, so a trailing path segment is dropped rather than
         // treated as part of the token, matching a plain-token-only client.
-        let access_token = match rest.split_once('/') {
-            Some((token, _)) => token.to_string(),
-            None => rest.to_string(),
-        };
-        Some(NotificationService::Pushbullet { access_token })
+        // A missing/empty token (`pbul://`, `pbul:///device-id`) is rejected
+        // outright rather than reaching send_pushbullet with an empty
+        // Access-Token header.
+        let token = rest.split('/').next().filter(|token| !token.is_empty())?;
+        Some(NotificationService::Pushbullet {
+            access_token: token.to_string(),
+        })
     } else if let Some(rest) = url.strip_prefix("json://") {
         Some(NotificationService::Json {
             url: format!("http://{rest}"),

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -35,7 +35,10 @@ pub(crate) async fn dispatch_webhooks(
                 }
             }
             None => {
-                tracing::warn!(url = url_str, "unsupported notification URL scheme");
+                // Never log `url_str` here — a rejected pbul:// URL still
+                // embeds the Pushbullet access token even though parsing
+                // failed.
+                tracing::warn!("unsupported notification URL scheme");
             }
         }
     }

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -18,6 +18,11 @@ pub(crate) async fn dispatch_webhooks(
                     tracing::error!(error = %error, url = url_str, "failed to send discord notification");
                 }
             }
+            Some(NotificationService::Pushbullet { access_token }) => {
+                if let Err(error) = send_pushbullet(&ctx.http, &access_token, payload).await {
+                    tracing::error!(error = %error, url = url_str, "failed to send pushbullet notification");
+                }
+            }
             Some(NotificationService::Json { url }) => {
                 if let Err(error) = send_json_webhook(&ctx.http, &url, payload).await {
                     tracing::error!(error = %error, url = url_str, "failed to send json notification");
@@ -35,6 +40,9 @@ pub(crate) enum NotificationService {
         webhook_id: String,
         webhook_token: String,
     },
+    Pushbullet {
+        access_token: String,
+    },
     Json {
         url: String,
     },
@@ -50,6 +58,16 @@ pub(crate) fn parse_notification_url(url: &str) -> Option<NotificationService> {
             webhook_id: webhook_id.to_string(),
             webhook_token: webhook_token.to_string(),
         })
+    } else if let Some(rest) = url.strip_prefix("pbul://") {
+        // Apprise's pushbullet scheme also allows `pbul://token/#channel`,
+        // `.../DEVICE_ID`, `.../email@address` for targeted delivery — not
+        // supported here, so a trailing path segment is dropped rather than
+        // treated as part of the token, matching a plain-token-only client.
+        let access_token = match rest.split_once('/') {
+            Some((token, _)) => token.to_string(),
+            None => rest.to_string(),
+        };
+        Some(NotificationService::Pushbullet { access_token })
     } else if let Some(rest) = url.strip_prefix("json://") {
         Some(NotificationService::Json {
             url: format!("http://{rest}"),
@@ -227,6 +245,47 @@ fn build_detailed_embed(payload: &NotificationPayload) -> serde_json::Value {
     }
 
     serde_json::json!({ "embeds": [embed] })
+}
+
+async fn send_pushbullet(
+    http: &riven_core::http::HttpClient,
+    access_token: &str,
+    payload: &NotificationPayload,
+) -> anyhow::Result<()> {
+    let title = format!("Downloaded: {}", payload.full_title);
+    let body = build_pushbullet_body(payload);
+    tracing::debug!(
+        title = %payload.full_title,
+        "sending pushbullet notification"
+    );
+    http.send(profiles::PUSHBULLET, |client| {
+        client
+            .post("https://api.pushbullet.com/v2/pushes")
+            .header("Access-Token", access_token)
+            .json(&serde_json::json!({
+                "type": "note",
+                "title": title,
+                "body": body,
+            }))
+    })
+    .await?
+    .error_for_status()?;
+    Ok(())
+}
+
+/// Pushbullet notes are plain text — no embed support — so this condenses
+/// the same core fields `build_simple_embed` shows into one line.
+pub(crate) fn build_pushbullet_body(payload: &NotificationPayload) -> String {
+    let mut parts = vec![format!("{:?}", payload.item_type)];
+    if let Some(year) = payload.year {
+        parts.push(year.to_string());
+    }
+    parts.push(format!("via {}", payload.downloader));
+    if let Some(ref provider) = payload.provider {
+        parts.push(provider.clone());
+    }
+    parts.push(format!("in {}", format_duration(payload.duration_seconds)));
+    parts.join(" • ")
 }
 
 async fn send_json_webhook(

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -5,6 +5,8 @@ pub(crate) async fn dispatch_webhooks(
     urls: &[String],
     payload: &NotificationPayload,
     detailed: bool,
+    custom_title: Option<&str>,
+    custom_body: Option<&str>,
 ) {
     for url_str in urls {
         match parse_notification_url(url_str) {
@@ -12,8 +14,16 @@ pub(crate) async fn dispatch_webhooks(
                 webhook_id,
                 webhook_token,
             }) => {
-                if let Err(error) =
-                    send_discord(&ctx.http, &webhook_id, &webhook_token, payload, detailed).await
+                if let Err(error) = send_discord(
+                    &ctx.http,
+                    &webhook_id,
+                    &webhook_token,
+                    payload,
+                    detailed,
+                    custom_title,
+                    custom_body,
+                )
+                .await
                 {
                     // Never log `url_str` here — it's the full discord.com
                     // webhook URL, which is itself a bearer credential.
@@ -21,7 +31,10 @@ pub(crate) async fn dispatch_webhooks(
                 }
             }
             Some(NotificationService::Pushbullet { access_token }) => {
-                if let Err(error) = send_pushbullet(&ctx.http, &access_token, payload).await {
+                if let Err(error) =
+                    send_pushbullet(&ctx.http, &access_token, payload, custom_title, custom_body)
+                        .await
+                {
                     // Never log `url_str` here — it embeds the Pushbullet
                     // access token, which grants full account access.
                     tracing::error!(error = %error, service = "pushbullet", "failed to send pushbullet notification");
@@ -104,9 +117,13 @@ async fn send_discord(
     webhook_token: &str,
     payload: &NotificationPayload,
     detailed: bool,
+    custom_title: Option<&str>,
+    custom_body: Option<&str>,
 ) -> anyhow::Result<()> {
     let url = format!("https://discord.com/api/webhooks/{webhook_id}/{webhook_token}");
-    let body = if detailed {
+    let body = if custom_title.is_some() || custom_body.is_some() {
+        build_custom_embed(payload, custom_title, custom_body)
+    } else if detailed {
         build_detailed_embed(payload)
     } else {
         build_simple_embed(payload)
@@ -156,8 +173,10 @@ pub(crate) fn build_simple_embed(payload: &NotificationPayload) -> serde_json::V
     serde_json::json!({ "embeds": [embed] })
 }
 
-fn build_detailed_embed(payload: &NotificationPayload) -> serde_json::Value {
-    let media_label = if payload.is_anime {
+/// Human label for the item type, factoring in the anime override — shared
+/// between the detailed and custom embed builders.
+fn media_label(payload: &NotificationPayload) -> &'static str {
+    if payload.is_anime {
         "Anime"
     } else {
         match payload.item_type {
@@ -166,16 +185,55 @@ fn build_detailed_embed(payload: &NotificationPayload) -> serde_json::Value {
             MediaItemType::Season => "Season",
             MediaItemType::Episode => "Episode",
         }
-    };
+    }
+}
 
-    let color: u32 = if payload.is_anime {
+/// Embed accent color by item type, factoring in the anime override —
+/// shared between the detailed and custom embed builders.
+fn embed_color(payload: &NotificationPayload) -> u32 {
+    if payload.is_anime {
         0x9B59B6
     } else {
         match payload.item_type {
             MediaItemType::Movie => 0xE67E22,
             MediaItemType::Show | MediaItemType::Season | MediaItemType::Episode => 0x3498DB,
         }
-    };
+    }
+}
+
+/// A custom title/body template rendered into Discord's embed shape — the
+/// visual chrome (color, poster thumbnail, timestamp) is kept, but the
+/// structured fields/description of the default embeds are replaced
+/// entirely by the rendered body, since a user writing their own template
+/// is opting out of the auto-generated layout, not just its wording.
+fn build_custom_embed(
+    payload: &NotificationPayload,
+    custom_title: Option<&str>,
+    custom_body: Option<&str>,
+) -> serde_json::Value {
+    let title = custom_title
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("Downloaded: {}", payload.full_title));
+
+    let mut embed = serde_json::json!({
+        "title": title,
+        "color": embed_color(payload),
+        "timestamp": &payload.timestamp,
+    });
+
+    if let Some(body) = custom_body {
+        embed["description"] = serde_json::json!(body);
+    }
+    if let Some(ref poster) = payload.poster_path {
+        embed["thumbnail"] = serde_json::json!({ "url": poster });
+    }
+
+    serde_json::json!({ "embeds": [embed] })
+}
+
+fn build_detailed_embed(payload: &NotificationPayload) -> serde_json::Value {
+    let media_label = media_label(payload);
+    let color: u32 = embed_color(payload);
 
     let title = match payload.year {
         Some(year) => format!("{} ({})", payload.full_title, year),
@@ -269,9 +327,15 @@ async fn send_pushbullet(
     http: &riven_core::http::HttpClient,
     access_token: &str,
     payload: &NotificationPayload,
+    custom_title: Option<&str>,
+    custom_body: Option<&str>,
 ) -> anyhow::Result<()> {
-    let title = format!("Downloaded: {}", payload.full_title);
-    let body = build_pushbullet_body(payload);
+    let title = custom_title
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("Downloaded: {}", payload.full_title));
+    let body = custom_body
+        .map(str::to_string)
+        .unwrap_or_else(|| build_pushbullet_body(payload));
     tracing::debug!(
         title = %payload.full_title,
         "sending pushbullet notification"

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -67,15 +67,22 @@ pub(crate) fn parse_notification_url(url: &str) -> Option<NotificationService> {
     } else if let Some(rest) = url.strip_prefix("pbul://") {
         // Apprise's pushbullet scheme also allows `pbul://token/#channel`,
         // `.../DEVICE_ID`, `.../email@address` for targeted delivery — not
-        // supported here, so a trailing path segment is dropped rather than
-        // treated as part of the token, matching a plain-token-only client.
+        // supported here. A target segment is rejected outright rather than
+        // silently dropped: send_pushbullet never sends a target parameter,
+        // and Pushbullet broadcasts to every device on the account when no
+        // target is set, so silently dropping a configured target would leak
+        // the notification to devices the user deliberately excluded.
         // A missing/empty token (`pbul://`, `pbul:///device-id`) is rejected
-        // outright rather than reaching send_pushbullet with an empty
+        // outright too, rather than reaching send_pushbullet with an empty
         // Access-Token header.
-        let token = rest.split('/').next().filter(|token| !token.is_empty())?;
-        Some(NotificationService::Pushbullet {
-            access_token: token.to_string(),
-        })
+        let (token, target) = rest.split_once('/').unwrap_or((rest, ""));
+        if token.is_empty() || !target.is_empty() {
+            None
+        } else {
+            Some(NotificationService::Pushbullet {
+                access_token: token.to_string(),
+            })
+        }
     } else if let Some(rest) = url.strip_prefix("json://") {
         Some(NotificationService::Json {
             url: format!("http://{rest}"),

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+/// Sends the notification to every configured target. Returns `true` only if
+/// every one accepted it — `on_download_success` ignores this (a completed
+/// download must not fail over a flaky webhook), but the test-notification
+/// path uses it to report an actual failure instead of a false "sent".
 pub(crate) async fn dispatch_webhooks(
     ctx: &PluginContext,
     urls: &[String],
@@ -7,7 +11,8 @@ pub(crate) async fn dispatch_webhooks(
     detailed: bool,
     custom_title: Option<&str>,
     custom_body: Option<&str>,
-) {
+) -> bool {
+    let mut all_ok = true;
     for url_str in urls {
         match parse_notification_url(url_str) {
             Some(NotificationService::Discord {
@@ -25,6 +30,7 @@ pub(crate) async fn dispatch_webhooks(
                 )
                 .await
                 {
+                    all_ok = false;
                     // Never log `url_str` here — it's the full discord.com
                     // webhook URL, which is itself a bearer credential.
                     tracing::error!(error = %error, service = "discord", "failed to send discord notification");
@@ -35,6 +41,7 @@ pub(crate) async fn dispatch_webhooks(
                     send_pushbullet(&ctx.http, &access_token, payload, custom_title, custom_body)
                         .await
                 {
+                    all_ok = false;
                     // Never log `url_str` here — it embeds the Pushbullet
                     // access token, which grants full account access.
                     tracing::error!(error = %error, service = "pushbullet", "failed to send pushbullet notification");
@@ -42,12 +49,14 @@ pub(crate) async fn dispatch_webhooks(
             }
             Some(NotificationService::Json { url }) => {
                 if let Err(error) = send_json_webhook(&ctx.http, &url, payload).await {
+                    all_ok = false;
                     // Generic webhook URLs commonly embed a secret path
                     // segment too, so this omits `url_str`/`url` as well.
                     tracing::error!(error = %error, service = "json", "failed to send json notification");
                 }
             }
             None => {
+                all_ok = false;
                 // Never log `url_str` here — a rejected pbul:// URL still
                 // embeds the Pushbullet access token even though parsing
                 // failed.
@@ -55,6 +64,7 @@ pub(crate) async fn dispatch_webhooks(
             }
         }
     }
+    all_ok
 }
 
 pub(crate) enum NotificationService {
@@ -206,7 +216,26 @@ fn embed_color(payload: &NotificationPayload) -> u32 {
 /// structured fields/description of the default embeds are replaced
 /// entirely by the rendered body, since a user writing their own template
 /// is opting out of the auto-generated layout, not just its wording.
-fn build_custom_embed(
+/// Discord's hard per-embed caps (<https://discord.com/safety/using-webhooks-and-embeds>):
+/// title 256 chars, description 4096 chars. Exceeding either makes Discord
+/// reject the whole webhook request with a 400, so a rendered custom
+/// template — which can be arbitrarily long once `{{overview}}` or a verbose
+/// body template is in the mix — is truncated before being sent.
+const DISCORD_EMBED_TITLE_MAX_CHARS: usize = 256;
+const DISCORD_EMBED_DESCRIPTION_MAX_CHARS: usize = 4096;
+
+/// Truncates at a `char` boundary (never splits a multi-byte UTF-8
+/// sequence) and appends an ellipsis when truncation actually happened.
+pub(crate) fn truncate_chars(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let mut truncated: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+    truncated.push('…');
+    truncated
+}
+
+pub(crate) fn build_custom_embed(
     payload: &NotificationPayload,
     custom_title: Option<&str>,
     custom_body: Option<&str>,
@@ -214,6 +243,7 @@ fn build_custom_embed(
     let title = custom_title
         .map(str::to_string)
         .unwrap_or_else(|| format!("Downloaded: {}", payload.full_title));
+    let title = truncate_chars(&title, DISCORD_EMBED_TITLE_MAX_CHARS);
 
     let mut embed = serde_json::json!({
         "title": title,
@@ -222,7 +252,8 @@ fn build_custom_embed(
     });
 
     if let Some(body) = custom_body {
-        embed["description"] = serde_json::json!(body);
+        embed["description"] =
+            serde_json::json!(truncate_chars(body, DISCORD_EMBED_DESCRIPTION_MAX_CHARS));
     }
     if let Some(ref poster) = payload.poster_path {
         embed["thumbnail"] = serde_json::json!({ "url": poster });

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -12,7 +12,7 @@ pub(crate) async fn dispatch_webhooks(
     custom_title: Option<&str>,
     custom_body: Option<&str>,
 ) -> bool {
-    let mut all_ok = true;
+    let mut all_ok = !urls.is_empty();
     for url_str in urls {
         match parse_notification_url(url_str) {
             Some(NotificationService::Discord {

--- a/crates/plugin-notifications/src/lib.rs
+++ b/crates/plugin-notifications/src/lib.rs
@@ -120,18 +120,18 @@ impl Plugin for NotificationsPlugin {
                 "Use custom template",
                 FieldType::Boolean,
             )
-            .with_section("Show notifications")
+            .with_section("TV show notifications")
             .with_description(
                 "Off by default (uses the built-in layout). Switch on to apply the templates \
                  below — leaves them in place, so you can draft a template without it taking \
                  effect yet.",
             ),
             SettingField::new("show_title_template", "Title", FieldType::Textarea)
-                .with_section("Show notifications")
+                .with_section("TV show notifications")
                 .with_placeholder("Downloaded: {{title}}")
                 .with_description(TEMPLATE_VARIABLES_HELP),
             SettingField::new("show_body_template", "Body", FieldType::Textarea)
-                .with_section("Show notifications")
+                .with_section("TV show notifications")
                 .with_placeholder("{{episode_title}} S{{season}}E{{episode}} — {{quality}}")
                 .with_description(TEMPLATE_VARIABLES_HELP),
         ]

--- a/crates/plugin-notifications/src/lib.rs
+++ b/crates/plugin-notifications/src/lib.rs
@@ -58,7 +58,10 @@ impl Plugin for NotificationsPlugin {
     }
 
     fn subscribed_events(&self) -> &[EventType] {
-        &[EventType::MediaItemDownloadSuccess]
+        &[
+            EventType::MediaItemDownloadSuccess,
+            EventType::NotificationTestRequested,
+        ]
     }
 
     async fn validate(
@@ -133,7 +136,6 @@ impl Plugin for NotificationsPlugin {
         info: &DownloadSuccessInfo<'_>,
         ctx: &PluginContext,
     ) -> anyhow::Result<HookResponse> {
-        let urls = ctx.settings.get_list("urls");
         let detailed = ctx.settings.get_bool("detailed");
 
         let mut payload = NotificationPayload {
@@ -194,43 +196,105 @@ impl Plugin for NotificationsPlugin {
             }
         }
 
-        let (use_custom_key, title_key, body_key) = match template_category(payload.item_type) {
-            TemplateCategory::Movie => (
-                "movie_use_custom_template",
-                "movie_title_template",
-                "movie_body_template",
-            ),
-            TemplateCategory::Show => (
-                "show_use_custom_template",
-                "show_title_template",
-                "show_body_template",
-            ),
-        };
-        let (custom_title, custom_body) = if ctx.settings.get_bool(use_custom_key) {
-            let vars = template_variables(&payload);
-            (
-                ctx.settings
-                    .get(title_key)
-                    .map(|t| render_template(t, &vars)),
-                ctx.settings
-                    .get(body_key)
-                    .map(|t| render_template(t, &vars)),
-            )
-        } else {
-            (None, None)
-        };
-
-        dispatch_webhooks(
-            ctx,
-            &urls,
-            &payload,
-            detailed,
-            custom_title.as_deref(),
-            custom_body.as_deref(),
-        )
-        .await;
+        render_and_dispatch(ctx, &payload, detailed).await;
 
         Ok(HookResponse::Empty)
+    }
+
+    /// Preview a template with placeholder data — see the trait default's
+    /// doc comment. `item_type` selects the dummy payload's category:
+    /// `Movie` for the movie templates, anything else for the show
+    /// templates (populated as a single test episode so season/episode/
+    /// episode_title all render with a value).
+    async fn on_notification_test_requested(
+        &self,
+        item_type: MediaItemType,
+        ctx: &PluginContext,
+    ) -> anyhow::Result<HookResponse> {
+        let detailed = ctx.settings.get_bool("detailed");
+        let payload = dummy_payload(item_type);
+        render_and_dispatch(ctx, &payload, detailed).await;
+        Ok(HookResponse::Empty)
+    }
+}
+
+/// Shared tail of `on_download_success` and `on_notification_test_requested`:
+/// pick the movie/show template pair, render it if that category's "use
+/// custom template" toggle is on, and dispatch to every configured target.
+async fn render_and_dispatch(ctx: &PluginContext, payload: &NotificationPayload, detailed: bool) {
+    let urls = ctx.settings.get_list("urls");
+    let (use_custom_key, title_key, body_key) = match template_category(payload.item_type) {
+        TemplateCategory::Movie => (
+            "movie_use_custom_template",
+            "movie_title_template",
+            "movie_body_template",
+        ),
+        TemplateCategory::Show => (
+            "show_use_custom_template",
+            "show_title_template",
+            "show_body_template",
+        ),
+    };
+    let (custom_title, custom_body) = if ctx.settings.get_bool(use_custom_key) {
+        let vars = template_variables(payload);
+        (
+            ctx.settings
+                .get(title_key)
+                .map(|t| render_template(t, &vars)),
+            ctx.settings
+                .get(body_key)
+                .map(|t| render_template(t, &vars)),
+        )
+    } else {
+        (None, None)
+    };
+
+    dispatch_webhooks(
+        ctx,
+        &urls,
+        payload,
+        detailed,
+        custom_title.as_deref(),
+        custom_body.as_deref(),
+    )
+    .await;
+}
+
+/// Placeholder payload for `on_notification_test_requested`. `item_type` is
+/// `Movie` for the movie category; any other value builds a single test
+/// episode so every show-only variable (season/episode/episode_title) has a
+/// value to preview.
+fn dummy_payload(item_type: MediaItemType) -> NotificationPayload {
+    let is_movie = item_type == MediaItemType::Movie;
+    let name = if is_movie { "Test Movie" } else { "Test Show" };
+    NotificationPayload {
+        event: "riven.notifications.test-requested".to_string(),
+        title: name.to_string(),
+        full_title: name.to_string(),
+        item_type,
+        year: Some(2026),
+        imdb_id: Some("tt0000000".to_string()),
+        tmdb_id: Some("0".to_string()),
+        tvdb_id: (!is_movie).then(|| "0".to_string()),
+        poster_path: None,
+        downloader: "stremthru".to_string(),
+        provider: Some("realdebrid".to_string()),
+        duration_seconds: 42.0,
+        timestamp: Utc::now().to_rfc3339(),
+        is_anime: false,
+        rating: Some(7.5),
+        overview: Some(
+            "This is a test notification, sent from Riven's settings to preview your \
+             notification template."
+                .to_string(),
+        ),
+        tvdb_slug: (!is_movie).then(|| "test-show".to_string()),
+        resolution: Some("1080p".to_string()),
+        quality: Some("WEB-DL".to_string()),
+        release_group: Some("GROUP".to_string()),
+        season: (!is_movie).then_some(1),
+        episode: (!is_movie).then_some(1),
+        episode_title: (!is_movie).then(|| "Test Episode".to_string()),
     }
 }
 

--- a/crates/plugin-notifications/src/lib.rs
+++ b/crates/plugin-notifications/src/lib.rs
@@ -15,7 +15,10 @@ mod metadata;
 
 use dispatch::dispatch_webhooks;
 #[cfg(test)]
-use dispatch::{NotificationService, build_simple_embed, format_duration, parse_notification_url};
+use dispatch::{
+    NotificationService, build_pushbullet_body, build_simple_embed, format_duration,
+    parse_notification_url,
+};
 use metadata::{fetch_tmdb_overview, fetch_tvdb_slug};
 
 const TMDB_BASE_URL: &str = "https://api.themoviedb.org/3";
@@ -60,7 +63,10 @@ impl Plugin for NotificationsPlugin {
                 .required()
                 .with_placeholder("https://discord.com/api/webhooks/...")
                 .with_description(
-                    "Comma-separated webhook URLs. Supports Discord and generic JSON endpoints.",
+                    "Comma-separated webhook URLs, using Apprise-style notation. Supports \
+                     Discord (a full webhook URL or discord://id/token), Pushbullet \
+                     (pbul://<access_token>), and generic JSON endpoints (json://... or \
+                     jsons://...).",
                 ),
             SettingField::new("detailed", "Detailed Embeds", FieldType::Boolean).with_description(
                 "Show rich Discord embeds with overview, rating, and external links.",

--- a/crates/plugin-notifications/src/lib.rs
+++ b/crates/plugin-notifications/src/lib.rs
@@ -17,11 +17,11 @@ mod templates;
 use dispatch::dispatch_webhooks;
 #[cfg(test)]
 use dispatch::{
-    NotificationService, build_pushbullet_body, build_simple_embed, format_duration,
-    parse_notification_url,
+    NotificationService, build_custom_embed, build_pushbullet_body, build_simple_embed,
+    format_duration, parse_notification_url, truncate_chars,
 };
 use metadata::{fetch_tmdb_overview, fetch_tvdb_slug};
-use templates::{TemplateCategory, render_template, template_category, template_variables};
+use templates::{render_template, template_category, template_keys, template_variables};
 
 const TMDB_BASE_URL: &str = "https://api.themoviedb.org/3";
 const TVDB_BASE_URL: &str = "https://api4.thetvdb.com/v4";
@@ -176,7 +176,16 @@ impl Plugin for NotificationsPlugin {
             return Ok(HookResponse::Empty);
         }
 
-        if detailed {
+        // A custom template can reference {{overview}}/{{tvdb_link}} whether
+        // or not "Detailed Embeds" (a Discord-only concern) is on, so this
+        // metadata is fetched whenever either could use it — not just when
+        // `detailed` is set, or a real notification would silently render
+        // both as empty for anyone using a custom template without also
+        // enabling detailed embeds, even though the test-notification
+        // preview (which doesn't consult this at all) would show them
+        // populated.
+        let (use_custom_key, _, _) = template_keys(template_category(payload.item_type));
+        if detailed || ctx.settings.get_bool(use_custom_key) {
             if let Some(api_key) = ctx.settings.get("tmdb_api_key") {
                 payload.overview = fetch_tmdb_overview(&ctx.http, api_key, &payload).await;
             }
@@ -202,6 +211,8 @@ impl Plugin for NotificationsPlugin {
             }
         }
 
+        // Best effort: a completed download must not fail (or retry) just
+        // because a webhook target is temporarily unreachable or misconfigured.
         render_and_dispatch(ctx, &payload, detailed).await;
 
         Ok(HookResponse::Empty)
@@ -212,6 +223,11 @@ impl Plugin for NotificationsPlugin {
     /// `Movie` for the movie templates, anything else for the show
     /// templates (populated as a single test episode so season/episode/
     /// episode_title all render with a value).
+    ///
+    /// Unlike `on_download_success`, delivery failure here is *not* best
+    /// effort — the whole point of a test notification is confirming the
+    /// configured target actually works, so a failed delivery must surface
+    /// as an error rather than reporting success unconditionally.
     async fn on_notification_test_requested(
         &self,
         item_type: MediaItemType,
@@ -219,28 +235,29 @@ impl Plugin for NotificationsPlugin {
     ) -> anyhow::Result<HookResponse> {
         let detailed = ctx.settings.get_bool("detailed");
         let payload = dummy_payload(item_type);
-        render_and_dispatch(ctx, &payload, detailed).await;
-        Ok(HookResponse::Empty)
+        if render_and_dispatch(ctx, &payload, detailed).await {
+            Ok(HookResponse::Empty)
+        } else {
+            Err(anyhow::anyhow!(
+                "failed to deliver the test notification to at least one configured target — check the logs for details"
+            ))
+        }
     }
 }
 
 /// Shared tail of `on_download_success` and `on_notification_test_requested`:
 /// pick the movie/show template pair, render it if that category's "use
 /// custom template" toggle is on, and dispatch to every configured target.
-async fn render_and_dispatch(ctx: &PluginContext, payload: &NotificationPayload, detailed: bool) {
+/// Returns whether every configured target accepted the notification —
+/// `on_download_success` ignores this (best effort), `on_notification_test_requested`
+/// surfaces a failure to the caller.
+async fn render_and_dispatch(
+    ctx: &PluginContext,
+    payload: &NotificationPayload,
+    detailed: bool,
+) -> bool {
     let urls = ctx.settings.get_list("urls");
-    let (use_custom_key, title_key, body_key) = match template_category(payload.item_type) {
-        TemplateCategory::Movie => (
-            "movie_use_custom_template",
-            "movie_title_template",
-            "movie_body_template",
-        ),
-        TemplateCategory::Show => (
-            "show_use_custom_template",
-            "show_title_template",
-            "show_body_template",
-        ),
-    };
+    let (use_custom_key, title_key, body_key) = template_keys(template_category(payload.item_type));
     let (custom_title, custom_body) = if ctx.settings.get_bool(use_custom_key) {
         let vars = template_variables(payload);
         (
@@ -263,7 +280,7 @@ async fn render_and_dispatch(ctx: &PluginContext, payload: &NotificationPayload,
         custom_title.as_deref(),
         custom_body.as_deref(),
     )
-    .await;
+    .await
 }
 
 /// Placeholder payload for `on_notification_test_requested`. `item_type` is

--- a/crates/plugin-notifications/src/lib.rs
+++ b/crates/plugin-notifications/src/lib.rs
@@ -96,36 +96,42 @@ impl Plugin for NotificationsPlugin {
             .with_description("Optional. Required for overview text in detailed Discord embeds."),
             SettingField::new(
                 "movie_use_custom_template",
-                "Movie: use custom template",
+                "Use custom template",
                 FieldType::Boolean,
             )
+            .with_section("Movie notifications")
             .with_description(
-                "Off by default (uses the built-in layout). Switch on to apply the movie \
-                 templates below — leaves them in place, so you can draft a template \
-                 without it taking effect yet.",
+                "Off by default (uses the built-in layout). Switch on to apply the templates \
+                 below — leaves them in place, so you can draft a template without it taking \
+                 effect yet.",
             ),
-            SettingField::new("movie_title_template", "Movie: title", FieldType::Textarea)
+            SettingField::new("movie_title_template", "Title", FieldType::Textarea)
+                .with_section("Movie notifications")
                 .with_placeholder("Downloaded: {{title}} ({{year}})")
                 .with_description(TEMPLATE_VARIABLES_HELP),
-            SettingField::new("movie_body_template", "Movie: body", FieldType::Textarea)
+            SettingField::new("movie_body_template", "Body", FieldType::Textarea)
+                .with_section("Movie notifications")
                 .with_placeholder(
                     "{{quality}} {{resolution}} by {{release_group}} via {{downloader}}",
                 )
                 .with_description(TEMPLATE_VARIABLES_HELP),
             SettingField::new(
                 "show_use_custom_template",
-                "Show: use custom template",
+                "Use custom template",
                 FieldType::Boolean,
             )
+            .with_section("Show notifications")
             .with_description(
-                "Off by default (uses the built-in layout). Switch on to apply the show \
-                 templates below — leaves them in place, so you can draft a template \
-                 without it taking effect yet.",
+                "Off by default (uses the built-in layout). Switch on to apply the templates \
+                 below — leaves them in place, so you can draft a template without it taking \
+                 effect yet.",
             ),
-            SettingField::new("show_title_template", "Show: title", FieldType::Textarea)
+            SettingField::new("show_title_template", "Title", FieldType::Textarea)
+                .with_section("Show notifications")
                 .with_placeholder("Downloaded: {{title}}")
                 .with_description(TEMPLATE_VARIABLES_HELP),
-            SettingField::new("show_body_template", "Show: body", FieldType::Textarea)
+            SettingField::new("show_body_template", "Body", FieldType::Textarea)
+                .with_section("Show notifications")
                 .with_placeholder("{{episode_title}} S{{season}}E{{episode}} — {{quality}}")
                 .with_description(TEMPLATE_VARIABLES_HELP),
         ]

--- a/crates/plugin-notifications/src/lib.rs
+++ b/crates/plugin-notifications/src/lib.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 mod dispatch;
 mod metadata;
+mod templates;
 
 use dispatch::dispatch_webhooks;
 #[cfg(test)]
@@ -20,10 +21,23 @@ use dispatch::{
     parse_notification_url,
 };
 use metadata::{fetch_tmdb_overview, fetch_tvdb_slug};
+use templates::{TemplateCategory, render_template, template_category, template_variables};
 
 const TMDB_BASE_URL: &str = "https://api.themoviedb.org/3";
 const TVDB_BASE_URL: &str = "https://api4.thetvdb.com/v4";
 const TVDB_DEFAULT_API_KEY: &str = "6be85335-5c4f-4d8d-b945-d3ed0eb8cdce";
+
+/// Shared description for all four template fields. Plain `{{variable}}`
+/// substitution, no conditionals — a variable with no value for this
+/// download renders as an empty string, so avoid a lone line built entirely
+/// from one optional variable (e.g. `Group: {{release_group}}`) if you'd
+/// rather it disappear than leave a bare label.
+const TEMPLATE_VARIABLES_HELP: &str = "Leave blank to use the default layout. Available in \
+     both movie and show templates: {{title}}, {{year}}, {{quality}}, {{resolution}}, \
+     {{release_group}}, {{downloader}}, {{provider}}, {{rating}}, {{overview}}, {{poster}}, \
+     {{duration}}, {{tmdb_link}}, {{imdb_link}}. Show templates only: {{season}}, \
+     {{episode}}, {{episode_title}}, {{tvdb_link}} — empty for a season/show-level \
+     completion rather than a single episode.";
 
 const TMDB_PROFILE: HttpServiceProfile =
     HttpServiceProfile::new("tmdb").with_rate_limit(40, Duration::from_secs(1));
@@ -77,6 +91,40 @@ impl Plugin for NotificationsPlugin {
                 FieldType::Password,
             )
             .with_description("Optional. Required for overview text in detailed Discord embeds."),
+            SettingField::new(
+                "movie_use_custom_template",
+                "Movie: use custom template",
+                FieldType::Boolean,
+            )
+            .with_description(
+                "Off by default (uses the built-in layout). Switch on to apply the movie \
+                 templates below — leaves them in place, so you can draft a template \
+                 without it taking effect yet.",
+            ),
+            SettingField::new("movie_title_template", "Movie: title", FieldType::Textarea)
+                .with_placeholder("Downloaded: {{title}} ({{year}})")
+                .with_description(TEMPLATE_VARIABLES_HELP),
+            SettingField::new("movie_body_template", "Movie: body", FieldType::Textarea)
+                .with_placeholder(
+                    "{{quality}} {{resolution}} by {{release_group}} via {{downloader}}",
+                )
+                .with_description(TEMPLATE_VARIABLES_HELP),
+            SettingField::new(
+                "show_use_custom_template",
+                "Show: use custom template",
+                FieldType::Boolean,
+            )
+            .with_description(
+                "Off by default (uses the built-in layout). Switch on to apply the show \
+                 templates below — leaves them in place, so you can draft a template \
+                 without it taking effect yet.",
+            ),
+            SettingField::new("show_title_template", "Show: title", FieldType::Textarea)
+                .with_placeholder("Downloaded: {{title}}")
+                .with_description(TEMPLATE_VARIABLES_HELP),
+            SettingField::new("show_body_template", "Show: body", FieldType::Textarea)
+                .with_placeholder("{{episode_title}} S{{season}}E{{episode}} — {{quality}}")
+                .with_description(TEMPLATE_VARIABLES_HELP),
         ]
     }
 
@@ -108,6 +156,12 @@ impl Plugin for NotificationsPlugin {
             rating: None,
             overview: None,
             tvdb_slug: None,
+            resolution: None,
+            quality: None,
+            release_group: None,
+            season: None,
+            episode: None,
+            episode_title: None,
         };
 
         if !rewrite_for_request_root(ctx, info.id, &mut payload).await? {
@@ -123,7 +177,58 @@ impl Plugin for NotificationsPlugin {
             }
         }
 
-        dispatch_webhooks(ctx, &urls, &payload, detailed).await;
+        // The release behind this download — quality/resolution/group come
+        // from the just-created filesystem entry's linked stream, not the
+        // item itself, so this always looks up `info.id` (the item that
+        // actually triggered this download) rather than any request-root
+        // item `rewrite_for_request_root` may have substituted above.
+        match repo::get_latest_release_info(info.id).await {
+            Ok(Some(release)) => {
+                payload.resolution = release.resolution;
+                payload.quality = release.quality;
+                payload.release_group = release.release_group;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(id = info.id, %error, "failed to look up release info for notification templates");
+            }
+        }
+
+        let (use_custom_key, title_key, body_key) = match template_category(payload.item_type) {
+            TemplateCategory::Movie => (
+                "movie_use_custom_template",
+                "movie_title_template",
+                "movie_body_template",
+            ),
+            TemplateCategory::Show => (
+                "show_use_custom_template",
+                "show_title_template",
+                "show_body_template",
+            ),
+        };
+        let (custom_title, custom_body) = if ctx.settings.get_bool(use_custom_key) {
+            let vars = template_variables(&payload);
+            (
+                ctx.settings
+                    .get(title_key)
+                    .map(|t| render_template(t, &vars)),
+                ctx.settings
+                    .get(body_key)
+                    .map(|t| render_template(t, &vars)),
+            )
+        } else {
+            (None, None)
+        };
+
+        dispatch_webhooks(
+            ctx,
+            &urls,
+            &payload,
+            detailed,
+            custom_title.as_deref(),
+            custom_body.as_deref(),
+        )
+        .await;
 
         Ok(HookResponse::Empty)
     }
@@ -141,6 +246,9 @@ async fn rewrite_for_request_root(
     payload.is_anime = item.is_anime;
     payload.rating = item.rating;
     payload.tvdb_id = item.tvdb_id.clone();
+    payload.season = item.season_number;
+    payload.episode = item.episode_number;
+    payload.episode_title = (item.item_type == MediaItemType::Episode).then(|| item.title.clone());
 
     let Some(request_id) = item.item_request_id else {
         return Ok(true);
@@ -171,6 +279,15 @@ async fn rewrite_for_request_root(
     payload.poster_path = root_item.poster_path.clone();
     payload.is_anime = root_item.is_anime;
     payload.rating = root_item.rating;
+    // Overwritten to match the root item rather than kept from the
+    // originally-triggering item: a request completing means the whole
+    // show/season is done, not specifically whichever episode happened to
+    // finish last, so season/episode should reflect that (empty unless the
+    // root item is itself a single requested episode).
+    payload.season = root_item.season_number;
+    payload.episode = root_item.episode_number;
+    payload.episode_title =
+        (root_item.item_type == MediaItemType::Episode).then(|| root_item.title.clone());
     payload.duration_seconds = request
         .completed_at
         .unwrap_or_else(Utc::now)
@@ -200,6 +317,12 @@ struct NotificationPayload {
     overview: Option<String>,
     #[serde(skip)]
     tvdb_slug: Option<String>,
+    resolution: Option<String>,
+    quality: Option<String>,
+    release_group: Option<String>,
+    season: Option<i32>,
+    episode: Option<i32>,
+    episode_title: Option<String>,
 }
 
 async fn mark_request_notification_sent(

--- a/crates/plugin-notifications/src/templates.rs
+++ b/crates/plugin-notifications/src/templates.rs
@@ -1,0 +1,193 @@
+use std::collections::HashMap;
+
+use riven_core::types::MediaItemType;
+
+use super::NotificationPayload;
+use super::dispatch::format_duration;
+
+/// Which set of custom templates applies to a payload's `item_type`.
+pub(crate) enum TemplateCategory {
+    Movie,
+    Show,
+}
+
+pub(crate) fn template_category(item_type: MediaItemType) -> TemplateCategory {
+    match item_type {
+        MediaItemType::Movie => TemplateCategory::Movie,
+        MediaItemType::Show | MediaItemType::Season | MediaItemType::Episode => {
+            TemplateCategory::Show
+        }
+    }
+}
+
+/// Build the `{{variable}}` → value map for a payload. Every variable listed
+/// in the plugin's settings schema has an entry here, even when the
+/// underlying field is absent — those substitute to an empty string rather
+/// than leaving the literal `{{placeholder}}` in the rendered text.
+pub(crate) fn template_variables(payload: &NotificationPayload) -> HashMap<&'static str, String> {
+    let tmdb_link = payload.tmdb_id.as_deref().map(|id| {
+        let path = if payload.item_type == MediaItemType::Movie {
+            "movie"
+        } else {
+            "tv"
+        };
+        format!("https://www.themoviedb.org/{path}/{id}")
+    });
+    let imdb_link = payload
+        .imdb_id
+        .as_deref()
+        .map(|id| format!("https://www.imdb.com/title/{id}"));
+    let tvdb_link = payload
+        .tvdb_slug
+        .as_deref()
+        .map(|slug| format!("https://thetvdb.com/series/{slug}"));
+
+    HashMap::from([
+        ("title", payload.title.clone()),
+        ("full_title", payload.full_title.clone()),
+        (
+            "year",
+            payload.year.map(|y| y.to_string()).unwrap_or_default(),
+        ),
+        (
+            "season",
+            payload.season.map(|s| s.to_string()).unwrap_or_default(),
+        ),
+        (
+            "episode",
+            payload.episode.map(|e| e.to_string()).unwrap_or_default(),
+        ),
+        (
+            "episode_title",
+            payload.episode_title.clone().unwrap_or_default(),
+        ),
+        ("quality", payload.quality.clone().unwrap_or_default()),
+        ("resolution", payload.resolution.clone().unwrap_or_default()),
+        (
+            "release_group",
+            payload.release_group.clone().unwrap_or_default(),
+        ),
+        ("downloader", payload.downloader.clone()),
+        ("provider", payload.provider.clone().unwrap_or_default()),
+        (
+            "rating",
+            payload
+                .rating
+                .map(|r| format!("{r:.1}"))
+                .unwrap_or_default(),
+        ),
+        ("overview", payload.overview.clone().unwrap_or_default()),
+        ("poster", payload.poster_path.clone().unwrap_or_default()),
+        ("duration", format_duration(payload.duration_seconds)),
+        ("tmdb_link", tmdb_link.unwrap_or_default()),
+        ("imdb_link", imdb_link.unwrap_or_default()),
+        ("tvdb_link", tvdb_link.unwrap_or_default()),
+    ])
+}
+
+/// Plain `{{variable}}` substitution — no conditionals or loops. A variable
+/// with no value (see [`template_variables`]) substitutes to an empty
+/// string rather than being left as a literal placeholder or removing the
+/// surrounding line, so templates that reference optional fields should
+/// account for that (e.g. avoid a lone "Group: {{release_group}}" line if
+/// the release group is commonly absent).
+pub(crate) fn render_template(template: &str, vars: &HashMap<&'static str, String>) -> String {
+    let mut result = template.to_string();
+    for (key, value) in vars {
+        result = result.replace(&format!("{{{{{key}}}}}"), value);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload() -> NotificationPayload {
+        NotificationPayload {
+            event: "riven.media-item.download.success".to_string(),
+            title: "Movie".to_string(),
+            full_title: "Movie".to_string(),
+            item_type: MediaItemType::Movie,
+            year: Some(2024),
+            imdb_id: Some("tt123".to_string()),
+            tmdb_id: Some("456".to_string()),
+            tvdb_id: None,
+            poster_path: Some("https://image.test/poster.jpg".to_string()),
+            downloader: "stremthru".to_string(),
+            provider: Some("realdebrid".to_string()),
+            duration_seconds: 125.0,
+            timestamp: "2026-04-16T12:00:00Z".to_string(),
+            is_anime: false,
+            rating: Some(8.25),
+            overview: Some("Short overview".to_string()),
+            tvdb_slug: None,
+            resolution: Some("1080p".to_string()),
+            quality: Some("WEB-DL".to_string()),
+            release_group: Some("GROUP".to_string()),
+            season: None,
+            episode: None,
+            episode_title: None,
+        }
+    }
+
+    #[test]
+    fn renders_known_variables_and_builds_external_links() {
+        let vars = template_variables(&payload());
+        let rendered = render_template(
+            "{{title}} ({{year}}) {{quality}} {{resolution}} by {{release_group}} via {{downloader}}/{{provider}} — {{tmdb_link}} {{imdb_link}}",
+            &vars,
+        );
+        assert_eq!(
+            rendered,
+            "Movie (2024) WEB-DL 1080p by GROUP via stremthru/realdebrid — https://www.themoviedb.org/movie/456 https://www.imdb.com/title/tt123"
+        );
+    }
+
+    #[test]
+    fn missing_optional_variables_render_as_empty_not_left_as_placeholders() {
+        let mut data = payload();
+        data.tmdb_id = None;
+        data.imdb_id = None;
+        data.release_group = None;
+        let vars = template_variables(&data);
+        let rendered = render_template("[{{tmdb_link}}][{{imdb_link}}][{{release_group}}]", &vars);
+        assert_eq!(rendered, "[][][]");
+    }
+
+    #[test]
+    fn tmdb_link_uses_tv_path_for_non_movie_items() {
+        let mut data = payload();
+        data.item_type = MediaItemType::Episode;
+        data.season = Some(1);
+        data.episode = Some(3);
+        data.episode_title = Some("Pilot".to_string());
+        let vars = template_variables(&data);
+        let rendered = render_template(
+            "{{title}} S{{season}}E{{episode}} {{episode_title}} {{tmdb_link}}",
+            &vars,
+        );
+        assert_eq!(
+            rendered,
+            "Movie S1E3 Pilot https://www.themoviedb.org/tv/456"
+        );
+    }
+
+    #[test]
+    fn movie_and_show_item_types_select_the_right_category() {
+        assert!(matches!(
+            template_category(MediaItemType::Movie),
+            TemplateCategory::Movie
+        ));
+        for item_type in [
+            MediaItemType::Show,
+            MediaItemType::Season,
+            MediaItemType::Episode,
+        ] {
+            assert!(matches!(
+                template_category(item_type),
+                TemplateCategory::Show
+            ));
+        }
+    }
+}

--- a/crates/plugin-notifications/src/templates.rs
+++ b/crates/plugin-notifications/src/templates.rs
@@ -20,6 +20,24 @@ pub(crate) fn template_category(item_type: MediaItemType) -> TemplateCategory {
     }
 }
 
+/// The plugin-setting keys for a category: (use custom template, title, body).
+pub(crate) fn template_keys(
+    category: TemplateCategory,
+) -> (&'static str, &'static str, &'static str) {
+    match category {
+        TemplateCategory::Movie => (
+            "movie_use_custom_template",
+            "movie_title_template",
+            "movie_body_template",
+        ),
+        TemplateCategory::Show => (
+            "show_use_custom_template",
+            "show_title_template",
+            "show_body_template",
+        ),
+    }
+}
+
 /// Build the `{{variable}}` → value map for a payload. Every variable listed
 /// in the plugin's settings schema has an entry here, even when the
 /// underlying field is absent — those substitute to an empty string rather

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -19,6 +19,12 @@ fn payload() -> NotificationPayload {
         rating: Some(8.25),
         overview: Some("Short overview".to_string()),
         tvdb_slug: None,
+        resolution: Some("1080p".to_string()),
+        quality: Some("WEB-DL".to_string()),
+        release_group: Some("GROUP".to_string()),
+        season: None,
+        episode: None,
+        episode_title: None,
     }
 }
 

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -119,3 +119,38 @@ fn simple_embed_contains_core_download_fields() {
             .any(|field| field["name"] == "Provider" && field["value"] == "realdebrid")
     );
 }
+
+#[test]
+fn truncate_chars_is_a_no_op_at_or_under_the_limit() {
+    assert_eq!(truncate_chars("hello", 5), "hello");
+    assert_eq!(truncate_chars("hello", 10), "hello");
+}
+
+#[test]
+fn truncate_chars_shortens_and_marks_anything_over_the_limit() {
+    let truncated = truncate_chars("hello world", 5);
+    assert_eq!(truncated.chars().count(), 5);
+    assert!(truncated.starts_with("hell"));
+    assert!(truncated.ends_with('…'));
+}
+
+#[test]
+fn truncate_chars_counts_chars_not_bytes_so_multi_byte_text_is_not_split_mid_character() {
+    // Each "é" is 2 UTF-8 bytes; a byte-index truncation at 5 would split one
+    // in half and produce invalid UTF-8 (or panic). char-based truncation
+    // must not.
+    let truncated = truncate_chars("ééééé", 3);
+    assert_eq!(truncated.chars().count(), 3);
+    assert!(truncated.ends_with('…'));
+}
+
+#[test]
+fn custom_embed_truncates_title_and_description_to_discords_limits() {
+    let long_title = "T".repeat(300);
+    let long_body = "B".repeat(5000);
+    let embed =
+        build_custom_embed(&payload(), Some(&long_title), Some(&long_body))["embeds"][0].clone();
+
+    assert_eq!(embed["title"].as_str().unwrap().chars().count(), 256);
+    assert_eq!(embed["description"].as_str().unwrap().chars().count(), 4096);
+}

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -65,6 +65,12 @@ fn notification_url_parser_supports_pushbullet() {
 }
 
 #[test]
+fn notification_url_parser_rejects_pushbullet_urls_with_no_token() {
+    assert!(parse_notification_url("pbul://").is_none());
+    assert!(parse_notification_url("pbul:///some-device-id").is_none());
+}
+
+#[test]
 fn pushbullet_body_condenses_the_core_fields_into_one_line() {
     let body = build_pushbullet_body(&payload());
     assert_eq!(

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -46,6 +46,34 @@ fn notification_url_parser_supports_discord_and_json_aliases() {
 }
 
 #[test]
+fn notification_url_parser_supports_pushbullet() {
+    match parse_notification_url("pbul://o.abc123token") {
+        Some(NotificationService::Pushbullet { access_token }) => {
+            assert_eq!(access_token, "o.abc123token");
+        }
+        _ => panic!("expected pushbullet URL"),
+    }
+
+    // A device/channel/email target (Apprise's `pbul://token/#channel` etc.)
+    // isn't supported, but must not be folded into the token itself.
+    match parse_notification_url("pbul://o.abc123token/some-device-id") {
+        Some(NotificationService::Pushbullet { access_token }) => {
+            assert_eq!(access_token, "o.abc123token");
+        }
+        _ => panic!("expected pushbullet URL"),
+    }
+}
+
+#[test]
+fn pushbullet_body_condenses_the_core_fields_into_one_line() {
+    let body = build_pushbullet_body(&payload());
+    assert_eq!(
+        body,
+        "Movie • 2024 • via stremthru • realdebrid • in 1h 1m 1s"
+    );
+}
+
+#[test]
 fn duration_formatter_uses_human_units() {
     assert_eq!(format_duration(12.4), "12.4s");
     assert_eq!(format_duration(125.0), "2m 5s");

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -54,9 +54,8 @@ fn notification_url_parser_supports_pushbullet() {
         _ => panic!("expected pushbullet URL"),
     }
 
-    // A device/channel/email target (Apprise's `pbul://token/#channel` etc.)
-    // isn't supported, but must not be folded into the token itself.
-    match parse_notification_url("pbul://o.abc123token/some-device-id") {
+    // A trailing slash with nothing after it is still a plain-token URL.
+    match parse_notification_url("pbul://o.abc123token/") {
         Some(NotificationService::Pushbullet { access_token }) => {
             assert_eq!(access_token, "o.abc123token");
         }
@@ -68,6 +67,18 @@ fn notification_url_parser_supports_pushbullet() {
 fn notification_url_parser_rejects_pushbullet_urls_with_no_token() {
     assert!(parse_notification_url("pbul://").is_none());
     assert!(parse_notification_url("pbul:///some-device-id").is_none());
+}
+
+#[test]
+fn notification_url_parser_rejects_pushbullet_urls_with_a_target() {
+    // A device/channel/email target (Apprise's `pbul://token/#channel`,
+    // `.../DEVICE_ID`, `.../email@address`) isn't supported. send_pushbullet
+    // never sends a target parameter, and Pushbullet broadcasts to every
+    // device on the account when none is set — so a target must be rejected
+    // outright rather than silently dropped, which would otherwise leak the
+    // notification to devices the user meant to exclude.
+    assert!(parse_notification_url("pbul://o.abc123token/some-device-id").is_none());
+    assert!(parse_notification_url("pbul://o.abc123token/#a-channel").is_none());
 }
 
 #[test]

--- a/crates/riven-api/src/schema.rs
+++ b/crates/riven-api/src/schema.rs
@@ -152,6 +152,7 @@ mod tests {
         ("updateRankSettings", "ManageSettings"),
         ("updateAllSettings", "ManageSettings"),
         ("updateSettings", "ManageSettings"),
+        ("sendTestNotification", "ManageSettings"),
         ("completeInitialSetup", "ManageSettings"),
         ("rematchFilesystemLibraryProfiles", "ManageSettings"),
         ("indexMovie", "ManageSettings"),

--- a/crates/riven-api/src/schema/mutations/settings.rs
+++ b/crates/riven-api/src/schema/mutations/settings.rs
@@ -184,7 +184,7 @@ impl SettingsMutations {
 
     /// Send a notification built from placeholder data, so a custom
     /// notification template can be previewed without waiting for a real
-    /// download. `item_type: Movie` previews the movie template; anything
+    /// download. `itemType: MOVIE` previews the movie template; anything
     /// else previews the show template as a single test episode.
     async fn send_test_notification(
         &self,

--- a/crates/riven-api/src/schema/mutations/settings.rs
+++ b/crates/riven-api/src/schema/mutations/settings.rs
@@ -1,5 +1,6 @@
 use async_graphql::*;
 use riven_core::downloader::DownloaderConfig;
+use riven_core::events::RivenEvent;
 use riven_core::logging::{LogControl, LogSettings};
 use riven_core::plugin::PluginRegistry;
 use riven_core::settings::FilesystemSettings;
@@ -178,6 +179,29 @@ impl SettingsMutations {
             apply_plugin_settings(ctx, &section, values).await?;
             let registry = ctx.data::<Arc<PluginRegistry>>()?;
             build_plugin_section(registry, &section).await
+        }
+    }
+
+    /// Send a notification built from placeholder data, so a custom
+    /// notification template can be previewed without waiting for a real
+    /// download. `item_type: Movie` previews the movie template; anything
+    /// else previews the show template as a single test episode.
+    async fn send_test_notification(
+        &self,
+        ctx: &Context<'_>,
+        item_type: riven_core::types::MediaItemType,
+    ) -> Result<bool> {
+        require_settings_access(ctx)?;
+        let registry = ctx.data::<Arc<PluginRegistry>>()?;
+        let event = RivenEvent::NotificationTestRequested { item_type };
+        match registry.dispatch_to_plugin("notifications", &event).await {
+            Some(Ok(_)) => Ok(true),
+            Some(Err(error)) => Err(Error::new(format!(
+                "failed to send test notification: {error}"
+            ))),
+            None => Err(Error::new(
+                "the notifications plugin isn't enabled, or its webhook URLs aren't configured",
+            )),
         }
     }
 

--- a/crates/riven-core/src/events/event.rs
+++ b/crates/riven-core/src/events/event.rs
@@ -190,6 +190,13 @@ pub enum RivenEvent {
         server: String,
         reference: String,
     },
+    /// Send a notification built from placeholder data so a custom template
+    /// can be previewed without waiting for a real download. `item_type`
+    /// picks which category's templates apply — `Movie` for the movie
+    /// templates, anything else for the show templates (mirroring
+    /// `plugin_notifications`'s own movie/show split).
+    #[serde(rename = "riven.notifications.test-requested")]
+    NotificationTestRequested { item_type: MediaItemType },
 }
 
 impl RivenEvent {
@@ -264,6 +271,7 @@ impl RivenEvent {
             Self::DebridUserInfoRequested => EventType::DebridUserInfoRequested,
             Self::ActivePlaybackSessionsRequested => EventType::ActivePlaybackSessionsRequested,
             Self::ArtworkRequested { .. } => EventType::ArtworkRequested,
+            Self::NotificationTestRequested { .. } => EventType::NotificationTestRequested,
         }
     }
 }

--- a/crates/riven-core/src/events/kind.rs
+++ b/crates/riven-core/src/events/kind.rs
@@ -74,6 +74,8 @@ pub enum EventType {
     ActivePlaybackSessionsRequested,
     #[serde(rename = "riven.media-server.artwork.requested")]
     ArtworkRequested,
+    #[serde(rename = "riven.notifications.test-requested")]
+    NotificationTestRequested,
 }
 
 impl EventType {
@@ -119,6 +121,7 @@ impl EventType {
             Self::DebridUserInfoRequested => "riven.debrid.user-info.requested",
             Self::ActivePlaybackSessionsRequested => "riven.media-server.active-sessions.requested",
             Self::ArtworkRequested => "riven.media-server.artwork.requested",
+            Self::NotificationTestRequested => "riven.notifications.test-requested",
         }
     }
 
@@ -176,7 +179,10 @@ impl EventType {
             | Self::DebridUserInfoRequested
             // Serves one browser request; the caller needs the bytes back, so
             // it cannot be queued.
-            | Self::ArtworkRequested => Inline,
+            | Self::ArtworkRequested
+            // The GraphQL mutation needs the send result in-process to
+            // report success/failure back to the caller.
+            | Self::NotificationTestRequested => Inline,
 
             Self::MediaItemScrapeRequested | Self::MediaItemIndexRequested
             | Self::ContentServiceRequested => FanIn,
@@ -237,6 +243,7 @@ mod tests {
             DebridUserInfoRequested,
             ActivePlaybackSessionsRequested,
             ArtworkRequested,
+            NotificationTestRequested,
         ];
         for variant in all {
             match variant {
@@ -265,7 +272,8 @@ mod tests {
                 | MediaItemsDeleted
                 | DebridUserInfoRequested
                 | ActivePlaybackSessionsRequested
-                | ArtworkRequested => {}
+                | ArtworkRequested
+                | NotificationTestRequested => {}
             }
         }
         all.to_vec()

--- a/crates/riven-core/src/http/profiles.rs
+++ b/crates/riven-core/src/http/profiles.rs
@@ -49,4 +49,7 @@ impl HttpServiceProfile {
 
 pub const DISCORD_WEBHOOK: HttpServiceProfile = HttpServiceProfile::new("discord_webhook");
 pub const WEBHOOK_JSON: HttpServiceProfile = HttpServiceProfile::new("json_webhook");
-pub const PUSHBULLET: HttpServiceProfile = HttpServiceProfile::new("pushbullet");
+// Single attempt: retrying a push on an ambiguous transport failure (e.g. a
+// timeout after the request already reached Pushbullet) risks delivering the
+// same "download complete" notification twice.
+pub const PUSHBULLET: HttpServiceProfile = HttpServiceProfile::new("pushbullet").with_attempts(1);

--- a/crates/riven-core/src/http/profiles.rs
+++ b/crates/riven-core/src/http/profiles.rs
@@ -49,3 +49,4 @@ impl HttpServiceProfile {
 
 pub const DISCORD_WEBHOOK: HttpServiceProfile = HttpServiceProfile::new("discord_webhook");
 pub const WEBHOOK_JSON: HttpServiceProfile = HttpServiceProfile::new("json_webhook");
+pub const PUSHBULLET: HttpServiceProfile = HttpServiceProfile::new("pushbullet");

--- a/crates/riven-core/src/plugin/traits.rs
+++ b/crates/riven-core/src/plugin/traits.rs
@@ -186,6 +186,18 @@ pub trait Plugin: Send + Sync + 'static {
         Ok(HookResponse::Empty)
     }
 
+    /// Send a notification built from placeholder data, so a plugin that
+    /// supports custom templates (currently only `notifications`) can let a
+    /// user preview one without waiting for a real download. The default is
+    /// `Empty`, so any other plugin simply declines.
+    async fn on_notification_test_requested(
+        &self,
+        _item_type: MediaItemType,
+        _ctx: &PluginContext,
+    ) -> anyhow::Result<HookResponse> {
+        Ok(HookResponse::Empty)
+    }
+
     /// Default dispatcher — do not override. Routes a `RivenEvent` to the matching `on_*` hook.
     async fn handle_event(
         &self,
@@ -319,6 +331,9 @@ pub trait Plugin: Send + Sync + 'static {
             }
             RivenEvent::ArtworkRequested { server, reference } => {
                 self.on_artwork_requested(server, reference, ctx).await
+            }
+            RivenEvent::NotificationTestRequested { item_type } => {
+                self.on_notification_test_requested(*item_type, ctx).await
             }
         }
     }

--- a/crates/riven-db/src/repo/streams.rs
+++ b/crates/riven-db/src/repo/streams.rs
@@ -521,6 +521,41 @@ pub async fn get_media_entry_by_id(entry_id: i64) -> Result<Option<FileSystemEnt
         .await?)
 }
 
+#[derive(Debug, Clone, FromQueryResult)]
+pub struct DownloadReleaseInfo {
+    pub resolution: Option<String>,
+    pub quality: Option<String>,
+    pub release_group: Option<String>,
+}
+
+/// The resolution/quality/release-group of the release behind the most
+/// recently created filesystem entry for an item — i.e. the one a
+/// `MediaItemDownloadSuccess` event for this item just fired for. Used by
+/// notification templates. `quality`/`release_group` come from the linked
+/// stream's parsed release data via a jsonb lookup the query builder can't
+/// express; `None` if the item has no filesystem entries yet, or its stream
+/// row is missing (usenet entries may have no `stream_id`).
+pub async fn get_latest_release_info(item_id: i64) -> Result<Option<DownloadReleaseInfo>> {
+    let sql = r#"SELECT
+               fe.resolution AS resolution,
+               s.parsed_data->>'quality' AS quality,
+               s.parsed_data->>'group' AS release_group
+           FROM filesystem_entries fe
+           LEFT JOIN streams s ON s.id = fe.stream_id
+           WHERE fe.media_item_id = $1 AND fe.entry_type = 'media'
+           ORDER BY fe.created_at DESC
+           LIMIT 1"#;
+    Ok(
+        DownloadReleaseInfo::find_by_statement(Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            sql,
+            [item_id.into()],
+        ))
+        .one(orm())
+        .await?,
+    )
+}
+
 /// Return the most likely next playback target for episodic content.
 /// Movies and non-episodic items return `None`.
 pub async fn get_next_playback_entry(entry_id: i64) -> Result<Option<FileSystemEntry>> {

--- a/frontend/src/lib/components/settings/operations.ts
+++ b/frontend/src/lib/components/settings/operations.ts
@@ -22,6 +22,12 @@ export const UPDATE_SETTINGS = `
     }
 `;
 
+export const SEND_TEST_NOTIFICATION = `
+    mutation SendTestNotification($itemType: MediaItemType!) {
+        sendTestNotification(itemType: $itemType)
+    }
+`;
+
 export const INSTANCE_STATUS = `
     query {
         instanceStatus {

--- a/frontend/src/lib/components/settings/plugins-tab.svelte
+++ b/frontend/src/lib/components/settings/plugins-tab.svelte
@@ -35,11 +35,16 @@
     };
     let testing = $state<Record<string, boolean>>({});
 
+    // Saves the plugin's current draft values before dispatching the test —
+    // otherwise a template edited but not yet saved would test against the
+    // stale, previously-persisted template instead of what's on screen,
+    // silently misleading whoever is trying to verify their edit.
     async function sendTestNotification(sectionTitle: string) {
         const itemType = TESTABLE_NOTIFICATION_SECTIONS[sectionTitle];
-        if (!itemType || testing[sectionTitle]) return;
+        if (!itemType || testing[sectionTitle] || saving || !selected) return;
         testing[sectionTitle] = true;
         try {
+            await save(selected);
             await gqlClient<{ sendTestNotification: boolean }>(SEND_TEST_NOTIFICATION, {
                 itemType
             });
@@ -140,7 +145,7 @@
                                     type="button"
                                     variant="outline"
                                     size="sm"
-                                    disabled={testing[group.title]}
+                                    disabled={testing[group.title] || saving}
                                     onclick={() => sendTestNotification(group.title)}>
                                     {testing[group.title] ? "Sending…" : "Send test notification"}
                                 </Button>

--- a/frontend/src/lib/components/settings/plugins-tab.svelte
+++ b/frontend/src/lib/components/settings/plugins-tab.svelte
@@ -3,7 +3,10 @@
     import { Button } from "$lib/components/ui/button/index.js";
     import { Separator } from "$lib/components/ui/separator/index.js";
     import SettingFieldEditor from "./setting-field-editor.svelte";
-    import { pluginStatus } from "./helpers";
+    import { pluginStatus, buildGeneralSections } from "./helpers";
+    import { gqlClient } from "$lib/graphql-client";
+    import { SEND_TEST_NOTIFICATION } from "./operations";
+    import { toast } from "svelte-sonner";
     import type { SettingsSection, SetupGroup } from "./types";
 
     let {
@@ -19,6 +22,36 @@
     let selectedId = $state<string | null>(null);
     let saving = $state(false);
     const selected = $derived(sections.find((s) => s.id === selectedId) ?? sections[0] ?? null);
+    const groupedSchema = $derived(buildGeneralSections(selected?.schema ?? []));
+
+    // The notifications plugin's movie/show template sections each get an
+    // inline "send a test notification" action so a template can be
+    // previewed without waiting for a real download. Keyed by section title
+    // rather than a boolean per category, since a plugin could in principle
+    // have more than two testable sections later.
+    const TESTABLE_NOTIFICATION_SECTIONS: Record<string, "MOVIE" | "EPISODE"> = {
+        "Movie notifications": "MOVIE",
+        "Show notifications": "EPISODE"
+    };
+    let testing = $state<Record<string, boolean>>({});
+
+    async function sendTestNotification(sectionTitle: string) {
+        const itemType = TESTABLE_NOTIFICATION_SECTIONS[sectionTitle];
+        if (!itemType || testing[sectionTitle]) return;
+        testing[sectionTitle] = true;
+        try {
+            await gqlClient<{ sendTestNotification: boolean }>(SEND_TEST_NOTIFICATION, {
+                itemType
+            });
+            toast.success(`Test ${itemType === "MOVIE" ? "movie" : "show"} notification sent`);
+        } catch (error) {
+            toast.error(
+                error instanceof Error ? error.message : "Failed to send test notification"
+            );
+        } finally {
+            testing[sectionTitle] = false;
+        }
+    }
 
     // Group plugins by their backend category, in the backend-defined group
     // order (media → sources → services), each sorted by name. Anything with an
@@ -93,9 +126,26 @@
                     {/if}
                 </div>
 
-                <div class="space-y-4">
-                    {#each selected.schema as field (field.key)}
-                        <SettingFieldEditor {field} bind:value={selected.values[field.key]} />
+                <div class="space-y-8">
+                    {#each groupedSchema as group, i (group.title || `__default-${i}`)}
+                        <section class="space-y-4">
+                            {#if group.title}
+                                <h3 class="text-base font-semibold tracking-tight">{group.title}</h3>
+                            {/if}
+                            {#each group.fields as field (field.key)}
+                                <SettingFieldEditor {field} bind:value={selected.values[field.key]} />
+                            {/each}
+                            {#if group.title in TESTABLE_NOTIFICATION_SECTIONS}
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={testing[group.title]}
+                                    onclick={() => sendTestNotification(group.title)}>
+                                    {testing[group.title] ? "Sending…" : "Send test notification"}
+                                </Button>
+                            {/if}
+                        </section>
                     {/each}
                 </div>
 

--- a/frontend/src/lib/components/settings/plugins-tab.svelte
+++ b/frontend/src/lib/components/settings/plugins-tab.svelte
@@ -31,7 +31,7 @@
     // have more than two testable sections later.
     const TESTABLE_NOTIFICATION_SECTIONS: Record<string, "MOVIE" | "EPISODE"> = {
         "Movie notifications": "MOVIE",
-        "Show notifications": "EPISODE"
+        "TV show notifications": "EPISODE"
     };
     let testing = $state<Record<string, boolean>>({});
 

--- a/frontend/src/lib/gql/schema.ts
+++ b/frontend/src/lib/gql/schema.ts
@@ -1047,6 +1047,13 @@ export type MutationRoot = {
    */
   seerrHandleWebhook: Scalars['Boolean']['output'];
   /**
+   * Send a notification built from placeholder data, so a custom
+   * notification template can be previewed without waiting for a real
+   * download. `item_type: Movie` previews the movie template; anything
+   * else previews the show template as a single test episode.
+   */
+  sendTestNotification: Scalars['Boolean']['output'];
+  /**
    * Enable or disable a ranking profile (built-in or custom) by name.
    * Enabled profiles are used for multi-version scraping and downloading.
    */
@@ -1229,6 +1236,11 @@ export type MutationRootScrapeMediaItemArgs = {
 
 export type MutationRootSeerrHandleWebhookArgs = {
   payload: Scalars['JSON']['input'];
+};
+
+
+export type MutationRootSendTestNotificationArgs = {
+  itemType: MediaItemType;
 };
 
 

--- a/frontend/src/lib/gql/schema.ts
+++ b/frontend/src/lib/gql/schema.ts
@@ -1049,7 +1049,7 @@ export type MutationRoot = {
   /**
    * Send a notification built from placeholder data, so a custom
    * notification template can be previewed without waiting for a real
-   * download. `item_type: Movie` previews the movie template; anything
+   * download. `itemType: MOVIE` previews the movie template; anything
    * else previews the show template as a single test episode.
    */
   sendTestNotification: Scalars['Boolean']['output'];

--- a/schema.graphql
+++ b/schema.graphql
@@ -1064,6 +1064,13 @@ type MutationRoot {
 	"""
 	updateSettings(section: String!, values: JSON!): SettingsSection!
 	"""
+	Send a notification built from placeholder data, so a custom
+	notification template can be previewed without waiting for a real
+	download. `item_type: Movie` previews the movie template; anything
+	else previews the show template as a single test episode.
+	"""
+	sendTestNotification(itemType: MediaItemType!): Boolean!
+	"""
 	Recompute stored library-profile matches for every existing media entry.
 	"""
 	rematchFilesystemLibraryProfiles: Int!

--- a/schema.graphql
+++ b/schema.graphql
@@ -1066,7 +1066,7 @@ type MutationRoot {
 	"""
 	Send a notification built from placeholder data, so a custom
 	notification template can be previewed without waiting for a real
-	download. `item_type: Movie` previews the movie template; anything
+	download. `itemType: MOVIE` previews the movie template; anything
 	else previews the show template as a single test episode.
 	"""
 	sendTestNotification(itemType: MediaItemType!): Boolean!


### PR DESCRIPTION
Stacked on #31 (Pushbullet support) — this PR's diff will shrink to just the template changes once that merges.

## Summary
- Adds a custom title/body template per notification category (movie, show — the latter covering show/season/episode completions), each with a "use custom template" toggle that's off by default. The toggle is separate from the template text fields so a template can be drafted without taking effect until switched on.
- Plain `{{variable}}` substitution, no conditionals. Available everywhere: `title`, `year`, `quality`, `resolution`, `release_group`, `downloader`, `provider`, `rating`, `overview`, `poster`, `duration`, `tmdb_link`, `imdb_link`. Show templates only: `season`, `episode`, `episode_title`, `tvdb_link` — empty for a season/show-level completion rather than a single episode. A variable with no value renders as an empty string.
- `quality`/`resolution`/`release_group` weren't tracked anywhere on the download-success path before. Rather than threading them through the event schema and all four persist call sites, this adds `repo::get_latest_release_info(item_id)` — a join from the just-created `filesystem_entries` row to its stream's `parsed_data`, mirroring the existing `get_media_item_hierarchy` raw-SQL pattern. `season`/`episode`/`episode_title` come from the `MediaItem` row already being fetched for request-root rewriting, extended to carry those fields through that same rewrite — so a fully-completed show/season correctly reports empty season/episode rather than whichever episode happened to finish last.
- Discord: a custom template renders as the embed's title + description; color, poster thumbnail, and timestamp are kept, but the auto-generated fields (rating, links, etc.) are replaced entirely. Pushbullet: rendered title/body sent directly. The generic JSON webhook target is unaffected — it already receives every field as structured data, template-agnostic by design.
- **New**: a `sendTestNotification(itemType: MediaItemType!)` mutation, so a template can be verified without waiting for (or forcing) a real download. It sends a notification built from placeholder data ("Test Movie", or "Test Show" S1E1 "Test Episode") through the exact same rendering/dispatch path as a real download success. Routed as a new `NotificationTestRequested` event dispatched in-process via `PluginRegistry::dispatch_to_plugin`, rather than a direct `riven-api` → `plugin-notifications` dependency, keeping the existing plugin-agnostic boundary intact (`riven-api` only ever talks to plugins through the trait-based registry).

## Test plan
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `pnpm run check`, `pnpm run lint` all pass. `schema.graphql` and the frontend's generated GraphQL types are regenerated and committed.
- New unit tests in `templates.rs`: variable substitution + external-link building, missing-optional-variable handling, movie-vs-show `tmdb_link` path selection, category selection for all four item types.
- **Live-verified end to end**, using the new test-notification mutation against a real Pushbullet account:
  - Movie category with a custom template on (`New grab: {{title}} ({{year}})` / `{{quality}} {{resolution}} • Group: {{release_group}} • via {{downloader}} ({{provider}}) • {{tmdb_link}}`) — arrived correctly rendered.
  - Show category with the toggle off — arrived using the default layout, confirming the fallback path.
  - Show category with a custom template on (`New episode: {{title}} S{{season}}E{{episode}}` / `{{episode_title}} • {{quality}} {{resolution}} • Group: {{release_group}} • {{tvdb_link}}`) — arrived correctly rendered, confirming show-only variables (season/episode/episode_title/tvdb_link) all populate correctly for the placeholder test episode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added customizable notification titles and message templates with placeholders for movies and TV shows.
  - Added Pushbullet support, including device targeting and plain-text notifications.
  - Discord notifications now support custom embeds.
  - Added test notification buttons in plugin settings with movie or show previews.
  - Download notifications now include resolution, quality, release group, season, episode, and episode title details.

- **Bug Fixes**
  - Improved protection against exposing credentials in notification logs.
  - Invalid Pushbullet URLs and empty access tokens are now rejected safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->