### PR TITLE
feat: add a provider-split chart to the dashboard

### DIFF
--- a/crates/plugin-dashboard/src/lib.rs
+++ b/crates/plugin-dashboard/src/lib.rs
@@ -48,6 +48,12 @@ pub struct YearRelease {
     pub count: i64,
 }
 
+#[derive(SimpleObject)]
+pub struct ProviderBreakdown {
+    pub provider: String,
+    pub count: i64,
+}
+
 #[derive(Default)]
 pub struct DashboardQuery;
 
@@ -147,6 +153,16 @@ impl DashboardQuery {
             .await?
             .into_iter()
             .map(|(year, count)| YearRelease { year, count })
+            .collect())
+    }
+
+    /// Count of completed downloads grouped by the plugin that fulfilled them
+    /// (usenet vs. debrid, via stremthru).
+    async fn provider_breakdown(&self, _ctx: &Context<'_>) -> GqlResult<Vec<ProviderBreakdown>> {
+        Ok(repo::get_provider_breakdown()
+            .await?
+            .into_iter()
+            .map(|(provider, count)| ProviderBreakdown { provider, count })
             .collect())
     }
 

--- a/crates/riven-db/src/repo/stats.rs
+++ b/crates/riven-db/src/repo/stats.rs
@@ -147,6 +147,30 @@ pub async fn get_year_releases() -> Result<Vec<(i32, i64)>> {
     Ok(rows.into_iter().map(|r| (r.year, r.count)).collect())
 }
 
+/// Count completed downloads grouped by the plugin that fulfilled them
+/// (`"usenet"` or `"stremthru"` today — see `filesystem_entries.plugin`).
+/// Only `media` entries count; subtitle sidecar rows would double-count a
+/// single download under the same provider.
+pub async fn get_provider_breakdown() -> Result<Vec<(String, i64)>> {
+    #[derive(FromQueryResult)]
+    struct ProviderRow {
+        provider: String,
+        count: i64,
+    }
+    // `entry_type = 'media'` is a predicate only, so no ::text cast is needed.
+    let rows = ProviderRow::find_by_statement(Statement::from_string(
+        DbBackend::Postgres,
+        r#"SELECT plugin AS provider, COUNT(*)::bigint AS count
+           FROM filesystem_entries
+           WHERE entry_type = 'media' AND plugin IS NOT NULL
+           GROUP BY plugin
+           ORDER BY count DESC"#,
+    ))
+    .all(orm())
+    .await?;
+    Ok(rows.into_iter().map(|r| (r.provider, r.count)).collect())
+}
+
 /// Fetch upcoming unreleased items with the show title resolved in a single JOIN.
 pub async fn get_calendar_entries(limit: i64) -> Result<Vec<crate::entities::CalendarRow>> {
     // Self-joins to resolve the ancestor show title — keep the raw statement.

--- a/frontend/src/lib/components/dashboard/library-charts-card.svelte
+++ b/frontend/src/lib/components/dashboard/library-charts-card.svelte
@@ -27,6 +27,28 @@
                   color: String(color)
               }))
     );
+
+    const PROVIDER_LABELS: Record<string, string> = {
+        usenet: "Usenet",
+        stremthru: "Debrid"
+    };
+    const PROVIDER_COLORS: Record<string, string> = {
+        usenet: "#a78bfa",
+        stremthru: "#22d3ee"
+    };
+    const FALLBACK_PROVIDER_COLORS = ["#94a3b8", "#f472b6", "#facc15"];
+
+    const providerRows = $derived.by(() =>
+        (statistics?.provider_breakdown ?? [])
+            .filter((item) => item.count > 0)
+            .map((item, index) => ({
+                label: PROVIDER_LABELS[item.provider] ?? item.provider,
+                value: item.count,
+                color:
+                    PROVIDER_COLORS[item.provider] ??
+                    FALLBACK_PROVIDER_COLORS[index % FALLBACK_PROVIDER_COLORS.length]
+            }))
+    );
 </script>
 
 {#snippet LegendRows({ items }: { items: { label: string; value: number; color?: string }[] })}
@@ -47,7 +69,7 @@
     </div>
 {/snippet}
 
-<section class="border-border/60 grid gap-12 border-b py-8 lg:grid-cols-2">
+<section class="border-border/60 grid gap-12 border-b py-8 lg:grid-cols-3">
     <div class="min-w-0">
         <h2 class="text-base font-semibold">Library States</h2>
 
@@ -89,6 +111,33 @@
                 </PieChart>
             </ResponsiveChartContainer>
             {@render LegendRows({ items: contentRows })}
+        </div>
+    </div>
+
+    <div class="min-w-0">
+        <h2 class="text-base font-semibold">Provider Split</h2>
+
+        <div class="mt-6 grid items-center gap-6 sm:grid-cols-[14rem_minmax(0,1fr)]">
+            {#if providerRows.length === 0}
+                <p class="text-muted-foreground text-sm">No completed downloads yet.</p>
+            {:else}
+                <ResponsiveChartContainer config={{}} class="mx-auto h-56 w-56">
+                    <PieChart
+                        data={providerRows}
+                        key="label"
+                        value="value"
+                        c="color"
+                        innerRadius={-50}
+                        cornerRadius={5}
+                        padAngle={0.02}
+                        padding={{ top: 16, bottom: 32, left: 32, right: 16 }}>
+                        {#snippet tooltip()}
+                            <Chart.Tooltip />
+                        {/snippet}
+                    </PieChart>
+                </ResponsiveChartContainer>
+                {@render LegendRows({ items: providerRows })}
+            {/if}
         </div>
     </div>
 </section>

--- a/frontend/src/lib/components/dashboard/types.ts
+++ b/frontend/src/lib/components/dashboard/types.ts
@@ -9,6 +9,7 @@ export type DashboardStatistics = {
 	states: Record<string, number>;
 	activity: Record<string, number>;
 	media_year_releases: { year: number; count: number }[];
+	provider_breakdown: { provider: string; count: number }[];
 };
 
 export type DownloaderService = {

--- a/frontend/src/lib/gql/schema.ts
+++ b/frontend/src/lib/gql/schema.ts
@@ -1360,6 +1360,11 @@ export type ProductionCompany = {
   originCountry?: Maybe<Scalars['String']['output']>;
 };
 
+export type ProviderBreakdown = {
+  count: Scalars['Int']['output'];
+  provider: Scalars['String']['output'];
+};
+
 export type QueryRoot = {
   /** Get active playback sessions from configured media-server plugins. */
   activePlaybackSessions: Array<ActivePlaybackSession>;
@@ -1443,6 +1448,11 @@ export type QueryRoot = {
   nntpProviders: Array<NntpProviderHealth>;
   /** A cast/crew member or a company, both rendered through one shape. */
   personDetails: PersonDetails;
+  /**
+   * Count of completed downloads grouped by the plugin that fulfilled them
+   * (usenet vs. debrid, via stremthru).
+   */
+  providerBreakdown: Array<ProviderBreakdown>;
   /**
    * Return all quality profiles as an ordered array of
    * `{ id, label, description, settings }` objects.

--- a/frontend/src/routes/(protected)/dashboard/+page.svelte
+++ b/frontend/src/routes/(protected)/dashboard/+page.svelte
@@ -204,6 +204,10 @@
                 year
                 count
             }
+            providerBreakdown {
+                provider
+                count
+            }
         }
     `;
 
@@ -227,6 +231,7 @@
         };
         activity: Record<string, number>;
         yearReleases: { year: number; count: number }[];
+        providerBreakdown: { provider: string; count: number }[];
     };
 
     function mapDashboardStats(result: GqlDashboardStats): DashboardStatistics {
@@ -251,7 +256,8 @@
                 Unreleased: s.unreleased
             },
             activity: result.activity ?? {},
-            media_year_releases: result.yearReleases ?? []
+            media_year_releases: result.yearReleases ?? [],
+            provider_breakdown: result.providerBreakdown ?? []
         };
     }
 

--- a/frontend/src/routes/(protected)/dashboard/+page.ts
+++ b/frontend/src/routes/(protected)/dashboard/+page.ts
@@ -39,6 +39,10 @@ const STATS_QUERY = `
             year
             count
         }
+        providerBreakdown {
+            provider
+            count
+        }
     }
 `;
 
@@ -185,6 +189,7 @@ type GqlStatsResult = {
 	};
 	activity: Record<string, number>;
 	yearReleases: { year: number; count: number }[];
+	providerBreakdown: { provider: string; count: number }[];
 };
 
 type GqlDebridAccountInfo = {
@@ -249,6 +254,7 @@ export const load = (async ({ depends }) => {
 				},
 				activity: data.activity ?? {},
 				media_year_releases: data.yearReleases ?? [],
+				provider_breakdown: data.providerBreakdown ?? [],
 			};
 		})
 		.catch((err) => {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1282,6 +1282,11 @@ type ProductionCompany {
 	originCountry: String
 }
 
+type ProviderBreakdown {
+	provider: String!
+	count: Int!
+}
+
 type QueryRoot {
 	viewer: Viewer!
 	mediaItemById(id: Int!): MediaItemUnion
@@ -1428,6 +1433,11 @@ type QueryRoot {
 	Count of movies and shows per release year.
 	"""
 	yearReleases: [YearRelease!]!
+	"""
+	Count of completed downloads grouped by the plugin that fulfilled them
+	(usenet vs. debrid, via stremthru).
+	"""
+	providerBreakdown: [ProviderBreakdown!]!
 	"""
 	Get debrid account information for all configured stores.
 	"""


### PR DESCRIPTION
## Summary
- The dashboard's Content Breakdown chart shows movies/shows/seasons/episodes, but nothing about how the library actually got filled — usenet vs. debrid.
- Adds a `providerBreakdown` GraphQL query that counts completed downloads (`filesystem_entries` rows with `entry_type = 'media'`) grouped by the plugin that fulfilled them. Today that's exactly `usenet` and `stremthru` (debrid) — the only two plugins that respond to `MediaItemDownloadRequested`.
- Adds a matching "Provider Split" pie chart next to Content Breakdown, with friendly labels (Usenet / Debrid) and a graceful empty state.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy -p riven-db -p plugin-dashboard -p riven-api --all-targets -- -D warnings`, `cargo test -p riven-db -p plugin-dashboard -p riven-api` (132 passed) — all clean
- [x] `pnpm run check` (svelte-check: 0 errors/warnings) and `pnpm run lint` (biome: clean)
- [x] Regenerated and committed `schema.graphql` and `frontend/src/lib/gql/schema.ts` via `make schema`
- [x] Deployed to a live instance and queried the real endpoint: `providerBreakdown` returned `usenet: 1331, stremthru: 1225`, matching a direct DB count exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Provider Split chart to the dashboard, showing completed downloads by provider.
  - Providers are displayed with labels, colors, counts, and a clear empty state when no data is available.
  - Dashboard statistics now include provider breakdown data through the public API.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->