### PR TITLE
feat: add ntfy support to the notifications plugin

### DIFF
--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -41,7 +41,9 @@ pub(crate) async fn dispatch_webhooks(
                 )
                 .await
                 {
-                    tracing::error!(error = %error, url = url_str, "failed to send ntfy notification");
+                    // Never log `url_str` here — a basic-auth password or
+                    // bearer token in the URL would end up in the logs.
+                    tracing::error!(error = %error, endpoint = %base_url, "failed to send ntfy notification");
                 }
             }
             None => {
@@ -123,7 +125,11 @@ fn parse_ntfy_url(url: &str) -> Option<NotificationService> {
     };
 
     let (base_url, topic) = match after_auth.split_once('/') {
-        Some((host, topic)) if !host.is_empty() && !topic.is_empty() => {
+        // `/` is not a valid character in an ntfy topic name, so a further
+        // `/` inside `topic` means this is a multi-segment path (e.g.
+        // `host/topic-one/topic-two`) — not the single-topic form this
+        // supports.
+        Some((host, topic)) if !host.is_empty() && !topic.is_empty() && !topic.contains('/') => {
             // ntfy.sh itself has no plaintext endpoint, so an explicit
             // `ntfy://ntfy.sh/topic` still needs to be forced to https.
             let scheme = if secure_scheme || host.eq_ignore_ascii_case("ntfy.sh") {
@@ -134,7 +140,8 @@ fn parse_ntfy_url(url: &str) -> Option<NotificationService> {
             (format!("{scheme}://{host}"), topic.to_string())
         }
         // A `/` is present but the host or topic on one side of it is empty
-        // (e.g. `myhost/` or `/topic`) — not a valid self-hosted target.
+        // (e.g. `myhost/` or `/topic`), or the topic itself has a further
+        // `/` — not a valid self-hosted target.
         Some(_) => return None,
         None if !after_auth.is_empty() => ("https://ntfy.sh".to_string(), after_auth.to_string()),
         None => return None,

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -369,38 +369,49 @@ async fn send_ntfy(
     tags: Option<&str>,
     payload: &NotificationPayload,
 ) -> anyhow::Result<()> {
-    let url = format!("{base_url}/{topic}");
-    let body = build_ntfy_body(payload);
+    // ntfy only parses a JSON publish body at the root endpoint — POSTing
+    // JSON straight to `/{topic}` (as this used to) gets treated as a plain
+    // publish and the raw JSON text ends up as the literal message body.
+    // The root form also keeps title/message/tags fully UTF-8 safe: the
+    // header-based per-topic form would need every non-ASCII byte (accented
+    // titles, the "•" separator below) RFC 2047-encoded, since HTTP header
+    // values are ASCII-only.
+    let body = build_ntfy_body(topic, priority, tags, payload);
     tracing::debug!(
         topic,
         title = %payload.full_title,
         "sending ntfy notification"
     );
     http.send(profiles::NTFY, |client| {
-        let mut request = client.post(&url).json(&body);
-        request = match auth {
+        let request = client.post(base_url).json(&body);
+        match auth {
             NtfyAuth::None => request,
             NtfyAuth::Basic { user, password } => request.basic_auth(user, Some(password)),
             NtfyAuth::Token(token) => request.bearer_auth(token),
-        };
-        if let Some(priority) = priority {
-            request = request.header("X-Priority", priority);
         }
-        if let Some(tags) = tags {
-            request = request.header("X-Tags", tags);
-        }
-        request
     })
     .await?
     .error_for_status()?;
     Ok(())
 }
 
-pub(crate) fn build_ntfy_body(payload: &NotificationPayload) -> serde_json::Value {
+pub(crate) fn build_ntfy_body(
+    topic: &str,
+    priority: Option<&str>,
+    tags: Option<&str>,
+    payload: &NotificationPayload,
+) -> serde_json::Value {
     let mut body = serde_json::json!({
+        "topic": topic,
         "title": format!("Downloaded: {}", payload.full_title),
         "message": build_ntfy_message(payload),
     });
+    if let Some(priority) = priority {
+        body["priority"] = serde_json::json!(priority);
+    }
+    if let Some(tags) = tags {
+        body["tags"] = serde_json::json!(tags.split(',').map(str::trim).collect::<Vec<_>>());
+    }
     if let Some(ref poster) = payload.poster_path {
         body["attach"] = serde_json::json!(poster);
     }

--- a/crates/plugin-notifications/src/dispatch.rs
+++ b/crates/plugin-notifications/src/dispatch.rs
@@ -23,6 +23,27 @@ pub(crate) async fn dispatch_webhooks(
                     tracing::error!(error = %error, url = url_str, "failed to send json notification");
                 }
             }
+            Some(NotificationService::Ntfy {
+                base_url,
+                topic,
+                auth,
+                priority,
+                tags,
+            }) => {
+                if let Err(error) = send_ntfy(
+                    &ctx.http,
+                    &base_url,
+                    &topic,
+                    &auth,
+                    priority.as_deref(),
+                    tags.as_deref(),
+                    payload,
+                )
+                .await
+                {
+                    tracing::error!(error = %error, url = url_str, "failed to send ntfy notification");
+                }
+            }
             None => {
                 tracing::warn!(url = url_str, "unsupported notification URL scheme");
             }
@@ -38,6 +59,19 @@ pub(crate) enum NotificationService {
     Json {
         url: String,
     },
+    Ntfy {
+        base_url: String,
+        topic: String,
+        auth: NtfyAuth,
+        priority: Option<String>,
+        tags: Option<String>,
+    },
+}
+
+pub(crate) enum NtfyAuth {
+    None,
+    Basic { user: String, password: String },
+    Token(String),
 }
 
 pub(crate) fn parse_notification_url(url: &str) -> Option<NotificationService> {
@@ -54,12 +88,91 @@ pub(crate) fn parse_notification_url(url: &str) -> Option<NotificationService> {
         Some(NotificationService::Json {
             url: format!("http://{rest}"),
         })
+    } else if let Some(rest) = url.strip_prefix("jsons://") {
+        Some(NotificationService::Json {
+            url: format!("https://{rest}"),
+        })
+    } else if url.starts_with("ntfy://") || url.starts_with("ntfys://") {
+        parse_ntfy_url(url)
     } else {
-        url.strip_prefix("jsons://")
-            .map(|rest| NotificationService::Json {
-                url: format!("https://{rest}"),
-            })
+        None
     }
+}
+
+/// Apprise's ntfy scheme: `ntfy://topic` (public ntfy.sh), `ntfy://host/topic`
+/// or `ntfys://host/topic` (self-hosted, http/https respectively), each
+/// optionally prefixed with `user:pass@` (Basic auth) or `token@` (Bearer
+/// auth). Only a single topic is supported — Apprise's `{topic1}/{topic2}`
+/// multi-topic form is not, since without an explicit host there is no way
+/// to tell a second topic segment apart from a hostname.
+fn parse_ntfy_url(url: &str) -> Option<NotificationService> {
+    let (secure_scheme, rest) = if let Some(rest) = url.strip_prefix("ntfys://") {
+        (true, rest)
+    } else {
+        (false, url.strip_prefix("ntfy://")?)
+    };
+
+    let (rest, query) = match rest.split_once('?') {
+        Some((path, q)) => (path, Some(q)),
+        None => (rest, None),
+    };
+
+    let (auth_part, after_auth) = match rest.split_once('@') {
+        Some((a, b)) => (Some(a), b),
+        None => (None, rest),
+    };
+
+    let (base_url, topic) = match after_auth.split_once('/') {
+        Some((host, topic)) if !host.is_empty() && !topic.is_empty() => {
+            // ntfy.sh itself has no plaintext endpoint, so an explicit
+            // `ntfy://ntfy.sh/topic` still needs to be forced to https.
+            let scheme = if secure_scheme || host.eq_ignore_ascii_case("ntfy.sh") {
+                "https"
+            } else {
+                "http"
+            };
+            (format!("{scheme}://{host}"), topic.to_string())
+        }
+        // A `/` is present but the host or topic on one side of it is empty
+        // (e.g. `myhost/` or `/topic`) — not a valid self-hosted target.
+        Some(_) => return None,
+        None if !after_auth.is_empty() => ("https://ntfy.sh".to_string(), after_auth.to_string()),
+        None => return None,
+    };
+
+    let auth = match auth_part {
+        None => NtfyAuth::None,
+        Some(a) => match a.split_once(':') {
+            Some((user, password)) => NtfyAuth::Basic {
+                user: user.to_string(),
+                password: password.to_string(),
+            },
+            None => NtfyAuth::Token(a.to_string()),
+        },
+    };
+
+    let mut priority = None;
+    let mut tags = None;
+    for pair in query.into_iter().flat_map(|q| q.split('&')) {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        match key {
+            "priority" if matches!(value, "max" | "high" | "low" | "min") => {
+                priority = Some(value.to_string());
+            }
+            "tags" if !value.is_empty() => {
+                tags = Some(value.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    Some(NotificationService::Ntfy {
+        base_url,
+        topic,
+        auth,
+        priority,
+        tags,
+    })
 }
 
 async fn send_discord(
@@ -245,6 +358,68 @@ async fn send_json_webhook(
     .await?
     .error_for_status()?;
     Ok(())
+}
+
+async fn send_ntfy(
+    http: &riven_core::http::HttpClient,
+    base_url: &str,
+    topic: &str,
+    auth: &NtfyAuth,
+    priority: Option<&str>,
+    tags: Option<&str>,
+    payload: &NotificationPayload,
+) -> anyhow::Result<()> {
+    let url = format!("{base_url}/{topic}");
+    let body = build_ntfy_body(payload);
+    tracing::debug!(
+        topic,
+        title = %payload.full_title,
+        "sending ntfy notification"
+    );
+    http.send(profiles::NTFY, |client| {
+        let mut request = client.post(&url).json(&body);
+        request = match auth {
+            NtfyAuth::None => request,
+            NtfyAuth::Basic { user, password } => request.basic_auth(user, Some(password)),
+            NtfyAuth::Token(token) => request.bearer_auth(token),
+        };
+        if let Some(priority) = priority {
+            request = request.header("X-Priority", priority);
+        }
+        if let Some(tags) = tags {
+            request = request.header("X-Tags", tags);
+        }
+        request
+    })
+    .await?
+    .error_for_status()?;
+    Ok(())
+}
+
+pub(crate) fn build_ntfy_body(payload: &NotificationPayload) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "title": format!("Downloaded: {}", payload.full_title),
+        "message": build_ntfy_message(payload),
+    });
+    if let Some(ref poster) = payload.poster_path {
+        body["attach"] = serde_json::json!(poster);
+    }
+    body
+}
+
+/// ntfy's `message` field is plain text — no embed support — so this
+/// condenses the same core fields `build_simple_embed` shows into one line.
+fn build_ntfy_message(payload: &NotificationPayload) -> String {
+    let mut parts = vec![format!("{:?}", payload.item_type)];
+    if let Some(year) = payload.year {
+        parts.push(year.to_string());
+    }
+    parts.push(format!("via {}", payload.downloader));
+    if let Some(ref provider) = payload.provider {
+        parts.push(provider.clone());
+    }
+    parts.push(format!("in {}", format_duration(payload.duration_seconds)));
+    parts.join(" • ")
 }
 
 pub(crate) fn format_duration(seconds: f64) -> String {

--- a/crates/plugin-notifications/src/lib.rs
+++ b/crates/plugin-notifications/src/lib.rs
@@ -15,7 +15,10 @@ mod metadata;
 
 use dispatch::dispatch_webhooks;
 #[cfg(test)]
-use dispatch::{NotificationService, build_simple_embed, format_duration, parse_notification_url};
+use dispatch::{
+    NotificationService, NtfyAuth, build_ntfy_body, build_simple_embed, format_duration,
+    parse_notification_url,
+};
 use metadata::{fetch_tmdb_overview, fetch_tvdb_slug};
 
 const TMDB_BASE_URL: &str = "https://api.themoviedb.org/3";

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -171,6 +171,14 @@ fn ntfy_url_parser_rejects_a_missing_topic() {
 }
 
 #[test]
+fn ntfy_url_parser_rejects_a_multi_segment_topic() {
+    // `/` isn't a valid character in an ntfy topic name, so a second
+    // segment here reads as a topic path rather than the supported
+    // single-topic form.
+    assert!(parse_notification_url("ntfy://host/topic-one/topic-two").is_none());
+}
+
+#[test]
 fn ntfy_body_condenses_the_core_fields_and_attaches_the_poster() {
     let body = build_ntfy_body("mytopic", None, None, &payload());
 

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -172,12 +172,23 @@ fn ntfy_url_parser_rejects_a_missing_topic() {
 
 #[test]
 fn ntfy_body_condenses_the_core_fields_and_attaches_the_poster() {
-    let body = build_ntfy_body(&payload());
+    let body = build_ntfy_body("mytopic", None, None, &payload());
 
+    assert_eq!(body["topic"], "mytopic");
     assert_eq!(body["title"], "Downloaded: Movie");
     assert_eq!(
         body["message"],
         "Movie • 2024 • via stremthru • realdebrid • in 1h 1m 1s"
     );
     assert_eq!(body["attach"], "https://image.test/poster.jpg");
+    assert!(body.get("priority").is_none());
+    assert!(body.get("tags").is_none());
+}
+
+#[test]
+fn ntfy_body_includes_priority_and_tags_as_a_json_array() {
+    let body = build_ntfy_body("mytopic", Some("high"), Some("warning, skull"), &payload());
+
+    assert_eq!(body["priority"], "high");
+    assert_eq!(body["tags"], serde_json::json!(["warning", "skull"]));
 }

--- a/crates/plugin-notifications/src/tests.rs
+++ b/crates/plugin-notifications/src/tests.rs
@@ -68,3 +68,116 @@ fn simple_embed_contains_core_download_fields() {
             .any(|field| field["name"] == "Provider" && field["value"] == "realdebrid")
     );
 }
+
+#[test]
+fn ntfy_url_parser_defaults_to_the_public_server() {
+    match parse_notification_url("ntfy://mytopic") {
+        Some(NotificationService::Ntfy {
+            base_url,
+            topic,
+            auth: NtfyAuth::None,
+            priority: None,
+            tags: None,
+        }) => {
+            assert_eq!(base_url, "https://ntfy.sh");
+            assert_eq!(topic, "mytopic");
+        }
+        _ => panic!("expected a public-server ntfy URL"),
+    }
+
+    // `ntfys://` is still just the public server when no host is given.
+    match parse_notification_url("ntfys://mytopic") {
+        Some(NotificationService::Ntfy { base_url, .. }) => {
+            assert_eq!(base_url, "https://ntfy.sh");
+        }
+        _ => panic!("expected a public-server ntfy URL"),
+    }
+}
+
+#[test]
+fn ntfy_url_parser_supports_self_hosted_servers() {
+    match parse_notification_url("ntfy://myhost.local/mytopic") {
+        Some(NotificationService::Ntfy {
+            base_url, topic, ..
+        }) => {
+            assert_eq!(base_url, "http://myhost.local");
+            assert_eq!(topic, "mytopic");
+        }
+        _ => panic!("expected a self-hosted ntfy URL"),
+    }
+
+    match parse_notification_url("ntfys://myhost.local:8080/mytopic") {
+        Some(NotificationService::Ntfy { base_url, .. }) => {
+            assert_eq!(base_url, "https://myhost.local:8080");
+        }
+        _ => panic!("expected a secure self-hosted ntfy URL"),
+    }
+
+    // The public server has no plaintext endpoint, so an explicit host of
+    // ntfy.sh is forced to https even under the plain `ntfy://` scheme.
+    match parse_notification_url("ntfy://ntfy.sh/mytopic") {
+        Some(NotificationService::Ntfy { base_url, .. }) => {
+            assert_eq!(base_url, "https://ntfy.sh");
+        }
+        _ => panic!("expected ntfy.sh to be forced to https"),
+    }
+}
+
+#[test]
+fn ntfy_url_parser_supports_basic_and_token_auth() {
+    match parse_notification_url("ntfy://user:pass@myhost/mytopic") {
+        Some(NotificationService::Ntfy {
+            auth: NtfyAuth::Basic { user, password },
+            ..
+        }) => {
+            assert_eq!(user, "user");
+            assert_eq!(password, "pass");
+        }
+        _ => panic!("expected basic auth"),
+    }
+
+    match parse_notification_url("ntfy://tk_abc123@ntfy.sh/mytopic") {
+        Some(NotificationService::Ntfy {
+            auth: NtfyAuth::Token(token),
+            ..
+        }) => {
+            assert_eq!(token, "tk_abc123");
+        }
+        _ => panic!("expected token auth"),
+    }
+}
+
+#[test]
+fn ntfy_url_parser_reads_priority_and_tags() {
+    match parse_notification_url("ntfy://mytopic?priority=high&tags=warning,skull") {
+        Some(NotificationService::Ntfy { priority, tags, .. }) => {
+            assert_eq!(priority.as_deref(), Some("high"));
+            assert_eq!(tags.as_deref(), Some("warning,skull"));
+        }
+        _ => panic!("expected priority and tags to be parsed"),
+    }
+
+    // An unrecognized priority is dropped rather than passed through blindly.
+    match parse_notification_url("ntfy://mytopic?priority=bogus") {
+        Some(NotificationService::Ntfy { priority, .. }) => assert_eq!(priority, None),
+        _ => panic!("expected an ntfy URL"),
+    }
+}
+
+#[test]
+fn ntfy_url_parser_rejects_a_missing_topic() {
+    assert!(parse_notification_url("ntfy://").is_none());
+    assert!(parse_notification_url("ntfy://myhost/").is_none());
+}
+
+#[test]
+fn ntfy_body_condenses_the_core_fields_and_attaches_the_poster() {
+    let body = build_ntfy_body(&payload());
+
+    assert_eq!(body["title"], "Downloaded: Movie");
+    assert_eq!(
+        body["message"],
+        "Movie • 2024 • via stremthru • realdebrid • in 1h 1m 1s"
+    );
+    assert_eq!(body["attach"], "https://image.test/poster.jpg");
+}

--- a/crates/riven-core/src/http/profiles.rs
+++ b/crates/riven-core/src/http/profiles.rs
@@ -49,3 +49,4 @@ impl HttpServiceProfile {
 
 pub const DISCORD_WEBHOOK: HttpServiceProfile = HttpServiceProfile::new("discord_webhook");
 pub const WEBHOOK_JSON: HttpServiceProfile = HttpServiceProfile::new("json_webhook");
+pub const NTFY: HttpServiceProfile = HttpServiceProfile::new("ntfy");


### PR DESCRIPTION
## Summary
- Adds `ntfy://` / `ntfys://` URL support to the notifications plugin, matching Apprise's ntfy scheme:
  - `ntfy://topic` — the public ntfy.sh server (always https, even under the plain `ntfy://` scheme, since the public server has no plaintext endpoint)
  - `ntfy://host/topic` / `ntfys://host/topic` — self-hosted server (http/https respectively)
  - Optional `user:pass@` (Basic) or `token@` (Bearer) auth
  - `?priority=max|high|low|min` and `?tags=a,b,c` query parameters
- Multiple topics per URL (Apprise's `{topic1}/{topic2}` form) aren't supported — without an explicit host there's no way to tell a second topic segment apart from a hostname.
- The message body condenses the same core download fields the other providers show into one line (ntfy's `message` field is plain text) and attaches the poster image via ntfy's `attach` field when available.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy -p plugin-notifications -p riven-core --all-targets -- -D warnings`, `cargo test -p plugin-notifications -p riven-core` (84 passed, including 6 new ntfy tests covering the public-server default, self-hosted host/port, basic/token auth, priority/tags parsing, and a missing-topic rejection) — all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ntfy notification support for public and self-hosted servers.
  * Supports HTTP/HTTPS delivery, Basic or token authentication, priorities, tags, and webhook-compatible JSON payloads.
  * Notifications can include formatted text and optional poster attachments.
  * Supports flexible ntfy topics and secure credential handling during delivery.

* **Tests**
  * Added coverage for URL parsing, authentication, topics, priorities, tags, payload formatting, and attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->