### PR TITLE
feat: allow admins to change an existing user's role

### DIFF
--- a/crates/riven-api/src/server/authn/account.rs
+++ b/crates/riven-api/src/server/authn/account.rs
@@ -418,18 +418,23 @@ pub(super) async fn update_user_role(
     if body.user_id == caller.id {
         return Err(ApiError::bad_request("Cannot change your own role"));
     }
-    let target = user::Entity::find_by_id(&body.user_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| ApiError::bad_request("No such user"))?;
 
     // Demoting the last admin would leave an instance nobody can administer.
-    // Counting and updating as separate statements would race: two admins
-    // demoting each other at the same time could each see "2 admins" and both
+    // `target` is fetched (and locked) inside the transaction, not before it:
+    // reading it beforehand would let a concurrent request promote it to
+    // admin in between, so this guard would evaluate against a stale
+    // "not admin" role and skip the admin count entirely. Counting and
+    // updating as separate statements would race too — two admins demoting
+    // each other at the same time could each see "2 admins" and both
     // proceed, leaving zero. `FOR UPDATE` inside a transaction locks every
     // admin row for its duration, so a concurrent demotion blocks until this
     // one commits (or rolls back) and then re-counts against the result.
     let tx = db.begin().await?;
+    let target = user::Entity::find_by_id(&body.user_id)
+        .lock_exclusive()
+        .one(&tx)
+        .await?
+        .ok_or_else(|| ApiError::bad_request("No such user"))?;
     if role_from_user(target.role.as_deref()) == UserRole::Admin && role != "admin" {
         let admin_ids: Vec<String> = user::Entity::find()
             .filter(user::Column::Role.eq("admin"))

--- a/crates/riven-api/src/server/authn/account.rs
+++ b/crates/riven-api/src/server/authn/account.rs
@@ -397,6 +397,56 @@ pub(super) async fn create_user(
 }
 
 #[derive(Deserialize)]
+pub(super) struct UpdateUserRole {
+    user_id: String,
+    role: String,
+}
+
+pub(super) async fn update_user_role(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+    Json(body): Json<UpdateUserRole>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let caller = require_admin(&state, &headers).await?;
+    let db = &state.auth.db;
+
+    let role = match body.role.as_str() {
+        role @ ("admin" | "manager" | "user") => role,
+        other => return Err(ApiError::bad_request(format!("Unknown role: {other}"))),
+    };
+
+    if body.user_id == caller.id {
+        return Err(ApiError::bad_request("Cannot change your own role"));
+    }
+    let target = user::Entity::find_by_id(&body.user_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| ApiError::bad_request("No such user"))?;
+
+    // Demoting the last admin would leave an instance nobody can administer.
+    if role_from_user(target.role.as_deref()) == UserRole::Admin && role != "admin" {
+        let admins = user::Entity::find()
+            .filter(user::Column::Role.eq("admin"))
+            .count(db)
+            .await?;
+        if admins <= 1 {
+            return Err(ApiError::bad_request("Cannot demote the last admin"));
+        }
+    }
+
+    let updated = user::ActiveModel {
+        id: Set(target.id),
+        role: Set(Some(role.to_string())),
+        updated_at: Set(Utc::now()),
+        ..Default::default()
+    }
+    .update(db)
+    .await?;
+    tracing::info!(user_id = %updated.id, role, by = %caller.id, "user role changed by admin");
+    Ok(Json(json!({ "user": updated })))
+}
+
+#[derive(Deserialize)]
 pub(super) struct RemoveUser {
     user_id: String,
 }

--- a/crates/riven-api/src/server/authn/account.rs
+++ b/crates/riven-api/src/server/authn/account.rs
@@ -424,12 +424,22 @@ pub(super) async fn update_user_role(
         .ok_or_else(|| ApiError::bad_request("No such user"))?;
 
     // Demoting the last admin would leave an instance nobody can administer.
+    // Counting and updating as separate statements would race: two admins
+    // demoting each other at the same time could each see "2 admins" and both
+    // proceed, leaving zero. `FOR UPDATE` inside a transaction locks every
+    // admin row for its duration, so a concurrent demotion blocks until this
+    // one commits (or rolls back) and then re-counts against the result.
+    let tx = db.begin().await?;
     if role_from_user(target.role.as_deref()) == UserRole::Admin && role != "admin" {
-        let admins = user::Entity::find()
+        let admin_ids: Vec<String> = user::Entity::find()
             .filter(user::Column::Role.eq("admin"))
-            .count(db)
+            .select_only()
+            .column(user::Column::Id)
+            .lock_exclusive()
+            .into_tuple()
+            .all(&tx)
             .await?;
-        if admins <= 1 {
+        if admin_ids.len() <= 1 {
             return Err(ApiError::bad_request("Cannot demote the last admin"));
         }
     }
@@ -440,8 +450,9 @@ pub(super) async fn update_user_role(
         updated_at: Set(Utc::now()),
         ..Default::default()
     }
-    .update(db)
+    .update(&tx)
     .await?;
+    tx.commit().await?;
     tracing::info!(user_id = %updated.id, role, by = %caller.id, "user role changed by admin");
     Ok(Json(json!({ "user": updated })))
 }

--- a/crates/riven-api/src/server/authn/mod.rs
+++ b/crates/riven-api/src/server/authn/mod.rs
@@ -125,6 +125,7 @@ pub fn router() -> axum::Router<ApiState> {
         .route("/passkey/update-passkey", post(passkey::update_passkey))
         .route("/admin/list-users", get(account::list_users))
         .route("/admin/create-user", post(account::create_user))
+        .route("/admin/update-user-role", post(account::update_user_role))
         .route("/admin/remove-user", post(account::remove_user))
         .route("/first-user", get(password::first_user_availability))
         .route("/oidc-providers", get(oidc_providers))

--- a/frontend/src/lib/auth-client.ts
+++ b/frontend/src/lib/auth-client.ts
@@ -330,6 +330,12 @@ export const authClient = {
 				body,
 			});
 		},
+		updateUserRole(body: { user_id: string; role: string }) {
+			return call<{ user: AuthUser }>("/admin/update-user-role", {
+				method: "POST",
+				body,
+			});
+		},
 		removeUser(body: { user_id: string }) {
 			return call<{ success: boolean }>("/admin/remove-user", {
 				method: "POST",

--- a/frontend/src/lib/components/auth/user-management.svelte
+++ b/frontend/src/lib/components/auth/user-management.svelte
@@ -64,10 +64,28 @@
 
     const { form: formData, enhance, delayed } = form;
     let deletingId = $state<string | null>(null);
+    let changingRoleId = $state<string | null>(null);
 
     function formatCreatedAt(value: ManagedUser["created_at"]) {
         if (!value) return "Unknown";
         return dateUtils.formatDate(value) ?? "Unknown";
+    }
+
+    async function changeRole(user: ManagedUser, role: string) {
+        if (role === (user.role ?? "user")) return;
+
+        changingRoleId = user.id;
+        const { error } = await authClient.admin.updateUserRole({ user_id: user.id, role });
+        changingRoleId = null;
+
+        if (error) {
+            toast.error(error.message);
+            await invalidateAll();
+            return;
+        }
+
+        await invalidateAll();
+        toast.success("User role updated.");
     }
 
     async function deleteUser(user: ManagedUser) {
@@ -185,9 +203,22 @@
                                 <div class="text-muted-foreground text-xs">{user.email}</div>
                             </Table.Cell>
                             <Table.Cell>
-                                <Badge variant={user.role === "admin" ? "default" : "secondary"}>
-                                    {user.role ?? "user"}
-                                </Badge>
+                                {#if user.id === currentUserId}
+                                    <Badge variant={user.role === "admin" ? "default" : "secondary"}>
+                                        {user.role ?? "user"}
+                                    </Badge>
+                                {:else}
+                                    <select
+                                        value={user.role ?? "user"}
+                                        disabled={changingRoleId === user.id}
+                                        onchange={(event) =>
+                                            changeRole(user, event.currentTarget.value)}
+                                        class="border-input bg-background ring-offset-background focus-visible:ring-ring h-8 rounded-md border px-2 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50">
+                                        <option value="user">User</option>
+                                        <option value="manager">Manager</option>
+                                        <option value="admin">Admin</option>
+                                    </select>
+                                {/if}
                             </Table.Cell>
                             <Table.Cell class="text-muted-foreground text-sm">
                                 {formatCreatedAt(user.created_at)}


### PR DESCRIPTION
## Summary
- Admins could previously only set a user's role at creation time — there was no way to change it afterward.
- Adds `POST /auth/admin/update-user-role`, mirroring `remove_user`'s guards: rejects unknown roles, blocks changing your own role, and blocks demoting an admin who is the last one on the instance.
- The Users admin table now shows an inline role selector (User/Manager/Admin) for every row except the caller's own, which stays a static badge.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy -p riven-api --all-targets -- -D warnings`, `cargo test -p riven-api` (90 passed) — all clean
- [x] `pnpm run check` (svelte-check: 0 errors/warnings) and `pnpm run lint` (biome: clean)
- [x] Deployed to a live instance and exercised the real endpoint end-to-end: promoted a real user to manager and back to user, confirmed the DB reflected the change on both hops
- [x] Confirmed the guardrails live: self-role-change rejected (`Cannot change your own role`), unknown role rejected (`Unknown role: superadmin`), unauthenticated request rejected with 401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can change other users’ roles between admin, manager, and user.
  * Added a role selector with progress feedback and success or error notifications.
  * The current administrator’s own role remains protected from modification.
* **Bug Fixes**
  * Prevents invalid role changes, updates to nonexistent users, and demotion of the last administrator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->