### PR TITLE
Fix/rate limit defers instead of sleeping

### DIFF
--- a/crates/plugin-newznab/src/lib.rs
+++ b/crates/plugin-newznab/src/lib.rs
@@ -423,6 +423,12 @@ async fn scrape_page(
         .await
     {
         Ok(r) => r,
+        // A deferred request means the limiter is saturated, not that the
+        // indexer is broken: report it as rate-limited so the scrape is
+        // requeued with backoff rather than counted as a failure.
+        Err(error) if error.is::<RateLimitedError>() => {
+            return ScrapeOutcome::RateLimited(error.to_string());
+        }
         Err(error) => return ScrapeOutcome::Failed(error),
     };
     let status = resp.status();

--- a/crates/plugin-usenet/src/lib.rs
+++ b/crates/plugin-usenet/src/lib.rs
@@ -369,15 +369,24 @@ impl Plugin for UsenetPlugin {
             return Ok(HookResponse::Empty);
         };
 
-        let Some(xml_arc) = fetch_nzb_xml(info_hash, ctx).await else {
-            // No NZB body means no release name exists anywhere yet — the
-            // media item id is the only handle a reader has here.
-            tracing::warn!(
-                info_hash,
-                media_item_id = id,
-                "no NZB body available; cannot ingest"
-            );
-            return Ok(HookResponse::DownloadStreamUnavailable);
+        let xml_arc = match fetch_nzb_xml(info_hash, ctx).await {
+            Ok(Some(xml)) => xml,
+            Ok(None) => {
+                // No NZB body means no release name exists anywhere yet — the
+                // media item id is the only handle a reader has here.
+                tracing::warn!(
+                    info_hash,
+                    media_item_id = id,
+                    "no NZB body available; cannot ingest"
+                );
+                return Ok(HookResponse::DownloadStreamUnavailable);
+            }
+            // The fetch was rate-limited, which says nothing about the
+            // release. Propagate so the download job requeues; answering
+            // `DownloadStreamUnavailable` here is how a saturated NZB
+            // limiter once permanently blacklisted thousands of good
+            // streams in an afternoon.
+            Err(error) => return Err(error),
         };
         // Cheap head-only peek (never a full parse — see `peek_release_title`),
         // so every log below this point names the release rather than only its
@@ -539,24 +548,44 @@ async fn nzb_indexer_for_hash(info_hash: &str, ctx: &PluginContext) -> Option<St
         .flatten()
 }
 
-async fn fetch_nzb_xml(info_hash: &str, ctx: &PluginContext) -> Option<Arc<String>> {
+/// `Ok(None)` means the NZB genuinely cannot be had (no URL mapping left in
+/// Redis, or the indexer answered without a body) — a verdict about the
+/// release. `Err` is [`RateLimitedError`] only: a verdict about *this moment*,
+/// which the caller must surface as a deferral, never as unavailability.
+/// Other transport errors stay `Ok(None)`, matching the behaviour this
+/// function has always had for them.
+async fn fetch_nzb_xml(
+    info_hash: &str,
+    ctx: &PluginContext,
+) -> anyhow::Result<Option<Arc<String>>> {
     if let Some(hit) = nzb_body_cache().get(info_hash) {
-        return Some(hit);
+        return Ok(Some(hit));
     }
-    let nzb_url = nzb_url_for_hash(info_hash, ctx).await?;
-    let resp = ctx
+    let Some(nzb_url) = nzb_url_for_hash(info_hash, ctx).await else {
+        return Ok(None);
+    };
+    let resp = match ctx
         .http
         .send_data(PROFILE, Some(nzb_url.clone()), |client| {
             client.get(&nzb_url)
         })
         .await
-        .ok()?;
+    {
+        Ok(resp) => resp,
+        Err(error) if error.is::<riven_core::http::RateLimitedError>() => return Err(error),
+        Err(error) => {
+            tracing::debug!(info_hash, %error, "nzb fetch failed");
+            return Ok(None);
+        }
+    };
     if !resp.status().is_success() {
         tracing::debug!(info_hash, status = %resp.status(), "nzb fetch returned non-success");
-        return None;
+        return Ok(None);
     }
-    let xml = resp.text().ok()?;
+    let Ok(xml) = resp.text() else {
+        return Ok(None);
+    };
     let arc = Arc::new(xml);
     nzb_body_cache().put(info_hash.to_string(), arc.clone(), arc.len() as u64);
-    Some(arc)
+    Ok(Some(arc))
 }

--- a/crates/riven-core/src/http.rs
+++ b/crates/riven-core/src/http.rs
@@ -130,4 +130,51 @@ mod tests {
         handle.abort();
         Ok(())
     }
+
+    /// The congestion-collapse guard: when the wait for a token is longer than
+    /// a job can afford, the call must hand back `RateLimitedError` promptly so
+    /// the caller can requeue, rather than sitting on its worker slot until the
+    /// job's own deadline kills it having made no request at all.
+    #[tokio::test]
+    async fn defers_instead_of_waiting_out_a_long_rate_limit() -> anyhow::Result<()> {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let (addr, handle) = spawn_json_server(Arc::clone(&counter)).await?;
+        let http = HttpClient::new(reqwest::Client::new());
+        let url = format!("http://{addr}/value");
+        // One token per minute: the second caller would have to wait ~60s,
+        // far past what the limiter is willing to block for.
+        let profile =
+            HttpServiceProfile::new("test-defer").with_rate_limit(1, Duration::from_secs(60));
+
+        http.get_json::<serde_json::Value, _>(profile.clone(), format!("{url}?a=1"), |client| {
+            client.get(format!("{url}?a=1"))
+        })
+        .await?;
+
+        let started = Instant::now();
+        let deferred = http
+            .get_json::<serde_json::Value, _>(profile, format!("{url}?a=2"), |client| {
+                client.get(format!("{url}?a=2"))
+            })
+            .await;
+
+        let error = deferred.expect_err("second call should defer, not wait");
+        assert!(
+            error.is::<super::RateLimitedError>(),
+            "expected RateLimitedError, got: {error}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "deferring must be prompt, took {:?}",
+            started.elapsed()
+        );
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "the deferred call must not reach the server"
+        );
+
+        handle.abort();
+        Ok(())
+    }
 }

--- a/crates/riven-core/src/http/client.rs
+++ b/crates/riven-core/src/http/client.rs
@@ -5,7 +5,7 @@ use dashmap::DashMap;
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 
-use super::inflight::InFlightRequest;
+use super::inflight::{InFlightRequest, SharedError};
 use super::rate_limit::ServiceState;
 use super::response::HttpResponseData;
 use super::retry::{BACKOFF_BASE_SECS, execute_with_retry, parse_rate_limit_pause};
@@ -31,11 +31,14 @@ impl HttpClient {
         &self.inner
     }
 
+    /// Fails with [`RateLimitedError`] when the service's limiter cannot supply
+    /// a token promptly. Callers should requeue rather than retry inline — the
+    /// point is to give the worker slot back, not to wait somewhere else.
     pub async fn send<F>(
         &self,
         profile: HttpServiceProfile,
         make_request: F,
-    ) -> reqwest::Result<reqwest::Response>
+    ) -> anyhow::Result<reqwest::Response>
     where
         F: Fn(&reqwest::Client) -> reqwest::RequestBuilder,
     {
@@ -91,9 +94,9 @@ impl HttpClient {
             impl Drop for InflightGuard {
                 fn drop(&mut self) {
                     if !self.completed {
-                        self.state.finish(Err(
-                            "inflight leader cancelled before completing request".to_string(),
-                        ));
+                        self.state.finish(Err(SharedError::message(
+                            "inflight leader cancelled before completing request",
+                        )));
                     }
                     self.inflight.remove(&self.key);
                 }
@@ -110,15 +113,15 @@ impl HttpClient {
                 Ok(response) => HttpResponseData::from_response(response)
                     .await
                     .map(Arc::new)
-                    .map_err(|e| e.to_string()),
-                Err(e) => Err(e.to_string()),
+                    .map_err(|e| SharedError::message(e.to_string())),
+                Err(e) => Err(SharedError::new(&e)),
             };
             state.finish(result.clone());
             guard.completed = true;
-            return result.map_err(anyhow::Error::msg);
+            return result.map_err(SharedError::into_anyhow);
         }
 
-        state.wait().await.map_err(anyhow::Error::msg)
+        state.wait().await.map_err(SharedError::into_anyhow)
     }
 
     pub async fn get_json<T, F>(

--- a/crates/riven-core/src/http/inflight.rs
+++ b/crates/riven-core/src/http/inflight.rs
@@ -2,13 +2,50 @@ use std::sync::Arc;
 
 use tokio::sync::watch;
 
-use super::HttpResponseData;
+use super::{HttpResponseData, RateLimitedError};
+
+/// A leader's failure, in a form its deduped followers can share.
+///
+/// `anyhow::Error` is neither `Clone` nor reconstructible, so what crosses the
+/// channel is the message plus the one distinction callers actually branch on:
+/// a rate-limit deferral means "requeue me", every other error means "this
+/// failed". Flattening both into a bare string (as this did) silently turned
+/// every follower's deferral into a generic failure.
+#[derive(Clone, Debug)]
+pub(super) struct SharedError {
+    message: String,
+    rate_limited: bool,
+}
+
+impl SharedError {
+    pub(super) fn new(error: &anyhow::Error) -> Self {
+        Self {
+            message: error.to_string(),
+            rate_limited: error.is::<RateLimitedError>(),
+        }
+    }
+
+    pub(super) fn message(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            rate_limited: false,
+        }
+    }
+
+    pub(super) fn into_anyhow(self) -> anyhow::Error {
+        if self.rate_limited {
+            RateLimitedError.into()
+        } else {
+            anyhow::Error::msg(self.message)
+        }
+    }
+}
 
 /// Deduplicates concurrent in-flight requests. Uses `watch` so late subscribers
 /// see the result immediately if the leader has already finished.
 #[derive(Debug)]
 pub(super) struct InFlightRequest {
-    tx: watch::Sender<Option<Result<Arc<HttpResponseData>, String>>>,
+    tx: watch::Sender<Option<Result<Arc<HttpResponseData>, SharedError>>>,
 }
 
 impl InFlightRequest {
@@ -17,15 +54,17 @@ impl InFlightRequest {
         Self { tx }
     }
 
-    pub(super) fn finish(&self, result: Result<Arc<HttpResponseData>, String>) {
+    pub(super) fn finish(&self, result: Result<Arc<HttpResponseData>, SharedError>) {
         self.tx.send_replace(Some(result));
     }
 
-    pub(super) async fn wait(&self) -> Result<Arc<HttpResponseData>, String> {
+    pub(super) async fn wait(&self) -> Result<Arc<HttpResponseData>, SharedError> {
         let mut rx = self.tx.subscribe();
         rx.wait_for(std::option::Option::is_some)
             .await
-            .map_err(|_e| "inflight leader cancelled before completing request".to_string())?
+            .map_err(|_e| {
+                SharedError::message("inflight leader cancelled before completing request")
+            })?
             .clone()
             .unwrap()
     }
@@ -36,18 +75,42 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use super::InFlightRequest;
+    use super::{InFlightRequest, SharedError};
 
     #[tokio::test]
     async fn late_subscriber_receives_completed_result() {
         let request = Arc::new(InFlightRequest::new());
         let late_subscriber = Arc::clone(&request);
 
-        request.finish(Err("completed before subscription".to_string()));
+        request.finish(Err(SharedError::message("completed before subscription")));
 
         let result = tokio::time::timeout(Duration::from_millis(50), late_subscriber.wait())
             .await
             .expect("late subscriber should not wait indefinitely");
-        assert_eq!(result.unwrap_err(), "completed before subscription");
+        assert_eq!(
+            result.unwrap_err().into_anyhow().to_string(),
+            "completed before subscription"
+        );
+    }
+
+    /// A follower must learn that the leader *deferred*, not merely that it
+    /// failed: the two lead to opposite handling (requeue vs give up), and
+    /// sharing only the message collapsed them.
+    #[tokio::test]
+    async fn a_deferral_stays_a_deferral_for_followers() {
+        let request = Arc::new(InFlightRequest::new());
+        let follower = Arc::clone(&request);
+
+        request.finish(Err(SharedError::new(&super::RateLimitedError.into())));
+
+        let error = follower
+            .wait()
+            .await
+            .expect_err("follower should see the leader's failure")
+            .into_anyhow();
+        assert!(
+            error.is::<super::RateLimitedError>(),
+            "follower lost the rate-limit signal: {error}"
+        );
     }
 }

--- a/crates/riven-core/src/http/rate_limit.rs
+++ b/crates/riven-core/src/http/rate_limit.rs
@@ -24,6 +24,12 @@ impl RateLimit {
     }
 }
 
+/// Longest a caller will block waiting for a token before being told to
+/// requeue. Short enough to stay far inside the tightest job deadline (the
+/// plugin-hook worker's 180s), long enough that ordinary sub-second pacing
+/// still resolves in-place rather than churning the queue.
+const MAX_LIMITER_WAIT: Duration = Duration::from_secs(10);
+
 #[derive(Debug)]
 pub(super) struct ServiceState {
     pub(super) profile: HttpServiceProfile,
@@ -38,12 +44,29 @@ impl ServiceState {
         }
     }
 
-    pub(super) async fn acquire_slot(&self) {
+    /// Take a token, or report that the caller should hand its job back to the
+    /// queue. `false` means no token was available and waiting for one would
+    /// cost more than [`MAX_LIMITER_WAIT`].
+    ///
+    /// riven-ts never has to make this choice: BullMQ's limiter is queue-level,
+    /// so a worker does not *pick up* a job while the queue is limited and a
+    /// rate-limited job is never sitting in a slot. riven's limiter is
+    /// per-request and inside the handler, so the equivalent is "wait briefly,
+    /// otherwise defer" — a job that keeps waiting holds its worker slot and
+    /// spends its own deadline doing nothing, which is how a saturated bucket
+    /// turns into every job dying at its timeout having made no request.
+    pub(super) async fn acquire_slot(&self) -> bool {
+        let deadline = Instant::now() + MAX_LIMITER_WAIT;
         loop {
             let wait = self.limiter.lock().next_wait(&self.profile);
             match wait {
-                Some(d) => sleep(d).await,
-                None => return,
+                Some(d) => {
+                    if Instant::now() + d > deadline {
+                        return false;
+                    }
+                    sleep(d).await;
+                }
+                None => return true,
             }
         }
     }

--- a/crates/riven-core/src/http/retry.rs
+++ b/crates/riven-core/src/http/retry.rs
@@ -5,8 +5,8 @@ use reqwest::header::HeaderMap;
 use serde::Deserialize;
 use tokio::time::sleep;
 
-use super::HttpServiceProfile;
 use super::rate_limit::ServiceState;
+use super::{HttpServiceProfile, RateLimitedError};
 
 pub(super) const BACKOFF_BASE_SECS: u64 = 5;
 const JITTER: f64 = 0.5;
@@ -156,12 +156,16 @@ pub(super) fn parse_rate_limit_pause(
     }
 }
 
+/// Returns [`RateLimitedError`] rather than blocking when the service's
+/// limiter cannot supply a token promptly, so the caller can requeue the job
+/// and free its worker slot — matching riven-ts, where a rate-limited job is
+/// handed back via `Worker.RateLimitError()` instead of waiting in place.
 pub(super) async fn execute_with_retry<F>(
     client: &reqwest::Client,
     service: Option<&ServiceState>,
     attempts: u32,
     make_request: F,
-) -> reqwest::Result<reqwest::Response>
+) -> anyhow::Result<reqwest::Response>
 where
     F: Fn(&reqwest::Client) -> reqwest::RequestBuilder,
 {
@@ -171,8 +175,14 @@ where
     loop {
         let is_last = attempt + 1 >= attempts;
 
-        if let Some(service) = service {
-            service.acquire_slot().await;
+        if let Some(service) = service
+            && !service.acquire_slot().await
+        {
+            tracing::debug!(
+                service = service.profile.name.as_ref(),
+                "http request deferred: the service is rate-limited, requeueing instead of holding the slot"
+            );
+            return Err(RateLimitedError.into());
         }
 
         match make_request(client).send().await {
@@ -202,7 +212,7 @@ where
                 sleep(delay).await;
                 attempt += 1;
             }
-            Err(e) => return Err(e),
+            Err(e) => return Err(e.into()),
         }
     }
 }

--- a/crates/riven-db/src/repo/state.rs
+++ b/crates/riven-db/src/repo/state.rs
@@ -13,6 +13,17 @@ use sea_orm::{
 
 use crate::orm;
 
+/// How many failed attempts an item that *already has a file* will spend
+/// chasing an enabled profile it is missing before settling for what it has.
+///
+/// Deliberately separate from `maximum_scrape_attempts`: that ceiling turns an
+/// item `Failed`, which is the wrong answer for something already downloaded
+/// and playable, and it is commonly left disabled (`0`) — which here would mean
+/// an item whose missing profile does not exist anywhere gets re-scraped
+/// forever. A profile upgrade is best-effort by nature, so it gets a small
+/// fixed budget and then stops asking.
+const PROFILE_UPGRADE_ATTEMPTS: i32 = 3;
+
 /// Read the per-item retry ceiling from the `general` settings blob. `0`
 /// disables the ceiling.
 async fn read_max_attempts() -> Result<i32> {
@@ -117,6 +128,7 @@ struct ItemFacts {
     is_unreleased: bool,
     failed_attempts: i32,
     has_media_entry: bool,
+    missing_enabled_profile: bool,
     has_non_blacklisted_stream: bool,
 }
 
@@ -137,6 +149,18 @@ async fn load_item_facts(item_id: i64) -> Result<Option<ItemFacts>> {
                   SELECT 1 FROM filesystem_entries fe
                   WHERE fe.media_item_id = m.id AND fe.entry_type = 'media'
               ) AS has_media_entry,
+              -- An enabled profile with no entry of its own: the item has a
+              -- file but not every file that was asked for.
+              EXISTS(
+                  SELECT 1 FROM ranking_profiles rp
+                  WHERE rp.enabled
+                    AND NOT EXISTS(
+                        SELECT 1 FROM filesystem_entries fe
+                        WHERE fe.media_item_id = m.id
+                          AND fe.entry_type = 'media'
+                          AND fe.ranking_profile_name = rp.name
+                    )
+              ) AS missing_enabled_profile,
               EXISTS(
                   SELECT 1 FROM media_item_streams ms
                   WHERE ms.media_item_id = m.id
@@ -199,6 +223,7 @@ pub fn leaf_state(
     is_unreleased: bool,
     failed_attempts: i32,
     has_media_entry: bool,
+    missing_enabled_profile: bool,
     has_non_blacklisted_stream: bool,
     max_attempts: i32,
 ) -> MediaItemState {
@@ -209,6 +234,17 @@ pub fn leaf_state(
         return current_state;
     }
     if matches!(item_type, MediaItemType::Movie | MediaItemType::Episode) && has_media_entry {
+        // A file exists, so this item can never be `Failed` and never re-enters
+        // the pipeline from scratch. It can still have work left: with more
+        // than one profile enabled, "has a file" and "has the files that were
+        // asked for" are different questions, and only the second one means
+        // done. `PartiallyCompleted` is already a retryable state, so saying it
+        // here is enough — the existing retry loop picks the item up, and
+        // `run_downloads` skips every profile `get_downloaded_profile_names`
+        // reports as satisfied, so only the missing one is chased.
+        if missing_enabled_profile && failed_attempts < PROFILE_UPGRADE_ATTEMPTS {
+            return MediaItemState::PartiallyCompleted;
+        }
         return MediaItemState::Completed;
     }
     if current_state == MediaItemState::Failed {
@@ -237,6 +273,7 @@ async fn recompute_one(item_id: i64, max_attempts: i32) -> Result<Option<i64>> {
             facts.is_unreleased,
             facts.failed_attempts,
             facts.has_media_entry,
+            facts.missing_enabled_profile,
             facts.has_non_blacklisted_stream,
             max_attempts,
         )

--- a/crates/riven-db/tests/state.rs
+++ b/crates/riven-db/tests/state.rs
@@ -229,8 +229,28 @@ fn leaf(
         is_unreleased,
         failed_attempts,
         has_media_entry,
+        false,
         has_non_blacklisted_stream,
         max_attempts,
+    )
+}
+
+/// Same, but for the profile-coverage cases: the item has a file and an
+/// enabled profile still has none.
+fn leaf_missing_profile(
+    item_type: MediaItemType,
+    state: MediaItemState,
+    failed_attempts: i32,
+) -> MediaItemState {
+    leaf_state(
+        item_type,
+        state,
+        false,
+        failed_attempts,
+        true,
+        true,
+        true,
+        0,
     )
 }
 
@@ -314,5 +334,70 @@ fn leaf_indexed_when_no_facts() {
     assert_eq!(
         leaf(MediaItemType::Movie, Indexed, false, 0, false, false, 0),
         Indexed
+    );
+}
+
+/// With more than one profile enabled, "has a file" and "has the files that
+/// were asked for" are different questions. Only the second means done, and
+/// `PartiallyCompleted` is already retryable, so the existing retry loop
+/// picks the item up and chases just the missing profile.
+#[test]
+fn leaf_with_a_missing_enabled_profile_is_partially_completed() {
+    assert_eq!(
+        leaf_missing_profile(MediaItemType::Episode, Completed, 0),
+        PartiallyCompleted
+    );
+    assert_eq!(
+        leaf_missing_profile(MediaItemType::Movie, Completed, 0),
+        PartiallyCompleted
+    );
+}
+
+/// The chase is best-effort and must terminate: an item whose missing profile
+/// simply does not exist anywhere would otherwise be re-scraped forever, since
+/// `maximum_scrape_attempts` cannot apply to something already downloaded
+/// (`Failed` is the wrong answer for a file that plays).
+#[test]
+fn leaf_settles_for_what_it_has_once_the_upgrade_budget_is_spent() {
+    assert_eq!(
+        leaf_missing_profile(MediaItemType::Episode, PartiallyCompleted, 2),
+        PartiallyCompleted
+    );
+    assert_eq!(
+        leaf_missing_profile(MediaItemType::Episode, PartiallyCompleted, 3),
+        Completed
+    );
+    assert_eq!(
+        leaf_missing_profile(MediaItemType::Episode, PartiallyCompleted, 99),
+        Completed
+    );
+}
+
+/// Every enabled profile satisfied is still plain `Completed` — the common
+/// case must not change.
+#[test]
+fn leaf_with_full_profile_coverage_is_completed() {
+    assert_eq!(
+        leaf(MediaItemType::Episode, Completed, false, 0, true, true, 0),
+        Completed
+    );
+}
+
+/// A missing profile must not resurrect an item that has no file at all: the
+/// flag is only consulted on the has-a-media-entry branch.
+#[test]
+fn leaf_without_a_file_ignores_profile_coverage() {
+    assert_eq!(
+        leaf_state(
+            MediaItemType::Episode,
+            Indexed,
+            false,
+            0,
+            false,
+            true,
+            true,
+            0
+        ),
+        Scraped
     );
 }

--- a/crates/riven-queue/src/application/download.rs
+++ b/crates/riven-queue/src/application/download.rs
@@ -217,6 +217,7 @@ pub async fn run_rank_streams(id: i64, job: &RankStreamsJob, queue: &JobQueue) {
         info_hash: preferred.clone().unwrap_or_default(),
         magnet: magnet_for_preferred.unwrap_or_default(),
         preferred_info_hash: preferred,
+        rate_limit_retries: 0,
     };
     queue.push_download(download_job).await;
 }
@@ -321,8 +322,8 @@ pub async fn run(id: i64, job: &DownloadJob, queue: &JobQueue) {
         "download: trying candidate streams best-first until one is cached and matches"
     );
 
-    if let Some(preferred_info_hash) = job.preferred_info_hash.as_ref() {
-        let _ = run_preferred_stream(
+    let outcome = if let Some(preferred_info_hash) = job.preferred_info_hash.as_ref() {
+        run_preferred_stream(
             id,
             &item,
             queue,
@@ -333,9 +334,9 @@ pub async fn run(id: i64, job: &DownloadJob, queue: &JobQueue) {
             &mut cache,
             hierarchy.as_ref(),
         )
-        .await;
+        .await
     } else {
-        let _ = run_downloads(
+        run_downloads(
             id,
             &item,
             queue,
@@ -346,7 +347,35 @@ pub async fn run(id: i64, job: &DownloadJob, queue: &JobQueue) {
             &mut cache,
             hierarchy.as_ref(),
         )
-        .await;
+        .await
+    };
+
+    // A deferred walk learned nothing about any stream: requeue the whole job
+    // on the shared rate-limit ladder and record nothing against the item —
+    // no `failed_attempts`, no blacklist, no error event. Mirrors what
+    // `handle_scrape` does when every scraper is rate-limited, and riven-ts's
+    // `Worker.RateLimitError()` (hand the job back un-attempted). No retry
+    // ceiling on purpose: the ladder tops out at 24h, and the only thing a
+    // ceiling could add is converting "provider busy for a long time" into a
+    // recorded failure.
+    if matches!(outcome, DownloadWalkOutcome::Deferred) {
+        let backoff = super::scrape::rate_limit_backoff(job.rate_limit_retries);
+        tracing::warn!(
+            id,
+            title = %item.title,
+            attempt = job.rate_limit_retries + 1,
+            retry_in_secs = backoff.as_secs(),
+            "download: a provider is rate-limited right now; requeueing this download rather than judging its streams"
+        );
+        queue
+            .push_download_after(
+                DownloadJob {
+                    rate_limit_retries: job.rate_limit_retries + 1,
+                    ..job.clone()
+                },
+                backoff,
+            )
+            .await;
     }
 }
 
@@ -423,6 +452,20 @@ async fn load_item_silently(id: i64, phase: &str) -> Option<MediaItem> {
 /// `lookup` once per `(stream, plugin, provider)`; we lazily fetch the full
 /// hash list the first time and reuse the response for every subsequent
 /// stream that asks for the same provider.
+/// A provider's cache-check (or a download plugin mid-walk) was rate-limited:
+/// nothing was learned about any stream, and the whole job should requeue.
+struct WalkDeferred;
+
+/// How a download walk ended. `Finished` means it ran to a verdict — the
+/// walk's own success/failure handling (blacklists, `failed_attempts`, the
+/// events) has already run by the time it returns. `Deferred` means it
+/// stopped early because a service was rate-limited, and none of that
+/// verdict-recording happened: the caller owns requeueing the job.
+enum DownloadWalkOutcome {
+    Finished,
+    Deferred,
+}
+
 struct CacheMemo {
     hashes: Vec<String>,
     /// `(plugin, provider)` → `hash → cached files`. An empty inner Vec is
@@ -451,16 +494,20 @@ impl CacheMemo {
         provider: Option<&str>,
         info_hash: &str,
         attempt_unknown: bool,
-    ) -> Option<Vec<CacheCheckFile>> {
+    ) -> Result<Option<Vec<CacheCheckFile>>, WalkDeferred> {
         let key = (plugin_name.to_string(), provider.map(str::to_string));
         if !self.results.contains_key(&key) {
+            // A deferred fetch is deliberately not memoized: nothing was
+            // learned, and the requeued job should ask again.
             let map =
                 fetch_provider_cache(queue, plugin_name, provider, &self.hashes, attempt_unknown)
-                    .await;
+                    .await?;
             self.results.insert(key.clone(), map);
         }
-        let map = self.results.get(&key)?;
-        map.get(&info_hash.to_lowercase()).cloned()
+        Ok(self
+            .results
+            .get(&key)
+            .and_then(|map| map.get(&info_hash.to_lowercase()).cloned()))
     }
 }
 
@@ -474,7 +521,7 @@ async fn fetch_provider_cache(
     provider: Option<&str>,
     hashes: &[String],
     attempt_unknown: bool,
-) -> HashMap<String, Vec<CacheCheckFile>> {
+) -> Result<HashMap<String, Vec<CacheCheckFile>>, WalkDeferred> {
     let event = RivenEvent::MediaItemDownloadCacheCheckRequested {
         hashes: hashes.to_vec(),
         provider: provider.map(str::to_string),
@@ -494,6 +541,18 @@ async fn fetch_provider_cache(
             }
         }
         Some(Ok(_)) | None => {}
+        // Rate-limited is not "unavailable": an empty map here makes every
+        // stream look uncached, the walk skips them all, and the per-stream
+        // fallthrough blacklists releases nobody could actually check.
+        Some(Err(ref error)) if error.is::<riven_core::http::RateLimitedError>() => {
+            tracing::debug!(
+                plugin = plugin_name,
+                provider,
+                hashes = hashes.len(),
+                "download: this provider's cache-check is rate-limited; requeueing the job"
+            );
+            return Err(WalkDeferred);
+        }
         Some(Err(error)) => {
             tracing::warn!(
                 plugin = plugin_name,
@@ -504,7 +563,7 @@ async fn fetch_provider_cache(
             );
         }
     }
-    out
+    Ok(out)
 }
 
 /// Build the flat `(plugin, provider)` iteration order used by the download
@@ -581,7 +640,7 @@ async fn run_preferred_stream(
     plugin_providers: &[(String, Option<String>)],
     cache: &mut CacheMemo,
     hierarchy: Option<&DownloadHierarchyContext>,
-) -> bool {
+) -> DownloadWalkOutcome {
     let Some(stream) = streams
         .iter()
         .find(|s| s.info_hash.eq_ignore_ascii_case(preferred_info_hash))
@@ -602,7 +661,7 @@ async fn run_preferred_stream(
                 tvdb_id: notification_tvdb_id(item, hierarchy),
             })
             .await;
-        return false;
+        return DownloadWalkOutcome::Finished;
     };
 
     let attempt_unknown = queue
@@ -612,7 +671,7 @@ async fn run_preferred_stream(
         .attempt_unknown_downloads;
 
     for (plugin, provider) in plugin_providers {
-        let cached_files = cache
+        let cached_files = match cache
             .lookup(
                 queue,
                 plugin,
@@ -620,7 +679,11 @@ async fn run_preferred_stream(
                 &stream.info_hash,
                 attempt_unknown,
             )
-            .await;
+            .await
+        {
+            Ok(files) => files,
+            Err(WalkDeferred) => return DownloadWalkOutcome::Deferred,
+        };
         let stores = stores_for_attempt(provider, cached_files);
 
         match attempt_download(
@@ -629,12 +692,13 @@ async fn run_preferred_stream(
         .await
         {
             DownloadAttemptOutcome::Failed => continue,
+            DownloadAttemptOutcome::Deferred => return DownloadWalkOutcome::Deferred,
             DownloadAttemptOutcome::TerminalHandled | DownloadAttemptOutcome::Progressed => {
-                return true;
+                return DownloadWalkOutcome::Finished;
             }
             DownloadAttemptOutcome::Succeeded => {
                 finalize_download_success(id, item, queue, start_time, None, None, hierarchy).await;
-                return true;
+                return DownloadWalkOutcome::Finished;
             }
         }
     }
@@ -656,7 +720,7 @@ async fn run_preferred_stream(
             tvdb_id: notification_tvdb_id(item, hierarchy),
         })
         .await;
-    false
+    DownloadWalkOutcome::Finished
 }
 
 async fn run_downloads(
@@ -669,7 +733,7 @@ async fn run_downloads(
     plugin_providers: &[(String, Option<String>)],
     cache: &mut CacheMemo,
     hierarchy: Option<&DownloadHierarchyContext>,
-) -> bool {
+) -> DownloadWalkOutcome {
     let mut done_profiles: HashSet<String> = fetch_done_profiles(id, item.item_type)
         .await
         .into_iter()
@@ -720,7 +784,7 @@ async fn run_downloads(
                     title = %item.title,
                     "download: cancelled by the user, stopping without trying the remaining streams"
                 );
-                return any_success;
+                return DownloadWalkOutcome::Finished;
             }
 
             if let Some(size) = stream.file_size_bytes
@@ -745,7 +809,7 @@ async fn run_downloads(
                     continue;
                 }
 
-                let cached_files = cache
+                let cached_files = match cache
                     .lookup(
                         queue,
                         plugin,
@@ -753,7 +817,11 @@ async fn run_downloads(
                         &stream.info_hash,
                         attempt_unknown,
                     )
-                    .await;
+                    .await
+                {
+                    Ok(files) => files,
+                    Err(WalkDeferred) => return DownloadWalkOutcome::Deferred,
+                };
 
                 let is_cached = cached_files.is_some();
                 if !is_cached && !attempt_unknown {
@@ -785,6 +853,10 @@ async fn run_downloads(
                     DownloadAttemptOutcome::Failed => {
                         attempted.insert(key);
                     }
+                    // Returning from inside the provider loop also skips the
+                    // per-stream permanent blacklist below — deliberately, as
+                    // nothing was learned about this stream.
+                    DownloadAttemptOutcome::Deferred => return DownloadWalkOutcome::Deferred,
                     DownloadAttemptOutcome::TerminalHandled | DownloadAttemptOutcome::Succeeded => {
                         done_profiles.insert(profile_name.clone());
                         any_success = true;
@@ -843,14 +915,14 @@ async fn run_downloads(
                 tvdb_id: notification_tvdb_id(item, hierarchy),
             })
             .await;
-        return false;
+        return DownloadWalkOutcome::Finished;
     }
 
     // Season/Show persists already emit their own Success/PartialSuccess events
     // and library-state updates per profile (see persist_season/persist_show);
     // the notify+finalize below is the Movie/Episode-only completion path.
     if matches!(item.item_type, MediaItemType::Season | MediaItemType::Show) {
-        return true;
+        return DownloadWalkOutcome::Finished;
     }
 
     if !profiles
@@ -870,7 +942,7 @@ async fn run_downloads(
     }
 
     finalize_download_success(id, item, queue, start_time, None, None, hierarchy).await;
-    true
+    DownloadWalkOutcome::Finished
 }
 
 fn stores_for_attempt(

--- a/crates/riven-queue/src/application/download/execute.rs
+++ b/crates/riven-queue/src/application/download/execute.rs
@@ -25,6 +25,14 @@ pub enum DownloadAttemptOutcome {
     /// count, can be a day apart under the escalating backoff).
     Progressed,
     TerminalHandled,
+    /// A plugin was rate-limited before it could say anything about the
+    /// release. This is a fact about *now*, not about the stream, and the
+    /// two must never be conflated: recording it as `Failed` counts toward
+    /// `failed_attempts` and — once every provider "fails" — permanently
+    /// blacklists a release nobody actually looked at. The caller must stop
+    /// the walk and requeue the whole job, because the limiter that deferred
+    /// this candidate would defer every later candidate the same way.
+    Deferred,
 }
 
 pub async fn attempt_download(
@@ -66,15 +74,21 @@ pub async fn attempt_download(
         cached_stores: stores.clone(),
     };
 
+    #[derive(Default)]
+    struct DispatchVerdict {
+        result: Option<Box<DownloadResult>>,
+        saw_unavailable: bool,
+        saw_rate_limited: bool,
+    }
+
     async fn dispatch_once(
         queue: &JobQueue,
         event: &RivenEvent,
         info_hash: &str,
         raw_title: &str,
-    ) -> (Option<Box<DownloadResult>>, bool) {
+    ) -> DispatchVerdict {
         let results = queue.registry.dispatch(event).await;
-        let mut download_result: Option<Box<DownloadResult>> = None;
-        let mut saw_unavailable = false;
+        let mut verdict = DispatchVerdict::default();
         for (plugin_name, result) in results {
             match result {
                 Ok(HookResponse::Download(download)) => {
@@ -85,11 +99,11 @@ pub async fn attempt_download(
                         files = download.files.len(),
                         "download: plugin accepted the release and returned its file list"
                     );
-                    download_result = Some(download);
+                    verdict.result = Some(download);
                     break;
                 }
                 Ok(HookResponse::DownloadStreamUnavailable) => {
-                    saw_unavailable = true;
+                    verdict.saw_unavailable = true;
                     tracing::debug!(
                         plugin = plugin_name,
                         info_hash,
@@ -98,6 +112,19 @@ pub async fn attempt_download(
                     );
                 }
                 Ok(_) => {}
+                // A rate-limited plugin said nothing about the release — it
+                // never got as far as looking. Kept apart from real errors so
+                // the caller defers the job instead of letting the walk fall
+                // through to "no provider could fetch it", which blacklists.
+                Err(ref error) if error.is::<riven_core::http::RateLimitedError>() => {
+                    verdict.saw_rate_limited = true;
+                    tracing::debug!(
+                        plugin = plugin_name,
+                        info_hash,
+                        raw_title,
+                        "download: plugin is rate-limited; the job will requeue rather than judge this release"
+                    );
+                }
                 Err(error) => {
                     tracing::warn!(
                         plugin = plugin_name,
@@ -109,13 +136,12 @@ pub async fn attempt_download(
                 }
             }
         }
-        (download_result, saw_unavailable)
+        verdict
     }
 
-    let (mut download_result, mut saw_unavailable) =
-        dispatch_once(queue, &event, info_hash, raw_title).await;
+    let mut verdict = dispatch_once(queue, &event, info_hash, raw_title).await;
 
-    if download_result.is_none() && saw_unavailable {
+    if verdict.result.is_none() && verdict.saw_unavailable && !verdict.saw_rate_limited {
         if let Err(error) = clear_stremthru_cache_check_keys(queue, info_hash, raw_title).await {
             tracing::error!(
                 id,
@@ -137,15 +163,20 @@ pub async fn attempt_download(
                 magnet: stream.magnet.clone(),
                 cached_stores: Vec::new(),
             };
-            let (retry_result, retry_unavailable) =
-                dispatch_once(queue, &retry_event, info_hash, raw_title).await;
-            download_result = retry_result;
-            saw_unavailable = retry_unavailable;
+            verdict = dispatch_once(queue, &retry_event, info_hash, raw_title).await;
         }
     }
 
-    let Some(download) = download_result else {
-        if saw_unavailable
+    // Deferral outranks every no-result verdict: with a rate-limited plugin
+    // in the mix, "unavailable" from the others is at best a partial answer,
+    // and "no provider could provide it" would be recorded against the
+    // stream. Only an actual accepted download supersedes it.
+    if verdict.result.is_none() && verdict.saw_rate_limited {
+        return DownloadAttemptOutcome::Deferred;
+    }
+
+    let Some(download) = verdict.result else {
+        if verdict.saw_unavailable
             && let Err(error) = clear_stremthru_cache_check_keys(queue, info_hash, raw_title).await
         {
             tracing::error!(

--- a/crates/riven-queue/src/application/scrape.rs
+++ b/crates/riven-queue/src/application/scrape.rs
@@ -15,7 +15,9 @@ use crate::context::{
 use crate::discovery::rank_streams;
 use crate::{IndexJob, JobQueue, ParseScrapeResultsJob, ScrapeJob};
 
-fn rate_limit_backoff(prior_retries: u32) -> Duration {
+/// Shared by the scrape and download flows: both requeue with this ladder
+/// when every service they depend on is rate-limited right now.
+pub(crate) fn rate_limit_backoff(prior_retries: u32) -> Duration {
     let secs = match prior_retries {
         0 => 2 * 60,
         1 => 5 * 60,

--- a/crates/riven-queue/src/dispatch.rs
+++ b/crates/riven-queue/src/dispatch.rs
@@ -40,6 +40,17 @@ impl JobQueue {
         .await;
     }
 
+    /// Push a `DownloadJob` to run after `delay` — the requeue half of a
+    /// rate-limit deferral. Bypasses `push_deduped` for the same reason
+    /// `push_scrape_after` does: the dedup key only covers the in-flight
+    /// phase, and this job is the continuation of one that just released it.
+    pub async fn push_download_after(&self, job: DownloadJob, delay: std::time::Duration) {
+        let task = TaskBuilder::new(job).run_after(delay).build();
+        if let Err(e) = self.download_storage.clone().push_task(task).await {
+            tracing::error!(error = %e, "failed to push delayed DownloadJob");
+        }
+    }
+
     /// Entry point for the download flow. Pushes a `RankStreamsJob` which loads
     /// streams, runs the cache check, builds ranked candidates, hands off to
     /// `DownloadJob` (find-valid-torrent + persist).

--- a/crates/riven-queue/src/jobs.rs
+++ b/crates/riven-queue/src/jobs.rs
@@ -176,6 +176,12 @@ pub struct DownloadJob {
     pub magnet: String,
     #[serde(default)]
     pub preferred_info_hash: Option<String>,
+    /// How many times this job has been requeued because a download plugin
+    /// was rate-limited mid-walk. Drives the same escalating backoff the
+    /// scrape flow uses; `serde(default)` keeps jobs serialized before the
+    /// field existed deserializable.
+    #[serde(default)]
+    pub rate_limit_retries: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Downloads affected by provider rate limits are automatically deferred and requeued with increasing backoff.
  - Rate-limited requests stop promptly instead of waiting indefinitely, improving queue responsiveness.
  - Temporary rate limits no longer mark streams as unavailable, failed, or blacklisted.

- **Bug Fixes**
  - Missing ranking-profile files are now reflected in item completion status during upgrade attempts.
  - Rate-limit handling is preserved across shared and concurrent requests, including NZB fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->