### PR TITLE
fix: don't scrape episodes with an unknown air date

### DIFF
--- a/crates/riven-db/src/repo/hierarchy.rs
+++ b/crates/riven-db/src/repo/hierarchy.rs
@@ -330,6 +330,27 @@ pub async fn create_season(
     Ok(item)
 }
 
+/// A known-past/-present air date is the only case that's actually ready to
+/// scrape. A future date, and an entirely unknown one (a TVDB "TBA" stub with
+/// no title or air date yet), both mean the same thing here: there's nothing
+/// real to search for yet. Treating "unknown" as "already aired" used to send
+/// these straight into the scrape/retry pipeline, where they'd burn through
+/// attempts against placeholder metadata until they landed on `Failed`.
+/// `Unreleased` instead puts them on the reindex scheduler
+/// (`next_reindex_at`'s `unknown_air_date_offset_days` fallback for a `None`
+/// date), which just re-checks the metadata periodically until a real date
+/// appears; `create_episode`'s ON CONFLICT branch already flips it to
+/// `Indexed` itself once that happens.
+pub fn episode_state_for_air_date(
+    aired_at_utc: Option<chrono::DateTime<Utc>>,
+    now: chrono::DateTime<Utc>,
+) -> MediaItemState {
+    match aired_at_utc {
+        Some(dt) if dt <= now => MediaItemState::Indexed,
+        _ => MediaItemState::Unreleased,
+    }
+}
+
 pub async fn create_episode(
     season_id: i64,
     number: i32,
@@ -346,12 +367,12 @@ pub async fn create_episode(
     let now = Utc::now();
     let default_title = format!("Episode {number:02}");
     let title_str = title.unwrap_or(&default_title);
-    let state = match aired_at_utc
-        .or_else(|| aired_at.map(|d| d.and_hms_opt(0, 0, 0).expect("midnight is valid").and_utc()))
-    {
-        Some(dt) if dt > now => MediaItemState::Unreleased,
-        _ => MediaItemState::Indexed,
-    };
+    let state = episode_state_for_air_date(
+        aired_at_utc.or_else(|| {
+            aired_at.map(|d| d.and_hms_opt(0, 0, 0).expect("midnight is valid").and_utc())
+        }),
+        now,
+    );
     let state_text = match state {
         MediaItemState::Unreleased => "unreleased",
         _ => "indexed",

--- a/crates/riven-db/src/repo/hierarchy.rs
+++ b/crates/riven-db/src/repo/hierarchy.rs
@@ -393,11 +393,13 @@ pub async fn create_episode(
                absolute_number = COALESCE(EXCLUDED.absolute_number, media_items.absolute_number),
                season_number   = COALESCE(EXCLUDED.season_number, media_items.season_number),
                is_requested    = EXCLUDED.is_requested OR media_items.is_requested,
-               -- Transition unreleased episodes that have since aired, preferring precise UTC time
+               -- Transition unreleased episodes that have since aired, preferring precise UTC time.
+               -- `date::timestamptz` interprets midnight in the session's TimeZone, not UTC — explicit
+               -- `::timestamp AT TIME ZONE 'UTC'` anchors it regardless of session config.
                state = CASE
                    WHEN media_items.state = 'unreleased'
-                    AND COALESCE(EXCLUDED.aired_at_utc, EXCLUDED.aired_at::timestamptz) IS NOT NULL
-                    AND COALESCE(EXCLUDED.aired_at_utc, EXCLUDED.aired_at::timestamptz) <= NOW()
+                    AND COALESCE(EXCLUDED.aired_at_utc, EXCLUDED.aired_at::timestamp AT TIME ZONE 'UTC') IS NOT NULL
+                    AND COALESCE(EXCLUDED.aired_at_utc, EXCLUDED.aired_at::timestamp AT TIME ZONE 'UTC') <= NOW()
                    THEN 'indexed'::media_item_state
                    ELSE media_items.state
                END,

--- a/crates/riven-db/tests/hierarchy.rs
+++ b/crates/riven-db/tests/hierarchy.rs
@@ -1,0 +1,44 @@
+use chrono::{TimeZone, Utc};
+use riven_core::types::MediaItemState;
+use riven_db::repo::hierarchy::episode_state_for_air_date;
+
+fn at(y: i32, m: u32, d: u32) -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(y, m, d, 0, 0, 0).unwrap()
+}
+
+#[test]
+fn unknown_air_date_is_unreleased_not_indexed() {
+    let now = at(2026, 8, 11);
+    assert_eq!(
+        episode_state_for_air_date(None, now),
+        MediaItemState::Unreleased,
+        "a TVDB 'TBA' stub with no air date must wait for real metadata, not be scraped"
+    );
+}
+
+#[test]
+fn future_air_date_is_unreleased() {
+    let now = at(2026, 8, 11);
+    assert_eq!(
+        episode_state_for_air_date(Some(at(2026, 8, 12)), now),
+        MediaItemState::Unreleased
+    );
+}
+
+#[test]
+fn past_air_date_is_indexed() {
+    let now = at(2026, 8, 11);
+    assert_eq!(
+        episode_state_for_air_date(Some(at(2026, 8, 10)), now),
+        MediaItemState::Indexed
+    );
+}
+
+#[test]
+fn air_date_exactly_now_is_indexed() {
+    let now = at(2026, 8, 11);
+    assert_eq!(
+        episode_state_for_air_date(Some(now), now),
+        MediaItemState::Indexed
+    );
+}


### PR DESCRIPTION
## Summary
- `create_episode` treated "no air date known yet" (a TVDB TBA placeholder — no title, no date) the same as "already aired," creating it as `Indexed` and sending it straight into the scrape/retry pipeline.
- With nothing real to search for, these burn through retry attempts against placeholder metadata indefinitely. What that turns into depends on `maximum_scrape_attempts`: with a ceiling configured, the item eventually lands on `Failed`, which then makes the parent season sticky-`Failed` too even though nothing is actually wrong with it; with the ceiling disabled (`0`, this instance's setting), it never reaches `Failed` at all and just retries forever on the escalating backoff — one real episode on this instance had racked up **8,170** failed attempts.
- Now an unknown air date resolves to `Unreleased`, the same as a known future date. That keeps it off the scrape/retry pipeline and puts it on the reindex scheduler instead, which re-checks metadata periodically (`unknown_air_date_offset_days`, 7 days by default) until a real air date shows up — `create_episode`'s existing `ON CONFLICT` branch already flips it to `Indexed` on its own once that happens.
- Extracted the state decision into `episode_state_for_air_date()` so it's unit-testable without a DB connection, following the same pattern as `cooldown_for_failed_attempts`/`tests/media.rs` elsewhere in this crate.
- **This fix is forward-only.** `create_episode`'s `ON CONFLICT` branch only ever transitions `unreleased → indexed`, never the reverse, so rows that were already miscreated as `Indexed`/`Failed` before this fix don't self-heal — they need a one-time manual reset (see below) to benefit from it.

## Found via a real instance
A library-wide scan for the pattern (`item_type = episode`, `aired_at IS NULL`, `is_requested = true`, `state NOT IN ('unreleased', 'completed', 'paused')`) turned up three shows on this instance, covering both failure modes:

| Show | Episodes | Before | Failed attempts |
|---|---|---|---|
| Show A | 1 | `Failed` (season also sticky-`Failed`) | 5 |
| Show B | 6 | `Indexed` (ceiling disabled, never reached `Failed`) | up to 8,170 |
| Show C | 9 | `Indexed` (ceiling disabled, never reached `Failed`) | up to 10 |

All three were reset to `Unreleased` with `failed_attempts` cleared once this fix was deployed; Show B's and Show C's season/show rows were also re-rolled-up to `Ongoing` to correctly reflect "half aired, half not yet released" instead of the stale rollup left behind by the runaway retries.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy -p riven-db --all-targets -- -D warnings`, `cargo test -p riven-db` (45 passed, including 4 new regression tests in `tests/hierarchy.rs`) — all clean
- [x] Verified live against a real instance: found and reset 3 real shows (16 episodes total) exhibiting exactly this bug in both its `Failed` and runaway-`Indexed` forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Episodes without a known air date are now correctly shown as unreleased.
  - Episodes with a future air date remain unreleased until their scheduled time.
  - Episodes airing today or in the past are correctly marked as indexed.
- **Tests**
  - Added coverage for missing, future, current, and past air dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->