### PR TITLE
fix: reconcile scheduled reindex jobs against the DB on startup and every sweep

### DIFF
--- a/crates/riven-core/src/reindex.rs
+++ b/crates/riven-core/src/reindex.rs
@@ -3,6 +3,7 @@
 pub struct ReindexConfig {
     pub schedule_offset_minutes: u64,
     pub unknown_air_date_offset_days: u64,
+    pub reconcile_scheduled_reindexes: bool,
 }
 
 impl From<&crate::settings::RivenSettings> for ReindexConfig {
@@ -10,6 +11,7 @@ impl From<&crate::settings::RivenSettings> for ReindexConfig {
         Self {
             schedule_offset_minutes: s.schedule_offset_minutes,
             unknown_air_date_offset_days: s.unknown_air_date_offset_days,
+            reconcile_scheduled_reindexes: s.reconcile_scheduled_reindexes,
         }
     }
 }

--- a/crates/riven-core/src/settings/app.rs
+++ b/crates/riven-core/src/settings/app.rs
@@ -52,6 +52,15 @@ pub struct RivenSettings {
     pub schedule_offset_minutes: u64,
     /// Fallback delay when an unreleased/ongoing item has no known future air date.
     pub unknown_air_date_offset_days: u64,
+    /// When true (default), reconcile the index queue's scheduled-reindex
+    /// entries against the database on startup and on every retry-library
+    /// tick: a continuing show or unreleased item that should have a pending
+    /// reindex scheduled but doesn't (its Redis entry was lost — a restart
+    /// without persistence, an eviction, a bug) gets a fresh one scheduled
+    /// rather than silently never being rechecked again. Set to false to
+    /// disable if this sweep ever needs to be ruled out as a cause of
+    /// unexpected load.
+    pub reconcile_scheduled_reindexes: bool,
 
     /// Bearer token / API key required on the GraphQL endpoint.
     /// Empty string means no authentication is enforced.
@@ -111,6 +120,7 @@ impl Default for RivenSettings {
             maximum_scrape_attempts: 0,
             schedule_offset_minutes: 30,
             unknown_air_date_offset_days: 7,
+            reconcile_scheduled_reindexes: true,
             api_key: String::new(),
             public_url: String::new(),
             cors_allowed_origins: String::new(),

--- a/crates/riven-db/src/repo/media.rs
+++ b/crates/riven-db/src/repo/media.rs
@@ -234,23 +234,29 @@ pub async fn get_ongoing_container_ids() -> Result<Vec<i64>> {
         .await?)
 }
 
-/// IDs of every item that should currently have a pending scheduled reindex
-/// — a continuing show, or any non-show item still `Unreleased` — mirroring
-/// `MainOrchestrator::handle_index_success`'s own `needs_reindex` predicate
-/// (the show branch's "has a known next air date" half is intentionally
-/// dropped here: an ended show can't have one, and a continuing show is
-/// already covered, so the `show_status` check alone is equivalent for this
-/// purpose). Used to detect a scheduled-reindex job that Redis lost — e.g. a
-/// restart without persistence — so it can be recreated instead of the item
-/// silently never being rechecked again.
-pub async fn get_items_needing_scheduled_reindex() -> Result<Vec<i64>> {
+/// IDs of every item that *might* need a pending scheduled reindex — a
+/// deliberately loose superset, not the precise predicate. It's the SQL-cheap
+/// half of the check: any non-`Ended` show (`show_status` is `Continuing`,
+/// or `NULL` on a not-yet-fully-indexed row — only an explicitly `Ended` show
+/// can be safely excluded, since it can never have a future air date either
+/// way), plus any non-show item still `Unreleased`. Whether a candidate
+/// *actually* needs one — in particular a non-`Continuing` show's "has a
+/// known next air date" case — depends on a query keyed by show id
+/// (`get_next_unreleased_air_date_for_show`), so callers must still apply
+/// `MainOrchestrator`'s real `needs_reindex` predicate per candidate; this
+/// only narrows the table scan down to the plausible set first.
+pub async fn get_reindex_schedule_candidates() -> Result<Vec<i64>> {
     Ok(media_items::Entity::find()
         .filter(
             Condition::any()
                 .add(
                     Condition::all()
                         .add(media_items::Column::ItemType.eq(MediaItemType::Show))
-                        .add(media_items::Column::ShowStatus.eq(ShowStatus::Continuing)),
+                        .add(
+                            Condition::any()
+                                .add(media_items::Column::ShowStatus.is_null())
+                                .add(media_items::Column::ShowStatus.ne(ShowStatus::Ended)),
+                        ),
                 )
                 .add(
                     Condition::all()

--- a/crates/riven-db/src/repo/media.rs
+++ b/crates/riven-db/src/repo/media.rs
@@ -234,6 +234,37 @@ pub async fn get_ongoing_container_ids() -> Result<Vec<i64>> {
         .await?)
 }
 
+/// IDs of every item that should currently have a pending scheduled reindex
+/// — a continuing show, or any non-show item still `Unreleased` — mirroring
+/// `MainOrchestrator::handle_index_success`'s own `needs_reindex` predicate
+/// (the show branch's "has a known next air date" half is intentionally
+/// dropped here: an ended show can't have one, and a continuing show is
+/// already covered, so the `show_status` check alone is equivalent for this
+/// purpose). Used to detect a scheduled-reindex job that Redis lost — e.g. a
+/// restart without persistence — so it can be recreated instead of the item
+/// silently never being rechecked again.
+pub async fn get_items_needing_scheduled_reindex() -> Result<Vec<i64>> {
+    Ok(media_items::Entity::find()
+        .filter(
+            Condition::any()
+                .add(
+                    Condition::all()
+                        .add(media_items::Column::ItemType.eq(MediaItemType::Show))
+                        .add(media_items::Column::ShowStatus.eq(ShowStatus::Continuing)),
+                )
+                .add(
+                    Condition::all()
+                        .add(media_items::Column::ItemType.ne(MediaItemType::Show))
+                        .add(media_items::Column::State.eq(MediaItemState::Unreleased)),
+                ),
+        )
+        .select_only()
+        .column(media_items::Column::Id)
+        .into_tuple::<i64>()
+        .all(orm())
+        .await?)
+}
+
 /// Return the earliest requested unreleased descendant air date for a show.
 pub async fn get_next_unreleased_air_date_for_show(
     show_id: i64,

--- a/crates/riven-queue/src/main_orchestrator.rs
+++ b/crates/riven-queue/src/main_orchestrator.rs
@@ -24,6 +24,17 @@ use crate::context;
 use crate::lifecycle::{LibraryOrchestrator, sync_item_request_state};
 use crate::{IndexJob, JobQueue, ProcessMediaItemJob, ProcessStep, scheduled_index_task_id};
 
+/// Outcome of [`MainOrchestrator::needs_reindex`]'s eligibility check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReindexNeed {
+    Needed,
+    NotNeeded,
+    /// The eligibility lookup itself failed (e.g. a DB error) — callers must
+    /// not treat this as `NotNeeded`, since that would tear down a
+    /// legitimately scheduled job over a transient failure.
+    Unknown,
+}
+
 /// Owns the queue and dispatches events to typed actor calls.
 pub struct MainOrchestrator {
     queue: Arc<JobQueue>,
@@ -157,10 +168,13 @@ impl MainOrchestrator {
         };
         sync_item_request_state(&item).await;
 
-        if self.needs_reindex(&item).await {
-            self.schedule_reindex(&item).await;
-        } else {
-            self.queue.clear_scheduled_index(item.id).await;
+        match self.needs_reindex(&item).await {
+            ReindexNeed::Needed => self.schedule_reindex(&item).await,
+            ReindexNeed::NotNeeded => self.queue.clear_scheduled_index(item.id).await,
+            // Lookup failed — leave whatever schedule already exists alone
+            // rather than guessing; we'll get another chance at the next
+            // index or reconcile pass.
+            ReindexNeed::Unknown => {}
         }
         if item.state != MediaItemState::Unreleased && item.is_requested {
             self.process_media_item(&item).await;
@@ -174,17 +188,37 @@ impl MainOrchestrator {
     /// `handle_index_success` (decides right after a fresh index) and
     /// `reconcile_scheduled_reindexes` (checks Redis still has what it
     /// should) so the two can never drift apart.
-    async fn needs_reindex(&self, item: &MediaItem) -> bool {
+    ///
+    /// Returns `Unknown` rather than collapsing a failed eligibility lookup
+    /// to `NotNeeded` — a transient DB error must never look like "this show
+    /// has no upcoming episode" and cause an existing schedule to be torn
+    /// down.
+    async fn needs_reindex(&self, item: &MediaItem) -> ReindexNeed {
         match item.item_type {
             MediaItemType::Show => {
-                item.show_status == Some(ShowStatus::Continuing)
-                    || repo::get_next_unreleased_air_date_for_show(item.id)
-                        .await
-                        .ok()
-                        .flatten()
-                        .is_some()
+                if item.show_status == Some(ShowStatus::Continuing) {
+                    return ReindexNeed::Needed;
+                }
+                match repo::get_next_unreleased_air_date_for_show(item.id).await {
+                    Ok(Some(_)) => ReindexNeed::Needed,
+                    Ok(None) => ReindexNeed::NotNeeded,
+                    Err(error) => {
+                        tracing::error!(
+                            %error,
+                            item_id = item.id,
+                            "could not look up next air date; leaving its scheduled reindex as-is"
+                        );
+                        ReindexNeed::Unknown
+                    }
+                }
             }
-            _ => item.state == MediaItemState::Unreleased,
+            _ => {
+                if item.state == MediaItemState::Unreleased {
+                    ReindexNeed::Needed
+                } else {
+                    ReindexNeed::NotNeeded
+                }
+            }
         }
     }
 
@@ -352,7 +386,7 @@ impl MainOrchestrator {
             let Some(item) = self.load_item(id).await else {
                 continue;
             };
-            if self.needs_reindex(&item).await {
+            if matches!(self.needs_reindex(&item).await, ReindexNeed::Needed) {
                 self.schedule_reindex(&item).await;
                 rescheduled.push(id);
             }

--- a/crates/riven-queue/src/main_orchestrator.rs
+++ b/crates/riven-queue/src/main_orchestrator.rs
@@ -22,7 +22,7 @@ use tokio::sync::broadcast;
 use crate::application::process_media_item::{fan_out_to_children, push_requested_seasons};
 use crate::context;
 use crate::lifecycle::{LibraryOrchestrator, sync_item_request_state};
-use crate::{IndexJob, JobQueue, ProcessMediaItemJob, ProcessStep};
+use crate::{IndexJob, JobQueue, ProcessMediaItemJob, ProcessStep, scheduled_index_task_id};
 
 /// Owns the queue and dispatches events to typed actor calls.
 pub struct MainOrchestrator {
@@ -264,9 +264,91 @@ impl MainOrchestrator {
         schedule_datetime(target_date, offset_minutes, fallback_days)
     }
 
+    /// Recreates any scheduled-reindex entry the `index` queue's Redis-backed
+    /// schedule has lost — e.g. a restart without persistence, an eviction,
+    /// or a bug — but that Postgres still says should exist (a continuing
+    /// show, or an unreleased item). Without this, a lost schedule is
+    /// permanent: nothing else in the system would ever notice or recheck
+    /// that item again. Runs once at startup (the scheduler's first
+    /// `retry_library` tick) and on every subsequent tick, so a gap closes
+    /// within one sweep interval rather than persisting indefinitely.
+    /// Gated by `reconcile_scheduled_reindexes` (default on).
+    async fn reconcile_scheduled_reindexes(&self) {
+        if !self
+            .queue
+            .reindex_config
+            .read()
+            .await
+            .reconcile_scheduled_reindexes
+        {
+            return;
+        }
+
+        let candidate_ids = match repo::get_items_needing_scheduled_reindex().await {
+            Ok(ids) => ids,
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    "reconcile: could not list items needing a scheduled reindex, skipping this pass"
+                );
+                return;
+            }
+        };
+        if candidate_ids.is_empty() {
+            return;
+        }
+
+        let scheduled_set = self
+            .queue
+            .index_storage
+            .get_config()
+            .scheduled_jobs_set()
+            .to_string();
+        let mut conn = self.queue.redis.clone();
+        let existing: Vec<String> = match redis::cmd("ZRANGE")
+            .arg(&scheduled_set)
+            .arg(0)
+            .arg(-1)
+            .query_async(&mut conn)
+            .await
+        {
+            Ok(members) => members,
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    "reconcile: could not read the index queue's scheduled set, skipping this pass"
+                );
+                return;
+            }
+        };
+        let existing: std::collections::HashSet<String> = existing.into_iter().collect();
+
+        let missing: Vec<i64> = candidate_ids
+            .into_iter()
+            .filter(|id| !existing.contains(&scheduled_index_task_id(*id).to_string()))
+            .collect();
+        if missing.is_empty() {
+            return;
+        }
+
+        tracing::warn!(
+            count = missing.len(),
+            ids = ?missing,
+            "reconcile: found item(s) that should have a scheduled reindex but don't \
+             (likely a prior Redis restart/eviction) — rescheduling them now"
+        );
+        for id in missing {
+            if let Some(item) = self.load_item(id).await {
+                self.schedule_reindex(&item).await;
+            }
+        }
+    }
+
     /// Retry-library actor. Periodically called by the worker to nudge items
     /// stuck in retryable states.
     pub async fn retry_library(&self) {
+        self.reconcile_scheduled_reindexes().await;
+
         match repo::get_ongoing_container_ids().await {
             Ok(ids) => {
                 if let Err(error) = repo::force_recompute(&ids).await {

--- a/crates/riven-queue/src/main_orchestrator.rs
+++ b/crates/riven-queue/src/main_orchestrator.rs
@@ -157,7 +157,25 @@ impl MainOrchestrator {
         };
         sync_item_request_state(&item).await;
 
-        let needs_reindex = match item.item_type {
+        if self.needs_reindex(&item).await {
+            self.schedule_reindex(&item).await;
+        } else {
+            self.queue.clear_scheduled_index(item.id).await;
+        }
+        if item.state != MediaItemState::Unreleased && item.is_requested {
+            self.process_media_item(&item).await;
+        }
+    }
+
+    /// Whether `item` should have a pending scheduled reindex: a continuing
+    /// show, a show with a known next unreleased air date (covers a show
+    /// that hasn't settled into `Continuing` yet, e.g. right after its first
+    /// index), or any non-show item still `Unreleased`. Shared between
+    /// `handle_index_success` (decides right after a fresh index) and
+    /// `reconcile_scheduled_reindexes` (checks Redis still has what it
+    /// should) so the two can never drift apart.
+    async fn needs_reindex(&self, item: &MediaItem) -> bool {
+        match item.item_type {
             MediaItemType::Show => {
                 item.show_status == Some(ShowStatus::Continuing)
                     || repo::get_next_unreleased_air_date_for_show(item.id)
@@ -167,14 +185,6 @@ impl MainOrchestrator {
                         .is_some()
             }
             _ => item.state == MediaItemState::Unreleased,
-        };
-        if needs_reindex {
-            self.schedule_reindex(&item).await;
-        } else {
-            self.queue.clear_scheduled_index(item.id).await;
-        }
-        if item.state != MediaItemState::Unreleased && item.is_requested {
-            self.process_media_item(&item).await;
         }
     }
 
@@ -284,12 +294,12 @@ impl MainOrchestrator {
             return;
         }
 
-        let candidate_ids = match repo::get_items_needing_scheduled_reindex().await {
+        let candidate_ids = match repo::get_reindex_schedule_candidates().await {
             Ok(ids) => ids,
             Err(error) => {
                 tracing::error!(
                     %error,
-                    "reconcile: could not list items needing a scheduled reindex, skipping this pass"
+                    "reconcile: could not list items that might need a scheduled reindex, skipping this pass"
                 );
                 return;
             }
@@ -323,24 +333,37 @@ impl MainOrchestrator {
         };
         let existing: std::collections::HashSet<String> = existing.into_iter().collect();
 
-        let missing: Vec<i64> = candidate_ids
+        let missing_ids: Vec<i64> = candidate_ids
             .into_iter()
             .filter(|id| !existing.contains(&scheduled_index_task_id(*id).to_string()))
             .collect();
-        if missing.is_empty() {
+        if missing_ids.is_empty() {
             return;
         }
 
-        tracing::warn!(
-            count = missing.len(),
-            ids = ?missing,
-            "reconcile: found item(s) that should have a scheduled reindex but don't \
-             (likely a prior Redis restart/eviction) — rescheduling them now"
-        );
-        for id in missing {
-            if let Some(item) = self.load_item(id).await {
+        // `get_reindex_schedule_candidates` is a deliberately loose superset
+        // (SQL-cheap; can't express "has a known next air date" without a
+        // per-show query); `needs_reindex` is the real predicate, so it's
+        // applied here per candidate rather than trusting the SQL filter
+        // alone — otherwise a non-`Continuing` show with no upcoming episode
+        // would get rescheduled every single sweep for no reason.
+        let mut rescheduled = Vec::new();
+        for id in missing_ids {
+            let Some(item) = self.load_item(id).await else {
+                continue;
+            };
+            if self.needs_reindex(&item).await {
                 self.schedule_reindex(&item).await;
+                rescheduled.push(id);
             }
+        }
+        if !rescheduled.is_empty() {
+            tracing::warn!(
+                count = rescheduled.len(),
+                ids = ?rescheduled,
+                "reconcile: found item(s) that should have a scheduled reindex but don't \
+                 (likely a prior Redis restart/eviction) — rescheduled them now"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- A show's scheduled reindex (the mechanism that periodically re-checks a `continuing` show for new seasons/episodes) lives entirely in Redis, as a delayed apalis job on the `index` queue. If that job is ever lost — a Redis restart without persistence, an eviction, a bug — nothing else in the system notices: the item just silently stops being rechecked, forever, since the *only* thing that would ever reschedule its next check is the job that just vanished.
- Traced this from a real report: a show's Season 2 had been airing for weeks with zero episodes indexed. Its reindex schedule had been lost ~40 days earlier and never recovered — confirmed by manually injecting a one-off scheduled job for it and watching it fire correctly (proving the scheduler itself is healthy) and successfully index Season 2. It wasn't isolated: most `continuing` shows in the library were similarly stale (days to months out of date), correlating with whichever Redis restart happened to catch their pending schedule at the time.
- Adds `MainOrchestrator::reconcile_scheduled_reindexes()`: compares every item that should have a pending reindex (a continuing show, or any unreleased item — mirrors `handle_index_success`'s own `needs_reindex` predicate) against what's actually sitting in the `index` queue's Redis-backed scheduled set (`ZRANGE` on the apalis scheduled-jobs key, cross-referenced via the existing deterministic `scheduled_index_task_id`), and reschedules whatever's missing.
- Runs once at startup (the scheduler's first `retry_library` tick already fires immediately on boot) and on every subsequent tick, so a gap this causes closes within one sweep interval instead of persisting indefinitely.
- Gated by a new `reconcile_scheduled_reindexes` setting (default `true`; env var `RIVEN_SETTING__RECONCILE_SCHEDULED_REINDEXES`) in case this sweep ever needs to be ruled out as a cause of unexpected load.
- This is defense-in-depth specifically for reindex scheduling, which is fully derivable from Postgres (a continuing show should always eventually be rechecked, regardless of what Redis remembers) — it is not a substitute for durable Redis persistence in general; that's a separate fix (enabling AOF) applied alongside this.

## Test plan
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass.
- Live-verified end to end: with the index queue's scheduled set empty (a real Redis restart had just wiped it), deployed this build and confirmed on startup it logged finding 96 items missing their scheduled reindex, rescheduled all of them, and `ZCARD` on the scheduled set went from 0 to 96 — stable afterward (no duplicate scheduling on the following tick).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic reconciliation for scheduled reindex jobs.
  * Missing eligible jobs are detected and restored during startup and library retry cycles.
* **Settings**
  * Added an option to disable scheduled reindex reconciliation; it is enabled by default.
* **Reliability**
  * Improved reindex scheduling for active shows, including those with unknown status, and unreleased media.
  * Existing schedules are preserved when eligibility checks cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->