### PR TITLE
feat: manual magnet/NZB entry with full stream-candidate preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -4455,6 +4456,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4368,6 +4368,7 @@ dependencies = [
  "plugin-dashboard",
  "plugin-seerr",
  "rand_core 0.6.4",
+ "redis",
  "reqwest",
  "riven-core",
  "riven-db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,6 +3823,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/plugin-calendar/src/tests.rs
+++ b/crates/plugin-calendar/src/tests.rs
@@ -42,6 +42,7 @@ fn media_item(item_type: MediaItemType, title: &str) -> MediaItem {
         runtime: None,
         item_request_id: None,
         active_stream_id: None,
+        manual_scrape_only: false,
     }
 }
 

--- a/crates/plugin-usenet/Cargo.toml
+++ b/crates/plugin-usenet/Cargo.toml
@@ -16,6 +16,7 @@ tracing = { workspace = true }
 redis = { workspace = true }
 sea-orm = { workspace = true }
 tokio = { workspace = true }
+url = "2"
 
 [lints]
 workspace = true

--- a/crates/plugin-usenet/src/lib.rs
+++ b/crates/plugin-usenet/src/lib.rs
@@ -490,6 +490,17 @@ impl Plugin for UsenetPlugin {
             riven_core::indexer_stats::record_successful_grab(&indexer);
         }
 
+        // If this release came from Manual Scrape's "upload an NZB" entry
+        // point rather than a real indexer, the ingested article data (just
+        // written to the DB/usenet cache above) is now the durable copy —
+        // the temp file this URL points at has done its job and can go.
+        // `uploaded_nzb_filename` is a no-op for any real external NZB URL.
+        if let Some(url) = nzb_url_for_hash(info_hash, ctx).await
+            && let Some(filename) = riven_core::nzb::uploaded_nzb_filename(&url)
+        {
+            riven_core::nzb::delete_nzb_upload(filename).await;
+        }
+
         Ok(HookResponse::Download(Box::new(DownloadResult {
             info_hash: info_hash.to_string(),
             files,

--- a/crates/plugin-usenet/src/lib.rs
+++ b/crates/plugin-usenet/src/lib.rs
@@ -657,8 +657,9 @@ async fn fetch_pinned_manual_nzb_xml(nzb_url: &str) -> anyhow::Result<Option<Str
     };
     let client = riven_core::http::ssrf_guard::build_pinned_client(host, addr)?;
     let response = client.get(nzb_url).send().await?;
-    if !response.status().is_success() {
-        return Ok(None);
+    match riven_core::http::ssrf_guard::read_capped_text(response).await {
+        Ok(xml) => Ok(Some(xml)),
+        Err(riven_core::http::ssrf_guard::CappedReadError::NotSuccess(_)) => Ok(None),
+        Err(error) => Err(error.into()),
     }
-    Ok(Some(response.text().await?))
 }

--- a/crates/plugin-usenet/src/lib.rs
+++ b/crates/plugin-usenet/src/lib.rs
@@ -498,7 +498,7 @@ impl Plugin for UsenetPlugin {
         if let Some(url) = nzb_url_for_hash(info_hash, ctx).await
             && let Some(filename) = riven_core::nzb::uploaded_nzb_filename(&url)
         {
-            riven_core::nzb::delete_nzb_upload(filename).await;
+            riven_core::nzb::delete_nzb_upload(&filename).await;
         }
 
         Ok(HookResponse::Download(Box::new(DownloadResult {

--- a/crates/plugin-usenet/src/lib.rs
+++ b/crates/plugin-usenet/src/lib.rs
@@ -565,6 +565,17 @@ async fn nzb_indexer_for_hash(info_hash: &str, ctx: &PluginContext) -> Option<St
 /// which the caller must surface as a deferral, never as unavailability.
 /// Other transport errors stay `Ok(None)`, matching the behaviour this
 /// function has always had for them.
+///
+/// A manually-supplied URL (`downloadExplicitNzb`, tagged `"manual"` in
+/// [`nzb_indexer_for_hash`]) was already validated once when it was
+/// enqueued, but that check can be up to 30 days before this deferred fetch
+/// actually runs — long enough for DNS to answer differently, or for this
+/// very fetch to follow a redirect the earlier check never saw. Everything
+/// else (a real indexer's own URL, chosen by the admin rather than a
+/// GraphQL caller) keeps going through the ordinary shared client
+/// unchanged; re-running the public-address check against every indexer
+/// fetch would incorrectly reject a self-hosted indexer on an internal
+/// address, which was never the threat this exists for.
 async fn fetch_nzb_xml(
     info_hash: &str,
     ctx: &PluginContext,
@@ -575,28 +586,79 @@ async fn fetch_nzb_xml(
     let Some(nzb_url) = nzb_url_for_hash(info_hash, ctx).await else {
         return Ok(None);
     };
-    let resp = match ctx
-        .http
-        .send_data(PROFILE, Some(nzb_url.clone()), |client| {
-            client.get(&nzb_url)
-        })
-        .await
-    {
-        Ok(resp) => resp,
-        Err(error) if error.is::<riven_core::http::RateLimitedError>() => return Err(error),
-        Err(error) => {
-            tracing::debug!(info_hash, %error, "nzb fetch failed");
+
+    let is_manual = nzb_indexer_for_hash(info_hash, ctx).await.as_deref() == Some("manual");
+    // The loopback temp-upload shape is exempt even on the manual path: it
+    // was already strictly validated (including its port) at write time in
+    // `validate_nzb_fetch_target`, and it points at this process's own
+    // upload endpoint rather than attacker-influenced DNS, so there's
+    // nothing for a re-check here to catch.
+    let xml = if is_manual && riven_core::nzb::uploaded_nzb_filename(&nzb_url).is_none() {
+        match fetch_pinned_manual_nzb_xml(&nzb_url).await {
+            Ok(Some(xml)) => xml,
+            Ok(None) => {
+                tracing::debug!(
+                    info_hash,
+                    "manual nzb url no longer resolves to a public address"
+                );
+                return Ok(None);
+            }
+            Err(error) => {
+                tracing::debug!(info_hash, %error, "manual nzb fetch failed");
+                return Ok(None);
+            }
+        }
+    } else {
+        let resp = match ctx
+            .http
+            .send_data(PROFILE, Some(nzb_url.clone()), |client| {
+                client.get(&nzb_url)
+            })
+            .await
+        {
+            Ok(resp) => resp,
+            Err(error) if error.is::<riven_core::http::RateLimitedError>() => return Err(error),
+            Err(error) => {
+                tracing::debug!(info_hash, %error, "nzb fetch failed");
+                return Ok(None);
+            }
+        };
+        if !resp.status().is_success() {
+            tracing::debug!(info_hash, status = %resp.status(), "nzb fetch returned non-success");
             return Ok(None);
         }
+        let Ok(xml) = resp.text() else {
+            return Ok(None);
+        };
+        xml
     };
-    if !resp.status().is_success() {
-        tracing::debug!(info_hash, status = %resp.status(), "nzb fetch returned non-success");
-        return Ok(None);
-    }
-    let Ok(xml) = resp.text() else {
-        return Ok(None);
-    };
+
     let arc = Arc::new(xml);
     nzb_body_cache().put(info_hash.to_string(), arc.clone(), arc.len() as u64);
     Ok(Some(arc))
+}
+
+/// Re-resolves and re-validates a manually-supplied external NZB URL right
+/// before fetching it (see [`fetch_nzb_xml`]'s doc comment for why the
+/// enqueue-time check alone isn't enough for a fetch this deferred), then
+/// fetches it through a client pinned to exactly that address with
+/// redirects disabled — mirroring `riven-api`'s `validate_nzb_fetch_target`
+/// / `fetch_capped_nzb_text` for the synchronous preview path. `Ok(None)`
+/// covers both "doesn't resolve" and "resolves somewhere non-public";
+/// [`fetch_nzb_xml`] treats either the same as any other unavailable NZB.
+async fn fetch_pinned_manual_nzb_xml(nzb_url: &str) -> anyhow::Result<Option<String>> {
+    let parsed = url::Url::parse(nzb_url)?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| anyhow::anyhow!("nzb url has no host"))?;
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let Some(addr) = riven_core::http::ssrf_guard::resolve_public_target(host, port).await? else {
+        return Ok(None);
+    };
+    let client = riven_core::http::ssrf_guard::build_pinned_client(host, addr)?;
+    let response = client.get(nzb_url).send().await?;
+    if !response.status().is_success() {
+        return Ok(None);
+    }
+    Ok(Some(response.text().await?))
 }

--- a/crates/riven-api/Cargo.toml
+++ b/crates/riven-api/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 webauthn-rs = { workspace = true }
 base64 = { workspace = true }
 uuid = { workspace = true }
+redis = { workspace = true }
 riven-core = { path = "../riven-core" }
 riven-db = { path = "../riven-db" }
 riven-rank = { path = "../riven-rank" }

--- a/crates/riven-api/Cargo.toml
+++ b/crates/riven-api/Cargo.toml
@@ -21,7 +21,7 @@ plugin-calendar = { path = "../plugin-calendar" }
 plugin-seerr = { path = "../plugin-seerr" }
 async-graphql = { workspace = true }
 async-graphql-axum = { workspace = true }
-axum = { workspace = true }
+axum = { workspace = true, features = ["multipart"] }
 tower-http = { workspace = true, features = ["fs", "set-header"] }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/riven-api/src/schema.rs
+++ b/crates/riven-api/src/schema.rs
@@ -142,6 +142,8 @@ mod tests {
         ("discoverStreams", "ScrapeItems"),
         ("downloadDiscoveredStream", "ScrapeItems"),
         ("downloadExplicitNzb", "ScrapeItems"),
+        ("previewManualMagnet", "ScrapeItems"),
+        ("previewManualNzb", "ScrapeItems"),
         ("saveStreamUrl", "ScrapeItems"),
         ("rescanUsenetHealth", "ScrapeItems"),
         // Deletes *and* re-scrapes, so it requires both.

--- a/crates/riven-api/src/schema.rs
+++ b/crates/riven-api/src/schema.rs
@@ -45,6 +45,7 @@ impl StremioAddonToken {
 pub fn build_schema(
     registry: Arc<PluginRegistry>,
     job_queue: Arc<riven_queue::JobQueue>,
+    redis_conn: redis::aio::ConnectionManager,
     http_client: HttpClient,
     log_directory: String,
     downloader_config: Arc<RwLock<DownloaderConfig>>,
@@ -60,6 +61,7 @@ pub fn build_schema(
     )
     .data(registry)
     .data(job_queue)
+    .data(redis_conn)
     .data(http_client)
     .data(downloader_config)
     .data(log_control)
@@ -139,6 +141,7 @@ mod tests {
         ("downloadMediaItem", "ScrapeItems"),
         ("discoverStreams", "ScrapeItems"),
         ("downloadDiscoveredStream", "ScrapeItems"),
+        ("downloadExplicitNzb", "ScrapeItems"),
         ("saveStreamUrl", "ScrapeItems"),
         ("rescanUsenetHealth", "ScrapeItems"),
         // Deletes *and* re-scrapes, so it requires both.

--- a/crates/riven-api/src/schema.rs
+++ b/crates/riven-api/src/schema.rs
@@ -42,6 +42,16 @@ impl StremioAddonToken {
     }
 }
 
+/// This instance's own GraphQL/HTTP listen port, carried in the GraphQL
+/// context so a manual-NZB-URL resolver can tell a genuine
+/// `store_nzb_upload` loopback URL (same port this server is actually
+/// listening on) apart from an attacker-supplied `http://127.0.0.1:<other
+/// port>/internal/nzb-uploads/...` — which has the right shape but would
+/// otherwise smuggle an SSRF request to any other port on the container's
+/// loopback interface. See `validate_nzb_fetch_target`.
+#[derive(Clone, Copy)]
+pub struct GqlPort(pub u16);
+
 pub fn build_schema(
     registry: Arc<PluginRegistry>,
     job_queue: Arc<riven_queue::JobQueue>,
@@ -53,6 +63,7 @@ pub fn build_schema(
     log_tx: tokio::sync::broadcast::Sender<String>,
     vfs_mount_manager: Arc<VfsMountManager>,
     stremio_addon_token: StremioAddonToken,
+    gql_port: GqlPort,
 ) -> AppSchema {
     let builder = Schema::build(
         QueryRoot::default(),
@@ -67,7 +78,8 @@ pub fn build_schema(
     .data(log_control)
     .data(log_tx)
     .data(vfs_mount_manager)
-    .data(stremio_addon_token);
+    .data(stremio_addon_token)
+    .data(gql_port);
     let builder = queries::logs::register_with_schema(builder, log_directory);
     let builder = plugin_dashboard::register_with_schema(builder);
     builder

--- a/crates/riven-api/src/schema/discovery.rs
+++ b/crates/riven-api/src/schema/discovery.rs
@@ -340,7 +340,14 @@ pub async fn discover_streams(
     Ok(discovered)
 }
 
-async fn apply_cache_status(registry: &PluginRegistry, streams: &mut [DiscoveredStream]) {
+/// `pub(crate)`: also used by `mutations::streams` to check cache status for a
+/// single manually-pasted/uploaded release, not just a batch of scrape
+/// results — the dispatch itself doesn't care where its `info_hash`es came
+/// from.
+pub(crate) async fn apply_cache_status(
+    registry: &PluginRegistry,
+    streams: &mut [DiscoveredStream],
+) {
     if streams.is_empty() {
         return;
     }

--- a/crates/riven-api/src/schema/mutations/streams.rs
+++ b/crates/riven-api/src/schema/mutations/streams.rs
@@ -341,8 +341,21 @@ impl StreamsMutations {
             .text()
             .map_err(|error| async_graphql::Error::new(format!("Failed to read NZB: {error}")))?;
 
-        let title = riven_usenet::peek_release_title(&xml)
+        // Full parse rather than the cheap `peek_release_title` used at
+        // ingest time (log lines only): a preview also wants the total size,
+        // which needs every file's segment list materialized anyway, and
+        // this is a one-shot user action rather than a hot path.
+        let document = riven_usenet::parse_nzb_document(&xml).ok();
+        let title = document
+            .as_ref()
+            .and_then(riven_usenet::NzbDocument::release_title)
             .unwrap_or_else(|| riven_usenet::UNKNOWN_FILE_LABEL.to_string());
+        let file_size_bytes = document.as_ref().map(|doc| {
+            doc.files
+                .iter()
+                .map(|file| file.segments.total_bytes())
+                .sum::<u64>() as i64
+        });
         let parsed = riven_rank::parse(&title);
         let info_hash = nzb_info_hash(nzb_url);
 
@@ -353,7 +366,7 @@ impl StreamsMutations {
             info_hash,
             parsed_data: serde_json::to_value(&parsed).ok(),
             rank: None,
-            file_size_bytes: None,
+            file_size_bytes,
             is_cached: true,
             item_type,
             season_number,

--- a/crates/riven-api/src/schema/mutations/streams.rs
+++ b/crates/riven-api/src/schema/mutations/streams.rs
@@ -20,12 +20,6 @@ use crate::schema::types::DiscoveredStream;
 const PREVIEW_NZB_PROFILE: HttpServiceProfile =
     HttpServiceProfile::new("manual-nzb-preview").with_rate_limit(10, Duration::from_secs(60));
 
-/// Same cap as the upload endpoint's `MAX_UPLOAD_BYTES` (kept as a separate
-/// constant since that one is `pub(super)` to the `server` module) — one
-/// shared size philosophy for "an NZB body this API will ever read into
-/// memory," whether it arrived as an upload or was fetched from a URL.
-const MAX_FETCHED_NZB_BYTES: usize = 8 * 1024 * 1024;
-
 /// TTL for `download_explicit_nzb`'s Redis entry — deliberately longer than
 /// `riven_core::nzb::NZB_URL_TTL_SECS` (7 days, sized for a real scrape's URL
 /// going stale).
@@ -124,34 +118,22 @@ async fn fetch_capped_nzb_text(
                 async_graphql::Error::new("Failed to fetch NZB")
             })?,
     };
-    read_capped_nzb_body(response).await
-}
-
-/// Reads `response` as text, rejecting it once it exceeds
-/// [`MAX_FETCHED_NZB_BYTES`] rather than after — `HttpClient::send_data`
-/// buffers the whole body unconditionally before a caller ever gets to check
-/// its length, which for an NZB URL a caller supplies directly would let a
-/// malicious/huge response exhaust memory before any size check could run.
-/// Reading the raw response chunk-by-chunk with a running total closes that.
-async fn read_capped_nzb_body(mut response: reqwest::Response) -> Result<String> {
-    if !response.status().is_success() {
-        return Err(async_graphql::Error::new("Failed to fetch NZB"));
-    }
-
-    let mut buf = Vec::new();
-    while let Some(chunk) = response.chunk().await.map_err(|error| {
-        tracing::debug!(%error, "manual NZB fetch chunk read failed");
-        async_graphql::Error::new("Failed to fetch NZB")
-    })? {
-        buf.extend_from_slice(&chunk);
-        if buf.len() > MAX_FETCHED_NZB_BYTES {
-            return Err(async_graphql::Error::new("NZB response is too large"));
-        }
-    }
-    String::from_utf8(buf).map_err(|error| {
-        tracing::debug!(%error, "manual NZB response was not valid UTF-8");
-        async_graphql::Error::new("Failed to read NZB")
-    })
+    riven_core::http::ssrf_guard::read_capped_text(response)
+        .await
+        .map_err(|error| {
+            let message = match &error {
+                riven_core::http::ssrf_guard::CappedReadError::TooLarge => {
+                    "NZB response is too large"
+                }
+                riven_core::http::ssrf_guard::CappedReadError::InvalidUtf8 => "Failed to read NZB",
+                riven_core::http::ssrf_guard::CappedReadError::NotSuccess(_)
+                | riven_core::http::ssrf_guard::CappedReadError::Transport(_) => {
+                    "Failed to fetch NZB"
+                }
+            };
+            tracing::debug!(%error, "manual NZB fetch failed");
+            async_graphql::Error::new(message)
+        })
 }
 
 /// The `dn=` (display name) parameter from a magnet URI, URL-decoded. `None`

--- a/crates/riven-api/src/schema/mutations/streams.rs
+++ b/crates/riven-api/src/schema/mutations/streams.rs
@@ -43,10 +43,25 @@ const MANUAL_NZB_URL_TTL_SECS: u64 = 60 * 60 * 24 * 30;
 /// response status/error text this resolver would otherwise echo back as an
 /// oracle to enumerate what's reachable. Rejects anything that doesn't
 /// resolve to a public address, except this crate's own loopback temp-upload
-/// URL (`uploaded_nzb_filename` recognizes exactly that shape and nothing
-/// else — see its own doc comment for why a plain substring check there
-/// would have been just as exploitable as skipping this check entirely).
-async fn validate_nzb_fetch_target(raw: &str) -> Result<()> {
+/// URL — which must additionally land on `gql_port`, this instance's real
+/// listen port, or the shape check alone (`uploaded_nzb_filename`) would let
+/// an attacker reuse the trusted `127.0.0.1` exemption to reach *any* other
+/// port on the container's loopback interface.
+///
+/// Returns the exact address the caller must connect to (`None` for the
+/// trusted loopback-upload exemption, where no pinning is needed): DNS is
+/// resolved and validated here, but a caller that re-resolves the hostname
+/// itself when it actually connects (ordinary redirect-following HTTP
+/// clients do exactly this) reopens the same SSRF this function exists to
+/// close — either a compromised/malicious upstream's redirect, or the
+/// authoritative DNS answer simply changing between this check and the real
+/// connection (DNS rebinding). Callers that make a real outbound connection
+/// must pin to the returned address rather than letting the URL's hostname
+/// be resolved a second time.
+async fn validate_nzb_fetch_target(
+    raw: &str,
+    gql_port: u16,
+) -> Result<Option<(String, std::net::SocketAddr)>> {
     let parsed = url::Url::parse(raw).map_err(|error| {
         tracing::debug!(%error, "manual NZB URL failed to parse");
         async_graphql::Error::new("NZB URL must start with http:// or https://")
@@ -56,8 +71,10 @@ async fn validate_nzb_fetch_target(raw: &str) -> Result<()> {
             "NZB URL must start with http:// or https://",
         ));
     }
-    if riven_core::nzb::uploaded_nzb_filename(raw).is_some() {
-        return Ok(());
+    if riven_core::nzb::uploaded_nzb_filename(raw).is_some()
+        && parsed.port_or_known_default() == Some(gql_port)
+    {
+        return Ok(None);
     }
 
     let host = parsed
@@ -74,27 +91,24 @@ async fn validate_nzb_fetch_target(raw: &str) -> Result<()> {
     if addrs.is_empty() || !addrs.iter().all(|addr| is_global_ip(addr.ip())) {
         return Err(async_graphql::Error::new("NZB URL is not reachable"));
     }
-    Ok(())
+    Ok(Some((host.to_string(), addrs[0])))
 }
 
 /// Deliberately hand-rolled against the well-known private/reserved ranges
 /// rather than the standard library's `is_global()` (still unstable) or an
 /// extra dependency — this only needs to be right for IPv4 RFC 1918 /
-/// loopback / link-local and the IPv6 loopback / unique-local / link-local
-/// equivalents, which covers every realistic internal address a container on
-/// this host could be reached at.
+/// loopback / link-local / CGNAT / reserved and the IPv6 loopback /
+/// unique-local / link-local equivalents (including an IPv4 address embedded
+/// in an IPv4-mapped IPv6 address, e.g. `::ffff:127.0.0.1`, which the
+/// bare `Ipv6Addr` checks below don't catch), which covers every realistic
+/// internal address a container on this host could be reached at.
 fn is_global_ip(ip: std::net::IpAddr) -> bool {
     match ip {
-        std::net::IpAddr::V4(v4) => {
-            !(v4.is_private()
-                || v4.is_loopback()
-                || v4.is_link_local()
-                || v4.is_unspecified()
-                || v4.is_broadcast()
-                || v4.is_documentation()
-                || v4.is_multicast())
-        }
+        std::net::IpAddr::V4(v4) => is_global_ipv4(v4),
         std::net::IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return is_global_ipv4(mapped);
+            }
             let segments = v6.segments();
             !(v6.is_loopback()
                 || v6.is_unspecified()
@@ -105,21 +119,79 @@ fn is_global_ip(ip: std::net::IpAddr) -> bool {
     }
 }
 
-/// Fetches `url` and reads it as text, rejecting the response once it exceeds
+fn is_global_ipv4(v4: std::net::Ipv4Addr) -> bool {
+    let octets = v4.octets();
+    !(v4.is_private()
+        || v4.is_loopback()
+        || v4.is_link_local()
+        || v4.is_broadcast()
+        || v4.is_documentation()
+        || v4.is_multicast()
+        || octets[0] == 0 // 0.0.0.0/8 ("this network"), broader than is_unspecified's exact 0.0.0.0
+        || (octets[0] == 100 && (64..=127).contains(&octets[1])) // 100.64.0.0/10, CGNAT
+        || (octets[0] == 192 && octets[1] == 0 && octets[2] == 0) // 192.0.0.0/24, IETF protocol assignments
+        || octets[0] >= 240) // 240.0.0.0/4 reserved, includes 255.255.255.255
+}
+
+/// A one-shot client for a single validated external NZB URL, scoped to
+/// exactly the address [`validate_nzb_fetch_target`] checked: redirects are
+/// disabled outright (this feature has no legitimate need to follow one — a
+/// user whose indexer redirects can paste the final URL instead), and
+/// `.resolve` pins `host` to `addr` so the connection can't re-run DNS and
+/// land somewhere the earlier check never saw. Without both, a malicious or
+/// compromised upstream could 30x to an internal address, or simply change
+/// its DNS answer between the check and this connection, and bypass the
+/// public-address validation entirely.
+fn build_pinned_nzb_client(host: &str, addr: std::net::SocketAddr) -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .resolve(host, addr)
+        .timeout(Duration::from_secs(20))
+        .build()
+        .map_err(|error| {
+            tracing::debug!(%error, "failed to build pinned NZB fetch client");
+            async_graphql::Error::new("Failed to fetch NZB")
+        })
+}
+
+/// Fetches `nzb_url` and reads it as text. `pinned_target` is
+/// [`validate_nzb_fetch_target`]'s result: `Some((host, addr))` for a real
+/// external URL, fetched through [`build_pinned_nzb_client`] rather than the
+/// shared rate-limited client — that client follows redirects and performs
+/// its own DNS resolution, either of which would undo the validation that
+/// was just done. `None` is the trusted loopback-upload exemption, safe to
+/// fetch through the ordinary shared client.
+async fn fetch_capped_nzb_text(
+    http: &HttpClient,
+    nzb_url: &str,
+    pinned_target: Option<(String, std::net::SocketAddr)>,
+) -> Result<String> {
+    let response = match pinned_target {
+        Some((host, addr)) => {
+            let client = build_pinned_nzb_client(&host, addr)?;
+            client.get(nzb_url).send().await.map_err(|error| {
+                tracing::debug!(%error, "manual NZB fetch request failed");
+                async_graphql::Error::new("Failed to fetch NZB")
+            })?
+        }
+        None => http
+            .send(PREVIEW_NZB_PROFILE, |client| client.get(nzb_url))
+            .await
+            .map_err(|error| {
+                tracing::debug!(%error, "manual NZB fetch request failed");
+                async_graphql::Error::new("Failed to fetch NZB")
+            })?,
+    };
+    read_capped_nzb_body(response).await
+}
+
+/// Reads `response` as text, rejecting it once it exceeds
 /// [`MAX_FETCHED_NZB_BYTES`] rather than after — `HttpClient::send_data`
 /// buffers the whole body unconditionally before a caller ever gets to check
 /// its length, which for an NZB URL a caller supplies directly would let a
 /// malicious/huge response exhaust memory before any size check could run.
-/// Reading `HttpClient::send`'s raw response chunk-by-chunk with a running
-/// total closes that.
-async fn fetch_capped_nzb_text(http: &HttpClient, nzb_url: &str) -> Result<String> {
-    let mut response = http
-        .send(PREVIEW_NZB_PROFILE, |client| client.get(nzb_url))
-        .await
-        .map_err(|error| {
-            tracing::debug!(%error, "manual NZB fetch request failed");
-            async_graphql::Error::new("Failed to fetch NZB")
-        })?;
+/// Reading the raw response chunk-by-chunk with a running total closes that.
+async fn read_capped_nzb_body(mut response: reqwest::Response) -> Result<String> {
     if !response.status().is_success() {
         return Err(async_graphql::Error::new("Failed to fetch NZB"));
     }
@@ -327,9 +399,10 @@ impl StreamsMutations {
         let registry = ctx.data::<Arc<PluginRegistry>>()?;
         let job_queue = ctx.data::<Arc<JobQueue>>()?;
         let redis_conn = ctx.data::<redis::aio::ConnectionManager>()?;
+        let gql_port = ctx.data::<crate::schema::GqlPort>()?.0;
 
         let nzb_url = nzb_url.trim();
-        validate_nzb_fetch_target(nzb_url).await?;
+        validate_nzb_fetch_target(nzb_url, gql_port).await?;
 
         let target = resolve_manual_download_target(
             registry.as_ref(),
@@ -444,10 +517,11 @@ impl StreamsMutations {
     ) -> Result<DiscoveredStream> {
         require(ctx, Capability::ScrapeItems)?;
         let http = ctx.data::<HttpClient>()?;
+        let gql_port = ctx.data::<crate::schema::GqlPort>()?.0;
 
         let nzb_url = nzb_url.trim();
-        validate_nzb_fetch_target(nzb_url).await?;
-        let xml = fetch_capped_nzb_text(http, nzb_url).await?;
+        let pinned_target = validate_nzb_fetch_target(nzb_url, gql_port).await?;
+        let xml = fetch_capped_nzb_text(http, nzb_url, pinned_target).await?;
 
         // Full parse rather than the cheap `peek_release_title` used at
         // ingest time (log lines only): a preview also wants the total size,

--- a/crates/riven-api/src/schema/mutations/streams.rs
+++ b/crates/riven-api/src/schema/mutations/streams.rs
@@ -81,86 +81,23 @@ async fn validate_nzb_fetch_target(
         .host_str()
         .ok_or_else(|| async_graphql::Error::new("NZB URL is not reachable"))?;
     let port = parsed.port_or_known_default().unwrap_or(80);
-    let addrs = tokio::net::lookup_host((host, port))
+    let addr = riven_core::http::ssrf_guard::resolve_public_target(host, port)
         .await
         .map_err(|error| {
             tracing::debug!(%error, "manual NZB URL lookup_host failed");
             async_graphql::Error::new("NZB URL is not reachable")
         })?
-        .collect::<Vec<_>>();
-    if addrs.is_empty() || !addrs.iter().all(|addr| is_global_ip(addr.ip())) {
-        return Err(async_graphql::Error::new("NZB URL is not reachable"));
-    }
-    Ok(Some((host.to_string(), addrs[0])))
-}
-
-/// Deliberately hand-rolled against the well-known private/reserved ranges
-/// rather than the standard library's `is_global()` (still unstable) or an
-/// extra dependency — this only needs to be right for IPv4 RFC 1918 /
-/// loopback / link-local / CGNAT / reserved and the IPv6 loopback /
-/// unique-local / link-local equivalents (including an IPv4 address embedded
-/// in an IPv4-mapped IPv6 address, e.g. `::ffff:127.0.0.1`, which the
-/// bare `Ipv6Addr` checks below don't catch), which covers every realistic
-/// internal address a container on this host could be reached at.
-fn is_global_ip(ip: std::net::IpAddr) -> bool {
-    match ip {
-        std::net::IpAddr::V4(v4) => is_global_ipv4(v4),
-        std::net::IpAddr::V6(v6) => {
-            if let Some(mapped) = v6.to_ipv4_mapped() {
-                return is_global_ipv4(mapped);
-            }
-            let segments = v6.segments();
-            !(v6.is_loopback()
-                || v6.is_unspecified()
-                || v6.is_multicast()
-                || (segments[0] & 0xfe00) == 0xfc00 // unique local, fc00::/7
-                || (segments[0] & 0xffc0) == 0xfe80) // link-local, fe80::/10
-        }
-    }
-}
-
-fn is_global_ipv4(v4: std::net::Ipv4Addr) -> bool {
-    let octets = v4.octets();
-    !(v4.is_private()
-        || v4.is_loopback()
-        || v4.is_link_local()
-        || v4.is_broadcast()
-        || v4.is_documentation()
-        || v4.is_multicast()
-        || octets[0] == 0 // 0.0.0.0/8 ("this network"), broader than is_unspecified's exact 0.0.0.0
-        || (octets[0] == 100 && (64..=127).contains(&octets[1])) // 100.64.0.0/10, CGNAT
-        || (octets[0] == 192 && octets[1] == 0 && octets[2] == 0) // 192.0.0.0/24, IETF protocol assignments
-        || octets[0] >= 240) // 240.0.0.0/4 reserved, includes 255.255.255.255
-}
-
-/// A one-shot client for a single validated external NZB URL, scoped to
-/// exactly the address [`validate_nzb_fetch_target`] checked: redirects are
-/// disabled outright (this feature has no legitimate need to follow one — a
-/// user whose indexer redirects can paste the final URL instead), and
-/// `.resolve` pins `host` to `addr` so the connection can't re-run DNS and
-/// land somewhere the earlier check never saw. Without both, a malicious or
-/// compromised upstream could 30x to an internal address, or simply change
-/// its DNS answer between the check and this connection, and bypass the
-/// public-address validation entirely.
-fn build_pinned_nzb_client(host: &str, addr: std::net::SocketAddr) -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .resolve(host, addr)
-        .timeout(Duration::from_secs(20))
-        .build()
-        .map_err(|error| {
-            tracing::debug!(%error, "failed to build pinned NZB fetch client");
-            async_graphql::Error::new("Failed to fetch NZB")
-        })
+        .ok_or_else(|| async_graphql::Error::new("NZB URL is not reachable"))?;
+    Ok(Some((host.to_string(), addr)))
 }
 
 /// Fetches `nzb_url` and reads it as text. `pinned_target` is
 /// [`validate_nzb_fetch_target`]'s result: `Some((host, addr))` for a real
-/// external URL, fetched through [`build_pinned_nzb_client`] rather than the
-/// shared rate-limited client — that client follows redirects and performs
-/// its own DNS resolution, either of which would undo the validation that
-/// was just done. `None` is the trusted loopback-upload exemption, safe to
-/// fetch through the ordinary shared client.
+/// external URL, fetched through [`riven_core::http::ssrf_guard::build_pinned_client`]
+/// rather than the shared rate-limited client — that client follows
+/// redirects and performs its own DNS resolution, either of which would undo
+/// the validation that was just done. `None` is the trusted loopback-upload
+/// exemption, safe to fetch through the ordinary shared client.
 async fn fetch_capped_nzb_text(
     http: &HttpClient,
     nzb_url: &str,
@@ -168,7 +105,12 @@ async fn fetch_capped_nzb_text(
 ) -> Result<String> {
     let response = match pinned_target {
         Some((host, addr)) => {
-            let client = build_pinned_nzb_client(&host, addr)?;
+            let client = riven_core::http::ssrf_guard::build_pinned_client(&host, addr).map_err(
+                |error| {
+                    tracing::debug!(%error, "failed to build pinned NZB fetch client");
+                    async_graphql::Error::new("Failed to fetch NZB")
+                },
+            )?;
             client.get(nzb_url).send().await.map_err(|error| {
                 tracing::debug!(%error, "manual NZB fetch request failed");
                 async_graphql::Error::new("Failed to fetch NZB")

--- a/crates/riven-api/src/schema/mutations/streams.rs
+++ b/crates/riven-api/src/schema/mutations/streams.rs
@@ -1,7 +1,7 @@
 use async_graphql::*;
 use redis::AsyncCommands;
 use riven_core::http::{HttpClient, HttpServiceProfile};
-use riven_core::nzb::{NZB_URL_TTL_SECS, nzb_indexer_redis_key, nzb_info_hash, nzb_url_redis_key};
+use riven_core::nzb::{nzb_indexer_redis_key, nzb_info_hash, nzb_url_redis_key};
 use riven_core::plugin::PluginRegistry;
 use riven_core::types::MediaItemType;
 use riven_db::entities::MediaItem;
@@ -19,6 +19,126 @@ use crate::schema::types::DiscoveredStream;
 
 const PREVIEW_NZB_PROFILE: HttpServiceProfile =
     HttpServiceProfile::new("manual-nzb-preview").with_rate_limit(10, Duration::from_secs(60));
+
+/// Same cap as the upload endpoint's `MAX_UPLOAD_BYTES` (kept as a separate
+/// constant since that one is `pub(super)` to the `server` module) — one
+/// shared size philosophy for "an NZB body this API will ever read into
+/// memory," whether it arrived as an upload or was fetched from a URL.
+const MAX_FETCHED_NZB_BYTES: usize = 8 * 1024 * 1024;
+
+/// TTL for `download_explicit_nzb`'s Redis entry — deliberately longer than
+/// `riven_core::nzb::NZB_URL_TTL_SECS` (7 days, sized for a real scrape's URL
+/// going stale).
+/// See the call site for why: a manually-supplied URL's item is also marked
+/// `manual_scrape_only`, which forecloses the automatic-retry path that would
+/// otherwise be the safety net for a download that needs a delayed retry.
+const MANUAL_NZB_URL_TTL_SECS: u64 = 60 * 60 * 24 * 30;
+
+/// A manually-supplied NZB URL a caller with `ScrapeItems` controls directly
+/// gets fetched server-side (`preview_manual_nzb`) or handed to
+/// `plugin-usenet` to fetch later (`download_explicit_nzb`). Without this
+/// check that is a same-origin-request forgery primitive: an authenticated
+/// but otherwise unprivileged caller could point it at a cloud metadata
+/// endpoint, another container, or a localhost-bound admin port, and use the
+/// response status/error text this resolver would otherwise echo back as an
+/// oracle to enumerate what's reachable. Rejects anything that doesn't
+/// resolve to a public address, except this crate's own loopback temp-upload
+/// URL (`uploaded_nzb_filename` recognizes exactly that shape and nothing
+/// else — see its own doc comment for why a plain substring check there
+/// would have been just as exploitable as skipping this check entirely).
+async fn validate_nzb_fetch_target(raw: &str) -> Result<()> {
+    let parsed = url::Url::parse(raw).map_err(|error| {
+        tracing::debug!(%error, "manual NZB URL failed to parse");
+        async_graphql::Error::new("NZB URL must start with http:// or https://")
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(async_graphql::Error::new(
+            "NZB URL must start with http:// or https://",
+        ));
+    }
+    if riven_core::nzb::uploaded_nzb_filename(raw).is_some() {
+        return Ok(());
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| async_graphql::Error::new("NZB URL is not reachable"))?;
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let addrs = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|error| {
+            tracing::debug!(%error, "manual NZB URL lookup_host failed");
+            async_graphql::Error::new("NZB URL is not reachable")
+        })?
+        .collect::<Vec<_>>();
+    if addrs.is_empty() || !addrs.iter().all(|addr| is_global_ip(addr.ip())) {
+        return Err(async_graphql::Error::new("NZB URL is not reachable"));
+    }
+    Ok(())
+}
+
+/// Deliberately hand-rolled against the well-known private/reserved ranges
+/// rather than the standard library's `is_global()` (still unstable) or an
+/// extra dependency — this only needs to be right for IPv4 RFC 1918 /
+/// loopback / link-local and the IPv6 loopback / unique-local / link-local
+/// equivalents, which covers every realistic internal address a container on
+/// this host could be reached at.
+fn is_global_ip(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            !(v4.is_private()
+                || v4.is_loopback()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                || v4.is_multicast())
+        }
+        std::net::IpAddr::V6(v6) => {
+            let segments = v6.segments();
+            !(v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || (segments[0] & 0xfe00) == 0xfc00 // unique local, fc00::/7
+                || (segments[0] & 0xffc0) == 0xfe80) // link-local, fe80::/10
+        }
+    }
+}
+
+/// Fetches `url` and reads it as text, rejecting the response once it exceeds
+/// [`MAX_FETCHED_NZB_BYTES`] rather than after — `HttpClient::send_data`
+/// buffers the whole body unconditionally before a caller ever gets to check
+/// its length, which for an NZB URL a caller supplies directly would let a
+/// malicious/huge response exhaust memory before any size check could run.
+/// Reading `HttpClient::send`'s raw response chunk-by-chunk with a running
+/// total closes that.
+async fn fetch_capped_nzb_text(http: &HttpClient, nzb_url: &str) -> Result<String> {
+    let mut response = http
+        .send(PREVIEW_NZB_PROFILE, |client| client.get(nzb_url))
+        .await
+        .map_err(|error| {
+            tracing::debug!(%error, "manual NZB fetch request failed");
+            async_graphql::Error::new("Failed to fetch NZB")
+        })?;
+    if !response.status().is_success() {
+        return Err(async_graphql::Error::new("Failed to fetch NZB"));
+    }
+
+    let mut buf = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        tracing::debug!(%error, "manual NZB fetch chunk read failed");
+        async_graphql::Error::new("Failed to fetch NZB")
+    })? {
+        buf.extend_from_slice(&chunk);
+        if buf.len() > MAX_FETCHED_NZB_BYTES {
+            return Err(async_graphql::Error::new("NZB response is too large"));
+        }
+    }
+    String::from_utf8(buf).map_err(|error| {
+        tracing::debug!(%error, "manual NZB response was not valid UTF-8");
+        async_graphql::Error::new("Failed to read NZB")
+    })
+}
 
 /// The `dn=` (display name) parameter from a magnet URI, URL-decoded. `None`
 /// for a bare hash or a magnet with no `dn=` — the only case
@@ -209,11 +329,7 @@ impl StreamsMutations {
         let redis_conn = ctx.data::<redis::aio::ConnectionManager>()?;
 
         let nzb_url = nzb_url.trim();
-        if !nzb_url.starts_with("http://") && !nzb_url.starts_with("https://") {
-            return Err(async_graphql::Error::new(
-                "NZB URL must start with http:// or https://",
-            ));
-        }
+        validate_nzb_fetch_target(nzb_url).await?;
 
         let target = resolve_manual_download_target(
             registry.as_ref(),
@@ -231,15 +347,26 @@ impl StreamsMutations {
 
         let info_hash = nzb_info_hash(nzb_url);
         let mut redis_conn = redis_conn.clone();
+        // Longer than the 7-day TTL a real scrape's URL gets: this item is
+        // also being marked `manual_scrape_only` below, which opts it out of
+        // the automatic retry scheduler entirely — so if its own download
+        // ever needs a delayed retry (escalating cooldown after a transient
+        // failure, or the queue just being backed up) that pushes past seven
+        // days, the URL would otherwise expire with no automatic path left to
+        // recover it.
         redis_conn
-            .set_ex::<_, _, ()>(nzb_url_redis_key(&info_hash), nzb_url, NZB_URL_TTL_SECS)
+            .set_ex::<_, _, ()>(
+                nzb_url_redis_key(&info_hash),
+                nzb_url,
+                MANUAL_NZB_URL_TTL_SECS,
+            )
             .await
             .map_err(|error| async_graphql::Error::new(error.to_string()))?;
         redis_conn
             .set_ex::<_, _, ()>(
                 nzb_indexer_redis_key(&info_hash),
                 "manual",
-                NZB_URL_TTL_SECS,
+                MANUAL_NZB_URL_TTL_SECS,
             )
             .await
             .map_err(|error| async_graphql::Error::new(error.to_string()))?;
@@ -319,27 +446,8 @@ impl StreamsMutations {
         let http = ctx.data::<HttpClient>()?;
 
         let nzb_url = nzb_url.trim();
-        if !nzb_url.starts_with("http://") && !nzb_url.starts_with("https://") {
-            return Err(async_graphql::Error::new(
-                "NZB URL must start with http:// or https://",
-            ));
-        }
-
-        let response = http
-            .send_data(PREVIEW_NZB_PROFILE, Some(nzb_url.to_string()), |client| {
-                client.get(nzb_url)
-            })
-            .await
-            .map_err(|error| async_graphql::Error::new(format!("Failed to fetch NZB: {error}")))?;
-        if !response.status().is_success() {
-            return Err(async_graphql::Error::new(format!(
-                "NZB URL returned HTTP {}",
-                response.status()
-            )));
-        }
-        let xml = response
-            .text()
-            .map_err(|error| async_graphql::Error::new(format!("Failed to read NZB: {error}")))?;
+        validate_nzb_fetch_target(nzb_url).await?;
+        let xml = fetch_capped_nzb_text(http, nzb_url).await?;
 
         // Full parse rather than the cheap `peek_release_title` used at
         // ingest time (log lines only): a preview also wants the total size,

--- a/crates/riven-api/src/schema/mutations/streams.rs
+++ b/crates/riven-api/src/schema/mutations/streams.rs
@@ -1,5 +1,6 @@
 use async_graphql::*;
 use redis::AsyncCommands;
+use riven_core::http::{HttpClient, HttpServiceProfile};
 use riven_core::nzb::{NZB_URL_TTL_SECS, nzb_indexer_redis_key, nzb_info_hash, nzb_url_redis_key};
 use riven_core::plugin::PluginRegistry;
 use riven_core::types::MediaItemType;
@@ -7,12 +8,28 @@ use riven_db::entities::MediaItem;
 use riven_db::repo;
 use riven_queue::{JobQueue, RankStreamsJob};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::schema::auth::{Capability, require};
 use crate::schema::discovery::{
-    discover_streams, ensure_download_target, ensure_show_target, resolve_pack_seasons,
+    apply_cache_status, discover_streams, ensure_download_target, ensure_show_target,
+    resolve_pack_seasons,
 };
 use crate::schema::types::DiscoveredStream;
+
+const PREVIEW_NZB_PROFILE: HttpServiceProfile =
+    HttpServiceProfile::new("manual-nzb-preview").with_rate_limit(10, Duration::from_secs(60));
+
+/// The `dn=` (display name) parameter from a magnet URI, URL-decoded. `None`
+/// for a bare hash or a magnet with no `dn=` — the only case
+/// [`preview_manual_magnet`] can't offer a real title for.
+fn extract_magnet_display_name(magnet: &str) -> Option<String> {
+    let (_, query) = magnet.split_once('?')?;
+    url::form_urlencoded::parse(query.as_bytes())
+        .find(|(key, _)| key == "dn")
+        .map(|(_, value)| value.into_owned())
+        .filter(|name| !name.trim().is_empty())
+}
 
 #[derive(Default)]
 pub struct StreamsMutations;
@@ -239,5 +256,108 @@ impl StreamsMutations {
             .await;
 
         Ok("Download queued".to_string())
+    }
+
+    /// Turns a manually-pasted magnet link/hash into a full [`DiscoveredStream`]
+    /// card — same shape, same badges as a real scrape result — instead of
+    /// downloading it sight-unseen. Parses whatever the magnet's own `dn=`
+    /// carries through [`riven_rank::parse`] (the exact parser real scrape
+    /// results go through) for resolution/quality/audio/etc., and checks
+    /// debrid cache status via the same dispatch [`discover_streams`] uses.
+    /// Creates or mutates nothing — the pick only becomes real when the
+    /// resulting card's "Download This" calls `downloadDiscoveredStream`,
+    /// same as any other result in the list.
+    async fn preview_manual_magnet(
+        &self,
+        ctx: &Context<'_>,
+        item_type: MediaItemType,
+        info_hash: String,
+        magnet: String,
+        season_number: Option<i32>,
+        episode_number: Option<i32>,
+    ) -> Result<DiscoveredStream> {
+        require(ctx, Capability::ScrapeItems)?;
+        let registry = ctx.data::<Arc<PluginRegistry>>()?;
+
+        let title = extract_magnet_display_name(&magnet).unwrap_or_else(|| info_hash.clone());
+        let parsed = riven_rank::parse(&title);
+
+        let mut stream = DiscoveredStream {
+            key: format!("manual:{}", info_hash.to_lowercase()),
+            title,
+            magnet,
+            info_hash,
+            parsed_data: serde_json::to_value(&parsed).ok(),
+            rank: None,
+            file_size_bytes: None,
+            is_cached: false,
+            item_type,
+            season_number,
+            episode_number,
+        };
+        apply_cache_status(registry.as_ref(), std::slice::from_mut(&mut stream)).await;
+
+        Ok(stream)
+    }
+
+    /// The NZB equivalent of [`preview_manual_magnet`]: fetches the URL
+    /// (whether pasted directly or handed back by the upload endpoint),
+    /// peeks its release title the same way `plugin-usenet` does at ingest
+    /// time, and parses that through [`riven_rank::parse`]. Usenet has no
+    /// debrid-style cache concept — every `nzb-` hash is unconditionally
+    /// "cached" here, matching `plugin-usenet`'s own cache-check response.
+    /// Nothing is persisted; the fetched content is discarded once peeked.
+    async fn preview_manual_nzb(
+        &self,
+        ctx: &Context<'_>,
+        item_type: MediaItemType,
+        nzb_url: String,
+        season_number: Option<i32>,
+        episode_number: Option<i32>,
+    ) -> Result<DiscoveredStream> {
+        require(ctx, Capability::ScrapeItems)?;
+        let http = ctx.data::<HttpClient>()?;
+
+        let nzb_url = nzb_url.trim();
+        if !nzb_url.starts_with("http://") && !nzb_url.starts_with("https://") {
+            return Err(async_graphql::Error::new(
+                "NZB URL must start with http:// or https://",
+            ));
+        }
+
+        let response = http
+            .send_data(PREVIEW_NZB_PROFILE, Some(nzb_url.to_string()), |client| {
+                client.get(nzb_url)
+            })
+            .await
+            .map_err(|error| async_graphql::Error::new(format!("Failed to fetch NZB: {error}")))?;
+        if !response.status().is_success() {
+            return Err(async_graphql::Error::new(format!(
+                "NZB URL returned HTTP {}",
+                response.status()
+            )));
+        }
+        let xml = response
+            .text()
+            .map_err(|error| async_graphql::Error::new(format!("Failed to read NZB: {error}")))?;
+
+        let title = riven_usenet::peek_release_title(&xml)
+            .unwrap_or_else(|| riven_usenet::UNKNOWN_FILE_LABEL.to_string());
+        let parsed = riven_rank::parse(&title);
+        let info_hash = nzb_info_hash(nzb_url);
+
+        Ok(DiscoveredStream {
+            key: format!("manual-nzb:{}", info_hash.to_lowercase()),
+            title,
+            magnet: String::new(),
+            info_hash,
+            parsed_data: serde_json::to_value(&parsed).ok(),
+            rank: None,
+            file_size_bytes: None,
+            is_cached: true,
+            item_type,
+            season_number,
+            episode_number,
+        })
     }
 }

--- a/crates/riven-api/src/schema/mutations/streams.rs
+++ b/crates/riven-api/src/schema/mutations/streams.rs
@@ -1,6 +1,9 @@
 use async_graphql::*;
+use redis::AsyncCommands;
+use riven_core::nzb::{NZB_URL_TTL_SECS, nzb_indexer_redis_key, nzb_info_hash, nzb_url_redis_key};
 use riven_core::plugin::PluginRegistry;
 use riven_core::types::MediaItemType;
+use riven_db::entities::MediaItem;
 use riven_db::repo;
 use riven_queue::{JobQueue, RankStreamsJob};
 use std::sync::Arc;
@@ -13,6 +16,66 @@ use crate::schema::types::DiscoveredStream;
 
 #[derive(Default)]
 pub struct StreamsMutations;
+
+/// Shared by every "user picked/pasted a specific release" mutation: create or
+/// prepare the real target item only now, after the pick, mirroring
+/// [`download_discovered_stream`]'s original branching so a manually-pasted
+/// magnet/hash/NZB resolves a target exactly like a scraped one does.
+///
+/// For TV, the stream is matched against its parsed seasons (or the
+/// caller-supplied `seasons` / `season_number`). A single-season pack links
+/// to that season; a multi-season pack links to the **show** so the download
+/// flow can fill every season it contains.
+async fn resolve_manual_download_target(
+    registry: &PluginRegistry,
+    item_type: MediaItemType,
+    title: &str,
+    imdb_id: Option<&str>,
+    tmdb_id: Option<&str>,
+    tvdb_id: Option<&str>,
+    season_number: Option<i32>,
+    episode_number: Option<i32>,
+    seasons: Option<&[i32]>,
+    parsed_data: Option<&serde_json::Value>,
+) -> Result<MediaItem> {
+    if item_type == MediaItemType::Movie {
+        ensure_download_target(
+            registry, item_type, title, imdb_id, tmdb_id, tvdb_id, None, None,
+        )
+        .await
+    } else if item_type == MediaItemType::Episode {
+        ensure_download_target(
+            registry,
+            MediaItemType::Episode,
+            title,
+            imdb_id,
+            tmdb_id,
+            tvdb_id,
+            season_number,
+            episode_number,
+        )
+        .await
+    } else {
+        let pack_seasons = resolve_pack_seasons(parsed_data, seasons, season_number);
+        match pack_seasons.as_slice() {
+            [] => Err(async_graphql::Error::new("No season selected for download")),
+            [single] => {
+                ensure_download_target(
+                    registry,
+                    MediaItemType::Season,
+                    title,
+                    imdb_id,
+                    tmdb_id,
+                    tvdb_id,
+                    Some(*single),
+                    None,
+                )
+                .await
+            }
+            many => ensure_show_target(registry, title, imdb_id, tvdb_id, many).await,
+        }
+    }
+}
 
 #[Object]
 impl StreamsMutations {
@@ -72,63 +135,101 @@ impl StreamsMutations {
         let registry = ctx.data::<Arc<PluginRegistry>>()?;
         let job_queue = ctx.data::<Arc<JobQueue>>()?;
 
-        let target = if item_type == MediaItemType::Movie {
-            ensure_download_target(
-                registry.as_ref(),
-                item_type,
-                &title,
-                imdb_id.as_deref(),
-                tmdb_id.as_deref(),
-                tvdb_id.as_deref(),
-                None,
-                None,
-            )
-            .await?
-        } else if item_type == MediaItemType::Episode {
-            ensure_download_target(
-                registry.as_ref(),
-                MediaItemType::Episode,
-                &title,
-                imdb_id.as_deref(),
-                tmdb_id.as_deref(),
-                tvdb_id.as_deref(),
-                season_number,
-                episode_number,
-            )
-            .await?
-        } else {
-            let pack_seasons =
-                resolve_pack_seasons(parsed_data.as_ref(), seasons.as_deref(), season_number);
-            match pack_seasons.as_slice() {
-                [] => return Err(async_graphql::Error::new("No season selected for download")),
-                [single] => {
-                    ensure_download_target(
-                        registry.as_ref(),
-                        MediaItemType::Season,
-                        &title,
-                        imdb_id.as_deref(),
-                        tmdb_id.as_deref(),
-                        tvdb_id.as_deref(),
-                        Some(*single),
-                        None,
-                    )
-                    .await?
-                }
-                many => {
-                    ensure_show_target(
-                        registry.as_ref(),
-                        &title,
-                        imdb_id.as_deref(),
-                        tvdb_id.as_deref(),
-                        many,
-                    )
-                    .await?
-                }
-            }
-        };
+        let target = resolve_manual_download_target(
+            registry.as_ref(),
+            item_type,
+            &title,
+            imdb_id.as_deref(),
+            tmdb_id.as_deref(),
+            tvdb_id.as_deref(),
+            season_number,
+            episode_number,
+            seasons.as_deref(),
+            parsed_data.as_ref(),
+        )
+        .await?;
 
         let stream = repo::upsert_stream(&info_hash, &magnet, parsed_data, rank, None).await?;
         repo::link_stream_to_item(target.id, stream.id).await?;
+        repo::mark_manual_scrape_only(target.id).await?;
+
+        job_queue
+            .push_rank_streams(RankStreamsJob {
+                id: target.id,
+                preferred_info_hash: Some(info_hash),
+            })
+            .await;
+
+        Ok("Download queued".to_string())
+    }
+
+    /// Manually queue a specific NZB by URL, bypassing indexer search entirely
+    /// — the usenet equivalent of [`download_discovered_stream`]'s explicit
+    /// magnet/hash field. The URL is hashed into the same `nzb-`-prefixed
+    /// `info_hash` a real newznab scrape would produce and stashed in Redis
+    /// under the same keys ([`nzb_url_redis_key`]), so `plugin-usenet`'s
+    /// download-time fetch can't tell the difference from a scraped result.
+    ///
+    /// TV has no parsed release metadata to infer seasons from here (there was
+    /// no scrape), so the caller must supply `season_number`/`episode_number`
+    /// or `seasons` explicitly.
+    async fn download_explicit_nzb(
+        &self,
+        ctx: &Context<'_>,
+        item_type: MediaItemType,
+        title: String,
+        imdb_id: Option<String>,
+        tmdb_id: Option<String>,
+        tvdb_id: Option<String>,
+        season_number: Option<i32>,
+        episode_number: Option<i32>,
+        seasons: Option<Vec<i32>>,
+        nzb_url: String,
+    ) -> Result<String> {
+        require(ctx, Capability::ScrapeItems)?;
+        let registry = ctx.data::<Arc<PluginRegistry>>()?;
+        let job_queue = ctx.data::<Arc<JobQueue>>()?;
+        let redis_conn = ctx.data::<redis::aio::ConnectionManager>()?;
+
+        let nzb_url = nzb_url.trim();
+        if !nzb_url.starts_with("http://") && !nzb_url.starts_with("https://") {
+            return Err(async_graphql::Error::new(
+                "NZB URL must start with http:// or https://",
+            ));
+        }
+
+        let target = resolve_manual_download_target(
+            registry.as_ref(),
+            item_type,
+            &title,
+            imdb_id.as_deref(),
+            tmdb_id.as_deref(),
+            tvdb_id.as_deref(),
+            season_number,
+            episode_number,
+            seasons.as_deref(),
+            None,
+        )
+        .await?;
+
+        let info_hash = nzb_info_hash(nzb_url);
+        let mut redis_conn = redis_conn.clone();
+        redis_conn
+            .set_ex::<_, _, ()>(nzb_url_redis_key(&info_hash), nzb_url, NZB_URL_TTL_SECS)
+            .await
+            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+        redis_conn
+            .set_ex::<_, _, ()>(
+                nzb_indexer_redis_key(&info_hash),
+                "manual",
+                NZB_URL_TTL_SECS,
+            )
+            .await
+            .map_err(|error| async_graphql::Error::new(error.to_string()))?;
+
+        let stream = repo::upsert_stream(&info_hash, "", None, None, None).await?;
+        repo::link_stream_to_item(target.id, stream.id).await?;
+        repo::mark_manual_scrape_only(target.id).await?;
 
         job_queue
             .push_rank_streams(RankStreamsJob {

--- a/crates/riven-api/src/server.rs
+++ b/crates/riven-api/src/server.rs
@@ -40,6 +40,7 @@ pub struct StartServerConfig {
     pub port: u16,
     pub registry: Arc<PluginRegistry>,
     pub job_queue: Arc<JobQueue>,
+    pub redis_conn: redis::aio::ConnectionManager,
     pub http_client: HttpClient,
     pub api_key: Option<String>,
     pub log_directory: String,
@@ -94,6 +95,7 @@ pub async fn start_server(config: StartServerConfig) -> Result<()> {
         port,
         registry,
         job_queue,
+        redis_conn,
         http_client,
         api_key,
         log_directory,
@@ -115,6 +117,7 @@ pub async fn start_server(config: StartServerConfig) -> Result<()> {
     let schema = build_schema(
         registry.clone(),
         job_queue.clone(),
+        redis_conn,
         http_client,
         log_directory,
         downloader_config,

--- a/crates/riven-api/src/server.rs
+++ b/crates/riven-api/src/server.rs
@@ -5,6 +5,7 @@ mod board;
 mod graphql;
 mod legacy_password;
 mod media;
+mod nzb_upload;
 mod oidc;
 mod plex;
 mod stremio;
@@ -12,11 +13,15 @@ mod stremio;
 use std::sync::Arc;
 
 use anyhow::Result;
+use axum::extract::DefaultBodyLimit;
 use axum::http::{
     HeaderName, HeaderValue, Method,
     header::{ACCEPT_RANGES, AUTHORIZATION, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE},
 };
-use axum::{Router, routing::get};
+use axum::{
+    Router,
+    routing::{get, post},
+};
 use riven_core::http::HttpClient;
 use riven_core::logging::LogControl;
 use riven_core::plugin::PluginRegistry;
@@ -86,6 +91,10 @@ mod state {
         /// Held here as well as in the schema so the artwork proxy can dispatch
         /// to media-server plugins without going through GraphQL.
         pub registry: Arc<riven_core::plugin::PluginRegistry>,
+        /// The port this server itself is bound to, so the NZB-upload handler
+        /// can hand back a loopback URL (`http://127.0.0.1:{gql_port}/...`)
+        /// without threading the instance's public URL through just for this.
+        pub gql_port: u16,
     }
 }
 
@@ -160,6 +169,7 @@ pub async fn start_server(config: StartServerConfig) -> Result<()> {
         runtime: tokio::runtime::Handle::current(),
         auth: auth.clone(),
         registry,
+        gql_port: port,
     };
 
     let board_guard =
@@ -213,6 +223,25 @@ pub async fn start_server(config: StartServerConfig) -> Result<()> {
         // Proxies media-server artwork so the browser never receives the Plex
         // token / Emby API key that fetching it requires. See `artwork.rs`.
         .route("/artwork/{server}", get(artwork::artwork_handler))
+        // Manual Scrape's "upload an NZB file" entry point. The action lives
+        // at a deliberately distinct path from where the staged file is
+        // served back out (`/internal/nzb-uploads/{file}`, matching
+        // `riven_core::nzb::NZB_UPLOAD_ROUTE_PREFIX`) rather than sharing it,
+        // so this exact-match route and the `nest_service` below can never
+        // ambiguously overlap in the router. The upload action itself is
+        // capped to a small body via a route-scoped `DefaultBodyLimit`;
+        // serving the staged file back out (fetched by `plugin-usenet`'s own
+        // HTTP client, never the browser) carries no such limit since it only
+        // ever reads what this route already wrote. See `nzb_upload.rs`.
+        .route(
+            "/internal/nzb-upload",
+            post(nzb_upload::upload_handler)
+                .route_layer(DefaultBodyLimit::max(nzb_upload::MAX_UPLOAD_BYTES)),
+        )
+        .nest_service(
+            "/internal/nzb-uploads",
+            ServeDir::new(riven_core::nzb::NZB_UPLOAD_DIR),
+        )
         // Everything auth: sign-in/out, sign-up, sessions, password, Plex,
         // passkeys, OIDC, admin — see `authn::router`. It carries its own
         // rate-limit middleware, which needs the state to resolve a caller.

--- a/crates/riven-api/src/server.rs
+++ b/crates/riven-api/src/server.rs
@@ -136,6 +136,7 @@ pub async fn start_server(config: StartServerConfig) -> Result<()> {
         crate::schema::StremioAddonToken(riven_core::stremio::addon_token(
             api_key.as_deref().unwrap_or_default(),
         )),
+        crate::schema::GqlPort(port),
     );
 
     start_event_controller(job_queue.clone());

--- a/crates/riven-api/src/server/nzb_upload.rs
+++ b/crates/riven-api/src/server/nzb_upload.rs
@@ -1,0 +1,148 @@
+//! Manual Scrape's "upload an NZB file" entry point.
+//!
+//! Accepts a raw `.nzb` file, stages it under
+//! [`riven_core::nzb::NZB_UPLOAD_DIR`], and hands back a loopback URL that
+//! slots straight into the existing `downloadExplicitNzb` mutation — nothing
+//! downstream of that mutation needs to know the URL came from an upload
+//! rather than a pasted link. See `riven_core::nzb` for the storage/cleanup
+//! contract and why the URL is loopback rather than the instance's public
+//! one.
+//!
+//! Safety notes, since this is the one place in the API that accepts and
+//! persists an arbitrary file body:
+//! - Capped at [`MAX_UPLOAD_BYTES`] via a route-scoped `DefaultBodyLimit`, so
+//!   a caller can't fill the container's `/tmp` by uploading something huge.
+//! - Content is sniffed for a plausible XML/NZB prefix before it's written to
+//!   disk at all — rejects arbitrary binaries dressed up as `.nzb`.
+//! - The on-disk filename is always a fresh server-generated UUID, never
+//!   anything derived from the client's filename or content — no path ever
+//!   touches user input.
+//! - Requires the same `ScrapeItems` capability as every other Manual Scrape
+//!   mutation, checked the same way GraphQL's `require()` does.
+
+use axum::Json;
+use axum::extract::{Multipart, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+use crate::schema::auth::{Capability, RequestAuth};
+
+use super::ApiState;
+use super::auth::authorize_request;
+
+/// Generous headroom over any real NZB (typically low hundreds of KB even for
+/// large multi-file season packs) while still bounding worst-case disk use
+/// per upload.
+pub(super) const MAX_UPLOAD_BYTES: usize = 8 * 1024 * 1024;
+
+#[derive(Serialize)]
+struct UploadResponse {
+    url: String,
+}
+
+pub(super) async fn upload_handler(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+    mut multipart: Multipart,
+) -> Response {
+    let auth = match authorize_request(&state, &headers, None).await {
+        Ok(auth) => auth,
+        Err(_) => return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
+    };
+    if !capability_granted(&auth) {
+        return (StatusCode::FORBIDDEN, "Forbidden").into_response();
+    }
+
+    let field = match multipart.next_field().await {
+        Ok(Some(field)) => field,
+        Ok(None) => return (StatusCode::BAD_REQUEST, "No file field in upload").into_response(),
+        Err(error) => return (StatusCode::BAD_REQUEST, error.to_string()).into_response(),
+    };
+
+    let bytes = match field.bytes().await {
+        Ok(bytes) => bytes,
+        Err(error) => return (StatusCode::BAD_REQUEST, error.to_string()).into_response(),
+    };
+
+    // Belt-and-suspenders: the route-scoped `DefaultBodyLimit` should already
+    // have refused an oversized request before the body was even fully read,
+    // but a future refactor that drops that layer must not silently turn this
+    // into an unbounded write.
+    if bytes.len() > MAX_UPLOAD_BYTES {
+        return (StatusCode::PAYLOAD_TOO_LARGE, "NZB file too large").into_response();
+    }
+
+    if !looks_like_nzb(&bytes) {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "File does not look like a valid NZB (expected XML starting with <?xml or <nzb)",
+        )
+            .into_response();
+    }
+
+    match riven_core::nzb::store_nzb_upload(&bytes, state.gql_port).await {
+        Ok(url) => Json(UploadResponse { url }).into_response(),
+        Err(error) => {
+            tracing::warn!(%error, "failed to store NZB upload");
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to store upload").into_response()
+        }
+    }
+}
+
+fn capability_granted(auth: &RequestAuth) -> bool {
+    Capability::ScrapeItems.granted_to(auth.role)
+}
+
+/// Cheap content sniff, not a real NZB grammar check — `riven_usenet`'s own
+/// parser is what actually validates structure at ingest time. This exists
+/// only to reject obviously-wrong uploads (images, random binaries) before
+/// they're written to disk at all.
+///
+/// Works on raw bytes rather than decoding to `&str` first: upload content
+/// isn't guaranteed valid UTF-8, and `<?xml`/`<nzb` are pure ASCII anyway, so
+/// a byte-level prefix check needs no decoding (and none of the panic risk a
+/// fixed-byte-count slice of a `&str` would carry on a multi-byte boundary).
+fn looks_like_nzb(bytes: &[u8]) -> bool {
+    let mut head = bytes;
+    if let Some(rest) = head.strip_prefix(b"\xEF\xBB\xBF") {
+        head = rest; // UTF-8 BOM
+    }
+    let head = head.trim_ascii_start();
+    (head.len() >= 5 && head[..5].eq_ignore_ascii_case(b"<?xml"))
+        || (head.len() >= 4 && head[..4].eq_ignore_ascii_case(b"<nzb"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_real_nzb_shapes() {
+        assert!(looks_like_nzb(b"<?xml version=\"1.0\"?><nzb>...</nzb>"));
+        assert!(looks_like_nzb(b"<nzb xmlns=\"...\">"));
+        assert!(looks_like_nzb(b"  \n\t<?xml version=\"1.0\"?>")); // leading whitespace
+        assert!(looks_like_nzb(b"\xEF\xBB\xBF<?xml version=\"1.0\"?>")); // BOM
+        assert!(looks_like_nzb(b"<?XML VERSION=\"1.0\"?>")); // case-insensitive
+    }
+
+    #[test]
+    fn rejects_non_nzb_content() {
+        assert!(!looks_like_nzb(b""));
+        assert!(!looks_like_nzb(b"\x89PNG\r\n\x1a\n")); // PNG magic bytes
+        assert!(!looks_like_nzb(b"just some text"));
+        assert!(!looks_like_nzb(b"<html><body>not an nzb</body></html>"));
+        // Short enough that a naive fixed-length slice would panic rather
+        // than correctly report "doesn't match".
+        assert!(!looks_like_nzb(b"<"));
+        assert!(!looks_like_nzb(b"<?xm"));
+    }
+
+    /// Arbitrary bytes that aren't valid UTF-8 must not panic the sniff —
+    /// this runs on unauthenticated-shape (any bytes a client sends) input
+    /// before any validation has happened.
+    #[test]
+    fn handles_invalid_utf8_without_panicking() {
+        assert!(!looks_like_nzb(&[0xff, 0xfe, 0x00, 0x01, 0x02]));
+    }
+}

--- a/crates/riven-app/src/main.rs
+++ b/crates/riven-app/src/main.rs
@@ -219,7 +219,7 @@ async fn main() -> Result<()> {
 
     let registry = setup::register_plugins(
         http_client.clone(),
-        redis_conn,
+        redis_conn.clone(),
         settings.filesystem.mount_path.clone(),
         &settings,
     )
@@ -351,6 +351,7 @@ async fn main() -> Result<()> {
     let gql_handle = tokio::spawn({
         let jq = job_queue.clone();
         let reg = registry.clone();
+        let redis_conn = redis_conn.clone();
         let api_key = (!settings.api_key.is_empty()).then(|| settings.api_key.clone());
         let log_dir = settings.log_directory.clone();
         let mut cors_allowed_origins: Vec<String> = settings
@@ -383,6 +384,7 @@ async fn main() -> Result<()> {
                 port: gql_port,
                 registry: reg,
                 job_queue: jq.clone(),
+                redis_conn: redis_conn.clone(),
                 http_client: http_client.clone(),
                 api_key,
                 log_directory: log_dir,

--- a/crates/riven-core/Cargo.toml
+++ b/crates/riven-core/Cargo.toml
@@ -6,7 +6,8 @@ rust-version.workspace = true
 
 [dependencies]
 riven-rank = { path = "../riven-rank" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
+uuid = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/riven-core/src/entities/media_items.rs
+++ b/crates/riven-core/src/entities/media_items.rs
@@ -71,6 +71,11 @@ pub struct Model {
     pub network_timezone: Option<String>,
     pub aired_at_utc: Option<DateTimeUtc>,
     pub last_scrape_attempt_at: Option<DateTimeUtc>,
+    /// Set once a Manual Scrape (a picked discovery result, a pasted
+    /// magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+    /// `get_pending_items_for_retry`'s automatic re-scrape loop, since the
+    /// user has already made the pick that loop exists to make on its own.
+    pub manual_scrape_only: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/riven-core/src/http.rs
+++ b/crates/riven-core/src/http.rs
@@ -4,6 +4,7 @@ pub mod profiles;
 mod rate_limit;
 mod response;
 mod retry;
+pub mod ssrf_guard;
 
 pub use client::HttpClient;
 pub use profiles::HttpServiceProfile;

--- a/crates/riven-core/src/http/ssrf_guard.rs
+++ b/crates/riven-core/src/http/ssrf_guard.rs
@@ -13,14 +13,20 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
+/// Every caller-supplied NZB body this process reads into memory shares this
+/// cap — whether it arrived as an upload (`MAX_UPLOAD_BYTES`, `riven-api`'s
+/// `server` module) or was fetched from a URL ([`read_capped_text`]).
+pub const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
 /// Deliberately hand-rolled against the well-known private/reserved ranges
 /// rather than the standard library's `is_global()` (still unstable) or an
 /// extra dependency — this only needs to be right for IPv4 RFC 1918 /
 /// loopback / link-local / CGNAT / reserved and the IPv6 loopback /
-/// unique-local / link-local equivalents (including an IPv4 address embedded
-/// in an IPv4-mapped IPv6 address, e.g. `::ffff:127.0.0.1`, which the bare
-/// `Ipv6Addr` checks below don't catch), which covers every realistic
-/// internal address a container on a host like this could be reached at.
+/// unique-local / link-local equivalents, including an IPv4 address embedded
+/// in any of the three IPv6 forms that carry one (`::ffff:a.b.c.d` mapped,
+/// the deprecated `::a.b.c.d` compatible form, and `64:ff9b::a.b.c.d`
+/// NAT64), which covers every realistic internal address a container on a
+/// host like this could be reached at.
 pub fn is_global_ip(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => is_global_ipv4(v4),
@@ -29,6 +35,23 @@ pub fn is_global_ip(ip: IpAddr) -> bool {
                 return is_global_ipv4(mapped);
             }
             let segments = v6.segments();
+            // NAT64 well-known prefix (64:ff9b::/96, RFC 6052): a NAT64
+            // gateway routes this straight to the embedded IPv4 address, so
+            // it deserves exactly the same trust level as if the caller had
+            // supplied that address directly.
+            if segments[0..6] == [0x0064, 0xff9b, 0, 0, 0, 0] {
+                return is_global_ipv4(embedded_ipv4(segments));
+            }
+            // The deprecated IPv4-compatible form (`::a.b.c.d`, RFC 4291
+            // §2.5.5.1): high 96 bits zero. This overlaps a handful of
+            // genuinely-reserved low-value addresses (`::1`, `::2`, ...),
+            // but every one of those decodes to a `0.0.0.0/8` IPv4 address,
+            // which `is_global_ipv4` already rejects outright — so treating
+            // them as "compatible" here changes nothing about whether they
+            // pass.
+            if segments[0..6] == [0, 0, 0, 0, 0, 0] {
+                return is_global_ipv4(embedded_ipv4(segments));
+            }
             !(v6.is_loopback()
                 || v6.is_unspecified()
                 || v6.is_multicast()
@@ -36,6 +59,15 @@ pub fn is_global_ip(ip: IpAddr) -> bool {
                 || (segments[0] & 0xffc0) == 0xfe80) // link-local, fe80::/10
         }
     }
+}
+
+fn embedded_ipv4(segments: [u16; 8]) -> Ipv4Addr {
+    Ipv4Addr::new(
+        (segments[6] >> 8) as u8,
+        (segments[6] & 0xff) as u8,
+        (segments[7] >> 8) as u8,
+        (segments[7] & 0xff) as u8,
+    )
 }
 
 fn is_global_ipv4(v4: Ipv4Addr) -> bool {
@@ -83,4 +115,95 @@ pub fn build_pinned_client(host: &str, addr: SocketAddr) -> reqwest::Result<reqw
         .resolve(host, addr)
         .timeout(Duration::from_secs(20))
         .build()
+}
+
+/// Why a [`read_capped_text`] call failed. Kept distinct from a bare
+/// `reqwest::Error` so callers can tell "the upstream said no"/"too big"/"not
+/// text" apart from a genuine transport failure, without groveling through
+/// an error message to do it.
+#[derive(Debug)]
+pub enum CappedReadError {
+    NotSuccess(reqwest::StatusCode),
+    Transport(reqwest::Error),
+    TooLarge,
+    InvalidUtf8,
+}
+
+impl std::fmt::Display for CappedReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotSuccess(status) => write!(f, "response status {status}"),
+            Self::Transport(error) => write!(f, "transport error: {error}"),
+            Self::TooLarge => write!(f, "response exceeded {MAX_RESPONSE_BYTES} bytes"),
+            Self::InvalidUtf8 => write!(f, "response was not valid UTF-8"),
+        }
+    }
+}
+
+impl std::error::Error for CappedReadError {}
+
+/// Reads `response` as text, rejecting it once it exceeds
+/// [`MAX_RESPONSE_BYTES`] rather than after — buffering a whole body
+/// unconditionally before a caller ever gets to check its length would let a
+/// malicious or merely oversized upstream exhaust memory before any size
+/// check could run. Reading the raw response chunk-by-chunk with a running
+/// total closes that.
+pub async fn read_capped_text(mut response: reqwest::Response) -> Result<String, CappedReadError> {
+    if !response.status().is_success() {
+        return Err(CappedReadError::NotSuccess(response.status()));
+    }
+
+    let mut buf = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(CappedReadError::Transport)? {
+        buf.extend_from_slice(&chunk);
+        if buf.len() > MAX_RESPONSE_BYTES {
+            return Err(CappedReadError::TooLarge);
+        }
+    }
+    String::from_utf8(buf).map_err(|_utf8_error| CappedReadError::InvalidUtf8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_non_global_addresses() {
+        let non_global: &[&str] = &[
+            "10.0.0.1",           // RFC 1918 private
+            "127.0.0.1",          // loopback
+            "169.254.169.254",    // link-local / cloud metadata
+            "100.64.0.1",         // CGNAT
+            "0.0.0.0",            // unspecified / 0.0.0.0/8
+            "192.0.0.1",          // IETF protocol assignments
+            "240.0.0.1",          // reserved
+            "255.255.255.255",    // broadcast
+            "::1",                // IPv6 loopback
+            "fd00::1",            // unique local
+            "fe80::1",            // link-local
+            "::ffff:127.0.0.1",   // IPv4-mapped loopback
+            "::ffff:10.0.0.1",    // IPv4-mapped private
+            "::7f00:1",           // deprecated IPv4-compatible loopback (::127.0.0.1)
+            "64:ff9b::a9fe:a9fe", // NAT64-embedded link-local (169.254.169.254)
+        ];
+        for addr in non_global {
+            let ip: IpAddr = addr.parse().unwrap();
+            assert!(!is_global_ip(ip), "{addr} should not be global");
+        }
+    }
+
+    #[test]
+    fn accepts_public_addresses() {
+        let global: &[&str] = &[
+            "8.8.8.8",
+            "1.1.1.1",
+            "2606:4700:4700::1111",
+            "::ffff:8.8.8.8",
+            "64:ff9b::808:808", // NAT64-embedded 8.8.8.8
+        ];
+        for addr in global {
+            let ip: IpAddr = addr.parse().unwrap();
+            assert!(is_global_ip(ip), "{addr} should be global");
+        }
+    }
 }

--- a/crates/riven-core/src/http/ssrf_guard.rs
+++ b/crates/riven-core/src/http/ssrf_guard.rs
@@ -1,0 +1,86 @@
+//! Shared "is this a safe external HTTP(S) target" check, for the handful of
+//! places an authenticated-but-not-fully-trusted caller supplies a URL this
+//! process then fetches itself (manual NZB URLs, both the synchronous
+//! preview/enqueue path in `riven-api` and `plugin-usenet`'s deferred fetch
+//! of an already-enqueued one). The two halves only work together: resolving
+//! and validating a hostname is pointless if the connection that actually
+//! uses it re-resolves the same hostname a moment later (DNS can answer
+//! differently — deliberately, for a DNS-rebinding attack) or follows a
+//! redirect the check never saw. [`build_pinned_client`] must always be used
+//! with the exact address [`resolve_public_target`] returned, never with the
+//! caller's original hostname handed to an ordinary client.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+/// Deliberately hand-rolled against the well-known private/reserved ranges
+/// rather than the standard library's `is_global()` (still unstable) or an
+/// extra dependency — this only needs to be right for IPv4 RFC 1918 /
+/// loopback / link-local / CGNAT / reserved and the IPv6 loopback /
+/// unique-local / link-local equivalents (including an IPv4 address embedded
+/// in an IPv4-mapped IPv6 address, e.g. `::ffff:127.0.0.1`, which the bare
+/// `Ipv6Addr` checks below don't catch), which covers every realistic
+/// internal address a container on a host like this could be reached at.
+pub fn is_global_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_global_ipv4(v4),
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return is_global_ipv4(mapped);
+            }
+            let segments = v6.segments();
+            !(v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || (segments[0] & 0xfe00) == 0xfc00 // unique local, fc00::/7
+                || (segments[0] & 0xffc0) == 0xfe80) // link-local, fe80::/10
+        }
+    }
+}
+
+fn is_global_ipv4(v4: Ipv4Addr) -> bool {
+    let octets = v4.octets();
+    !(v4.is_private()
+        || v4.is_loopback()
+        || v4.is_link_local()
+        || v4.is_broadcast()
+        || v4.is_documentation()
+        || v4.is_multicast()
+        || octets[0] == 0 // 0.0.0.0/8 ("this network"), broader than is_unspecified's exact 0.0.0.0
+        || (octets[0] == 100 && (64..=127).contains(&octets[1])) // 100.64.0.0/10, CGNAT
+        || (octets[0] == 192 && octets[1] == 0 && octets[2] == 0) // 192.0.0.0/24, IETF protocol assignments
+        || octets[0] >= 240) // 240.0.0.0/4 reserved, includes 255.255.255.255
+}
+
+/// Resolves `host:port` and picks one address to pin the real connection to.
+/// `Ok(None)` covers both "nothing resolved" and "resolved, but at least one
+/// answer wasn't a public address" — a caller-supplied target must fail
+/// closed either way, so there's no reason for callers to tell those two
+/// apart. Rejecting the whole answer set when *any* entry is non-global
+/// (rather than just picking a global one and ignoring the rest) matters
+/// because the one this function ends up pinning to is a completely
+/// arbitrary member of the set — nothing here controls which address a
+/// caller's later, independent DNS lookup would have preferred.
+pub async fn resolve_public_target(host: &str, port: u16) -> std::io::Result<Option<SocketAddr>> {
+    let addrs = tokio::net::lookup_host((host, port))
+        .await?
+        .collect::<Vec<_>>();
+    if addrs.is_empty() || !addrs.iter().all(|addr| is_global_ip(addr.ip())) {
+        return Ok(None);
+    }
+    Ok(Some(addrs[0]))
+}
+
+/// A one-shot client scoped to exactly the address [`resolve_public_target`]
+/// validated: redirects are disabled outright (nothing that fetches a
+/// caller-supplied URL here has a legitimate need to follow one — a
+/// redirecting upstream just means the caller should have pasted the final
+/// URL), and `.resolve` pins `host` to `addr` so the connection can't re-run
+/// DNS and land somewhere the earlier check never saw.
+pub fn build_pinned_client(host: &str, addr: SocketAddr) -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .resolve(host, addr)
+        .timeout(Duration::from_secs(20))
+        .build()
+}

--- a/crates/riven-core/src/http/ssrf_guard.rs
+++ b/crates/riven-core/src/http/ssrf_guard.rs
@@ -42,6 +42,15 @@ pub fn is_global_ip(ip: IpAddr) -> bool {
             if segments[0..6] == [0x0064, 0xff9b, 0, 0, 0, 0] {
                 return is_global_ipv4(embedded_ipv4(segments));
             }
+            // The RFC 8215 *local-use* IPv4/IPv6 translation prefix
+            // (64:ff9b:1::/48) is a distinct block from the well-known one
+            // above: reserved for a site's own internal NAT64, not globally
+            // routable. Unlike 64:ff9b::/96, there's no embedded-IPv4
+            // fallback to defer to here — the whole point of this prefix is
+            // that it's local-use only, so reject it outright.
+            if segments[0] == 0x0064 && segments[1] == 0xff9b && segments[2] == 0x0001 {
+                return false;
+            }
             // The deprecated IPv4-compatible form (`::a.b.c.d`, RFC 4291
             // §2.5.5.1): high 96 bits zero. This overlaps a handful of
             // genuinely-reserved low-value addresses (`::1`, `::2`, ...),
@@ -155,10 +164,10 @@ pub async fn read_capped_text(mut response: reqwest::Response) -> Result<String,
 
     let mut buf = Vec::new();
     while let Some(chunk) = response.chunk().await.map_err(CappedReadError::Transport)? {
-        buf.extend_from_slice(&chunk);
-        if buf.len() > MAX_RESPONSE_BYTES {
+        if buf.len() + chunk.len() > MAX_RESPONSE_BYTES {
             return Err(CappedReadError::TooLarge);
         }
+        buf.extend_from_slice(&chunk);
     }
     String::from_utf8(buf).map_err(|_utf8_error| CappedReadError::InvalidUtf8)
 }
@@ -185,6 +194,8 @@ mod tests {
             "::ffff:10.0.0.1",    // IPv4-mapped private
             "::7f00:1",           // deprecated IPv4-compatible loopback (::127.0.0.1)
             "64:ff9b::a9fe:a9fe", // NAT64-embedded link-local (169.254.169.254)
+            "64:ff9b:1::1",       // RFC 8215 local-use translation prefix
+            "64:ff9b:1::808:808", // same prefix, would decode to a public IPv4 if allowed
         ];
         for addr in non_global {
             let ip: IpAddr = addr.parse().unwrap();

--- a/crates/riven-core/src/nzb.rs
+++ b/crates/riven-core/src/nzb.rs
@@ -71,14 +71,26 @@ pub async fn store_nzb_upload(bytes: &[u8], gql_port: u16) -> std::io::Result<St
 
 /// If `url` points at one of this crate's own temp uploads, the filename it
 /// was stored under (validated — see [`is_valid_upload_filename`]). `None` for
-/// any real external NZB URL, including one that merely happens to contain
-/// [`NZB_UPLOAD_ROUTE_PREFIX`] somewhere that isn't a genuine single path
-/// segment (a query string or fragment, say) — a `downloadExplicitNzb` caller
-/// controls this string directly, so it is untrusted input right up to this
-/// check.
-pub fn uploaded_nzb_filename(url: &str) -> Option<&str> {
-    let (_, tail) = url.split_once(NZB_UPLOAD_ROUTE_PREFIX)?;
-    is_valid_upload_filename(tail).then_some(tail)
+/// any real external NZB URL — a `downloadExplicitNzb`/`previewManualNzb`
+/// caller controls this string directly, so it is untrusted input right up to
+/// this check.
+///
+/// Parses `url` properly (scheme + host, not a raw substring match) rather
+/// than just checking the path contains [`NZB_UPLOAD_ROUTE_PREFIX`] somewhere:
+/// a plain `url.contains(...)` check would also accept
+/// `https://evil.example/internal/nzb-uploads/<uuid>.nzb` as "one of ours",
+/// which — since this function's whole purpose is deciding what's safe to
+/// delete on disk after a fetch succeeds — would let an attacker-controlled
+/// external host trigger a local file deletion by shaping their response to
+/// pass whatever came next. Requiring `http://127.0.0.1:<any port>/...`
+/// specifically (the exact shape [`store_nzb_upload`] produces) closes that.
+pub fn uploaded_nzb_filename(url: &str) -> Option<String> {
+    let parsed = url::Url::parse(url).ok()?;
+    if parsed.scheme() != "http" || parsed.host_str() != Some("127.0.0.1") {
+        return None;
+    }
+    let tail = parsed.path().strip_prefix(NZB_UPLOAD_ROUTE_PREFIX)?;
+    is_valid_upload_filename(tail).then(|| tail.to_string())
 }
 
 /// Best-effort delete of an ingested upload's temp file. Re-validates
@@ -564,7 +576,7 @@ mod tests {
     fn uploaded_nzb_filename_accepts_a_real_upload_url() {
         let filename = "550e8400-e29b-41d4-a716-446655440000.nzb";
         let url = format!("http://127.0.0.1:8082{NZB_UPLOAD_ROUTE_PREFIX}{filename}");
-        assert_eq!(uploaded_nzb_filename(&url), Some(filename));
+        assert_eq!(uploaded_nzb_filename(&url), Some(filename.to_string()));
     }
 
     #[test]
@@ -573,6 +585,26 @@ mod tests {
             uploaded_nzb_filename("https://indexer.example/get/abc123.nzb"),
             None
         );
+    }
+
+    /// The host, not just the path, must be the loopback upload address —
+    /// otherwise an external server could shape its own URL/path to be
+    /// mistaken for one of this instance's own temp uploads and have a local
+    /// file deleted on its behalf after a successful fetch.
+    #[test]
+    fn uploaded_nzb_filename_rejects_an_external_host_on_the_upload_path() {
+        let filename = "550e8400-e29b-41d4-a716-446655440000.nzb";
+        for hostile in [
+            format!("https://evil.example{NZB_UPLOAD_ROUTE_PREFIX}{filename}"),
+            format!("http://evil.example:8080{NZB_UPLOAD_ROUTE_PREFIX}{filename}"),
+            // Same path shape, wrong loopback literal (IPv6, or a hostname
+            // that merely resolves to 127.0.0.1) — only the exact
+            // `127.0.0.1` host string this crate itself writes is trusted.
+            format!("http://localhost{NZB_UPLOAD_ROUTE_PREFIX}{filename}"),
+            format!("http://[::1]{NZB_UPLOAD_ROUTE_PREFIX}{filename}"),
+        ] {
+            assert_eq!(uploaded_nzb_filename(&hostile), None, "{hostile:?}");
+        }
     }
 
     /// The specific attack this whole check exists to stop: a caller-supplied

--- a/crates/riven-core/src/nzb.rs
+++ b/crates/riven-core/src/nzb.rs
@@ -27,6 +27,104 @@ pub fn nzb_url_redis_key(info_hash: &str) -> String {
     format!("riven:nzb:url:{info_hash}")
 }
 
+/// Container-local staging area for manually-uploaded `.nzb` files (Manual
+/// Scrape's "upload an NZB" entry point). Deliberately `/tmp` rather than a
+/// persisted volume: an upload lives only from the moment it's saved to the
+/// moment `plugin-usenet` ingests it (or the hourly sweep in
+/// [`sweep_stale_nzb_uploads`] catches whatever never gets that far) — never
+/// across a restart, and never anything worth surviving one.
+pub const NZB_UPLOAD_DIR: &str = "/tmp/riven-nzb-uploads";
+
+/// Path prefix the upload-serving route is mounted at in `riven-api`. Shared
+/// here (rather than `riven-api` reaching into `plugin-usenet`, or vice versa)
+/// so the plugin can recognise "this NZB URL is one of our own temp uploads"
+/// — and clean the file up once ingest no longer needs it — without either
+/// crate depending on the other.
+pub const NZB_UPLOAD_ROUTE_PREFIX: &str = "/internal/nzb-uploads/";
+
+/// `true` only for the exact shape this crate's own upload route ever writes:
+/// a v4 UUID plus `.nzb`, nothing else. This is the one check standing between
+/// a filename and `Path::join`, so it is deliberately stricter than "contains
+/// no `/`" — a bare `..` contains no `/` either, and would otherwise walk the
+/// join straight out of [`NZB_UPLOAD_DIR`].
+fn is_valid_upload_filename(name: &str) -> bool {
+    name.strip_suffix(".nzb")
+        .is_some_and(|uuid_part| uuid::Uuid::parse_str(uuid_part).is_ok())
+}
+
+/// Save an uploaded NZB's bytes under a freshly-random name and return the
+/// loopback URL `plugin-usenet`'s own HTTP fetch will resolve it at later.
+/// Loopback, not the instance's public URL: today only `plugin-usenet`'s
+/// direct-NNTP path ever fetches an NZB URL itself — `plugin-stremthru`'s newz
+/// relay submits the URL to StremThru's own server, which would need it to be
+/// externally reachable instead. If a newz-capable StremThru store is ever
+/// wired up on this instance, this needs to switch to the public URL.
+pub async fn store_nzb_upload(bytes: &[u8], gql_port: u16) -> std::io::Result<String> {
+    tokio::fs::create_dir_all(NZB_UPLOAD_DIR).await?;
+    let filename = format!("{}.nzb", uuid::Uuid::new_v4());
+    let path = std::path::Path::new(NZB_UPLOAD_DIR).join(&filename);
+    tokio::fs::write(&path, bytes).await?;
+    Ok(format!(
+        "http://127.0.0.1:{gql_port}{NZB_UPLOAD_ROUTE_PREFIX}{filename}"
+    ))
+}
+
+/// If `url` points at one of this crate's own temp uploads, the filename it
+/// was stored under (validated — see [`is_valid_upload_filename`]). `None` for
+/// any real external NZB URL, including one that merely happens to contain
+/// [`NZB_UPLOAD_ROUTE_PREFIX`] somewhere that isn't a genuine single path
+/// segment (a query string or fragment, say) — a `downloadExplicitNzb` caller
+/// controls this string directly, so it is untrusted input right up to this
+/// check.
+pub fn uploaded_nzb_filename(url: &str) -> Option<&str> {
+    let (_, tail) = url.split_once(NZB_UPLOAD_ROUTE_PREFIX)?;
+    is_valid_upload_filename(tail).then_some(tail)
+}
+
+/// Best-effort delete of an ingested upload's temp file. Re-validates
+/// `filename` itself rather than trusting the caller to have already checked
+/// it via [`uploaded_nzb_filename`] — the one path-safety check that matters
+/// here, so it stays enforced at the point of the actual file I/O rather than
+/// only at whichever call site happens to remember it. Never surfaces an
+/// error: a cleanup miss just means [`sweep_stale_nzb_uploads`] catches it on
+/// the next hourly tick.
+pub async fn delete_nzb_upload(filename: &str) {
+    if !is_valid_upload_filename(filename) {
+        return;
+    }
+    let path = std::path::Path::new(NZB_UPLOAD_DIR).join(filename);
+    if let Err(error) = tokio::fs::remove_file(&path).await
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::debug!(%error, filename, "failed to delete temp NZB upload");
+    }
+}
+
+/// Delete every file in [`NZB_UPLOAD_DIR`] older than `max_age`. Runs on the
+/// queue Scheduler's hourly tick as a backstop for uploads whose ingest never
+/// reached the point that deletes them immediately — a bad upload, a crash
+/// mid-flow, or a manual scrape the user never followed through on. Returns
+/// the count removed, purely for logging.
+pub async fn sweep_stale_nzb_uploads(max_age: std::time::Duration) -> usize {
+    let Ok(mut entries) = tokio::fs::read_dir(NZB_UPLOAD_DIR).await else {
+        return 0;
+    };
+    let mut removed = 0usize;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let is_stale = entry
+            .metadata()
+            .await
+            .ok()
+            .and_then(|metadata| metadata.modified().ok())
+            .and_then(|modified| modified.elapsed().ok())
+            .is_some_and(|age| age > max_age);
+        if is_stale && tokio::fs::remove_file(entry.path()).await.is_ok() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
 /// Which indexer a release came from, written next to its URL at scrape time.
 /// The download path is where a grab becomes real, and by then the scrape
 /// results are long gone — this is the only handle back to the indexer that
@@ -460,5 +558,61 @@ mod tests {
         let b = nzb_info_hash("https://example/x.nzb");
         assert_eq!(a, b);
         assert!(is_nzb_info_hash(&a));
+    }
+
+    #[test]
+    fn uploaded_nzb_filename_accepts_a_real_upload_url() {
+        let filename = "550e8400-e29b-41d4-a716-446655440000.nzb";
+        let url = format!("http://127.0.0.1:8082{NZB_UPLOAD_ROUTE_PREFIX}{filename}");
+        assert_eq!(uploaded_nzb_filename(&url), Some(filename));
+    }
+
+    #[test]
+    fn uploaded_nzb_filename_rejects_a_real_external_nzb_url() {
+        assert_eq!(
+            uploaded_nzb_filename("https://indexer.example/get/abc123.nzb"),
+            None
+        );
+    }
+
+    /// The specific attack this whole check exists to stop: a caller-supplied
+    /// `nzbUrl` (any `downloadExplicitNzb` caller controls this string
+    /// directly) engineered so the tail after the prefix is `..` or similar.
+    /// A weaker check — e.g. "no `/` in the tail" — would let `..` straight
+    /// through, since it contains no `/` either, and joining it onto
+    /// `NZB_UPLOAD_DIR` would walk out of that directory entirely. Requiring
+    /// the tail to fully parse as `{uuid}.nzb` closes that regardless of what
+    /// shape the traversal attempt takes.
+    #[test]
+    fn uploaded_nzb_filename_rejects_path_traversal() {
+        for hostile in [
+            format!("http://127.0.0.1{NZB_UPLOAD_ROUTE_PREFIX}.."),
+            format!("http://127.0.0.1{NZB_UPLOAD_ROUTE_PREFIX}../../../etc/passwd"),
+            format!("http://127.0.0.1{NZB_UPLOAD_ROUTE_PREFIX}not-a-uuid.nzb"),
+            format!("http://127.0.0.1{NZB_UPLOAD_ROUTE_PREFIX}"),
+            // Same prefix substring, but not actually a single path segment —
+            // must not be mistaken for a real upload reference.
+            format!(
+                "http://evil.example/x?u=127.0.0.1{NZB_UPLOAD_ROUTE_PREFIX}550e8400-e29b-41d4-a716-446655440000.nzb/../../secrets"
+            ),
+        ] {
+            assert_eq!(uploaded_nzb_filename(&hostile), None, "{hostile:?}");
+        }
+    }
+
+    #[test]
+    fn delete_nzb_upload_refuses_a_non_uuid_filename() {
+        // No assertion beyond "doesn't panic and doesn't touch the
+        // filesystem" is possible without a real NZB_UPLOAD_DIR fixture;
+        // is_valid_upload_filename (exercised via uploaded_nzb_filename
+        // above) is the actual guarantee this relies on.
+        assert!(!is_valid_upload_filename(".."));
+        assert!(!is_valid_upload_filename("../../etc/passwd"));
+        assert!(!is_valid_upload_filename(
+            "550e8400-e29b-41d4-a716-446655440000"
+        ));
+        assert!(is_valid_upload_filename(
+            "550e8400-e29b-41d4-a716-446655440000.nzb"
+        ));
     }
 }

--- a/crates/riven-db/migrations/041_manual_scrape_no_auto_retry.sql
+++ b/crates/riven-db/migrations/041_manual_scrape_no_auto_retry.sql
@@ -1,0 +1,9 @@
+-- A user who manually resolves a specific release via Manual Scrape (a picked
+-- discovery result, a pasted magnet/hash, or a pasted NZB URL) has already
+-- made the call the automatic retry scheduler exists to make on its own.
+-- Letting `get_pending_items_for_retry` keep chasing the item afterwards can
+-- silently pick something different and download it over/alongside what the
+-- user actually chose. This flag opts an item out of that automatic loop
+-- without touching its state, so manual re-scrape/retry actions still work.
+ALTER TABLE media_items
+    ADD COLUMN IF NOT EXISTS manual_scrape_only BOOLEAN NOT NULL DEFAULT false;

--- a/crates/riven-db/src/migration.rs
+++ b/crates/riven-db/src/migration.rs
@@ -41,6 +41,7 @@ macro_rules! sql_migrations {
                 migrations.push(Box::new(M038DropBetterAuthPluginTables));
                 migrations.push(Box::new(M039DropUserBanColumns));
                 migrations.push(Box::new(M040IndexerStats));
+                migrations.push(Box::new(M041ManualScrapeNoAutoRetry));
                 migrations
             }
         }
@@ -69,6 +70,12 @@ sql_migration!(
     M040IndexerStats,
     "m040_indexer_stats",
     "040_indexer_stats.sql"
+);
+
+sql_migration!(
+    M041ManualScrapeNoAutoRetry,
+    "m041_manual_scrape_no_auto_retry",
+    "041_manual_scrape_no_auto_retry.sql"
 );
 
 /// Authentication tables, generated from riven's own entities.

--- a/crates/riven-db/src/repo.rs
+++ b/crates/riven-db/src/repo.rs
@@ -54,6 +54,12 @@ pub async fn reset_items_by_ids(ids: Vec<i64>) -> Result<u64> {
             MediaItemState::Indexed.as_enum(),
         )
         .col_expr(media_items::Column::FailedAttempts, Expr::value(0))
+        // An explicit reset through the library UI is the user opting these
+        // items back into automatic handling — clear any `manual_scrape_only`
+        // a prior Manual Scrape pick left set, or `get_pending_items_for_retry`
+        // would keep excluding them from the very automatic retry this reset
+        // is supposed to restore.
+        .col_expr(media_items::Column::ManualScrapeOnly, Expr::value(false))
         .col_expr(media_items::Column::UpdatedAt, Expr::cust("NOW()"))
         .filter(media_items::Column::Id.is_in(ids.iter().copied()))
         .exec(orm())
@@ -76,6 +82,9 @@ pub async fn retry_items_by_ids(ids: Vec<i64>) -> Result<u64> {
         // actually restores eligibility; resetting `failed_attempts` alone
         // does nothing if the item was scraped within the last 30 minutes.
         .col_expr(media_items::Column::LastScrapeAttemptAt, Expr::cust("NULL"))
+        // Same reasoning as `reset_items_by_ids`: an explicit "retry now"
+        // is the user re-opting these items into automatic handling.
+        .col_expr(media_items::Column::ManualScrapeOnly, Expr::value(false))
         .col_expr(media_items::Column::UpdatedAt, Expr::cust("NOW()"))
         .filter(media_items::Column::Id.is_in(ids.iter().copied()))
         .exec(orm())

--- a/crates/riven-db/src/repo/media.rs
+++ b/crates/riven-db/src/repo/media.rs
@@ -206,6 +206,7 @@ pub async fn get_pending_items_for_retry(item_type: MediaItemType) -> Result<Vec
         ]))
         .filter(media_items::Column::ItemType.eq(item_type))
         .filter(media_items::Column::IsRequested.eq(true))
+        .filter(media_items::Column::ManualScrapeOnly.eq(false))
         .filter(Expr::cust(FAILED_ATTEMPTS_COOLDOWN_SQL))
         .order_by_asc(media_items::Column::FailedAttempts)
         .order_by_with_nulls(
@@ -381,6 +382,20 @@ pub async fn set_active_stream(id: i64, stream_id: i64) -> Result<()> {
         id: Unchanged(id),
         active_stream_id: Set(Some(stream_id)),
         updated_at: Set(Some(Utc::now())),
+        ..Default::default()
+    }
+    .update(orm())
+    .await?;
+    Ok(())
+}
+
+/// Opt an item out of [`get_pending_items_for_retry`]'s automatic re-scrape
+/// loop — called after a Manual Scrape mutation resolves it, since the user
+/// has already made the pick that loop exists to make on its own.
+pub async fn mark_manual_scrape_only(id: i64) -> Result<()> {
+    media_items::ActiveModel {
+        id: Unchanged(id),
+        manual_scrape_only: Set(true),
         ..Default::default()
     }
     .update(orm())

--- a/crates/riven-db/tests/entities.rs
+++ b/crates/riven-db/tests/entities.rs
@@ -43,6 +43,7 @@ fn sample_movie(title: &str, year: Option<i32>, tmdb_id: Option<&str>) -> MediaI
         runtime: None,
         item_request_id: None,
         active_stream_id: None,
+        manual_scrape_only: false,
     }
 }
 

--- a/crates/riven-queue/src/application/download/candidates.rs
+++ b/crates/riven-queue/src/application/download/candidates.rs
@@ -298,6 +298,7 @@ mod tests {
             runtime: None,
             item_request_id: None,
             active_stream_id: None,
+            manual_scrape_only: false,
         }
     }
 

--- a/crates/riven-queue/src/application/process_media_item.rs
+++ b/crates/riven-queue/src/application/process_media_item.rs
@@ -161,6 +161,16 @@ async fn handle_validate(job: &ProcessMediaItemJob, item: &MediaItem, queue: &Jo
             fan_out_to_children(&item, queue).await;
         }
         MediaItemState::Failed | MediaItemState::Paused => {}
+        MediaItemState::Scraped | MediaItemState::Indexed | MediaItemState::Unreleased
+            if item.manual_scrape_only =>
+        {
+            tracing::debug!(
+                id = item.id,
+                title = %item.title,
+                state = ?item.state,
+                "pipeline: item still isn't complete after the download step, but it was manually scraped; not scheduling an automatic retry"
+            );
+        }
         MediaItemState::Scraped | MediaItemState::Indexed | MediaItemState::Unreleased => {
             // Mirrors `FAILED_ATTEMPTS_COOLDOWN_SQL`'s escalating tiers — this
             // job-level re-push doesn't go through `get_pending_items_for_retry`,

--- a/crates/riven-queue/src/worker.rs
+++ b/crates/riven-queue/src/worker.rs
@@ -7,6 +7,13 @@ use tokio_util::sync::CancellationToken;
 use crate::JobQueue;
 use crate::main_orchestrator::MainOrchestrator;
 
+/// How long a Manual Scrape NZB-upload temp file is allowed to sit unclaimed
+/// before the hourly sweep removes it. Generous relative to how fast the
+/// normal path actually clears one (ingest happens within seconds to minutes
+/// of the upload) — this is a backstop for the abnormal case, not the
+/// primary cleanup mechanism.
+const NZB_UPLOAD_STALE_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+
 /// Periodic scheduler.
 pub struct Scheduler {
     job_queue: Arc<JobQueue>,
@@ -69,6 +76,15 @@ impl Scheduler {
             Ok(0) => {}
             Ok(removed) => tracing::info!(removed, "pruned orphan streams"),
             Err(error) => tracing::error!(%error, "failed to prune orphan streams"),
+        }
+
+        // Backstop for Manual Scrape's NZB-upload temp files: the normal path
+        // deletes one the moment plugin-usenet ingests it, but a bad upload,
+        // a crash mid-flow, or a manual scrape the user never followed
+        // through on would otherwise leak a file forever.
+        let removed = riven_core::nzb::sweep_stale_nzb_uploads(NZB_UPLOAD_STALE_AGE).await;
+        if removed > 0 {
+            tracing::info!(removed, "pruned stale NZB upload temp files");
         }
     }
 

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -52,6 +52,11 @@
         itemType: "MOVIE" | "SEASON" | "EPISODE";
         seasonNumber?: number | null;
         episodeNumber?: number | null;
+        /** Client-only: set only on a card built from a manual NZB
+         * preview (paste or upload), never present on a real scrape
+         * result. Lets `downloadStream` route to `downloadExplicitNzb`
+         * instead of `downloadDiscoveredStream` for these cards. */
+        manualNzbUrl?: string;
     }
 
     /**
@@ -90,6 +95,38 @@
         downloadExplicitNzb(itemType: $itemType, title: $title, imdbId: $imdbId, tmdbId: $tmdbId, tvdbId: $tvdbId, seasonNumber: $seasonNumber, episodeNumber: $episodeNumber, seasons: $seasons, nzbUrl: $nzbUrl)
     }`;
 
+    const PREVIEW_MANUAL_MAGNET_MUTATION = `mutation($itemType: MediaItemType!, $infoHash: String!, $magnet: String!, $seasonNumber: Int, $episodeNumber: Int) {
+        previewManualMagnet(itemType: $itemType, infoHash: $infoHash, magnet: $magnet, seasonNumber: $seasonNumber, episodeNumber: $episodeNumber) {
+            key
+            title
+            infoHash
+            magnet
+            parsedData
+            rank
+            fileSizeBytes
+            isCached
+            itemType
+            seasonNumber
+            episodeNumber
+        }
+    }`;
+
+    const PREVIEW_MANUAL_NZB_MUTATION = `mutation($itemType: MediaItemType!, $nzbUrl: String!, $seasonNumber: Int, $episodeNumber: Int) {
+        previewManualNzb(itemType: $itemType, nzbUrl: $nzbUrl, seasonNumber: $seasonNumber, episodeNumber: $episodeNumber) {
+            key
+            title
+            infoHash
+            magnet
+            parsedData
+            rank
+            fileSizeBytes
+            isCached
+            itemType
+            seasonNumber
+            episodeNumber
+        }
+    }`;
+
     let {
         title,
         itemId,
@@ -115,6 +152,7 @@
     let explicitHash = $state("");
     let nzbUrl = $state("");
     let uploadingNzb = $state(false);
+    let previewingManual = $state(false);
     let nzbFileInput = $state<HTMLInputElement | undefined>(undefined);
     let searchQuery = $state("");
     let streams = $state<StreamCandidate[]>([]);
@@ -192,6 +230,7 @@
         explicitHash = "";
         nzbUrl = "";
         uploadingNzb = false;
+        previewingManual = false;
         searchQuery = "";
         advancedOpen = false;
         selectedSeasons = seasons
@@ -324,6 +363,46 @@
         if (nzbFileInput) nzbFileInput.value = "";
     }
 
+    /** Inserted at the top (most-recently-added is most visible) rather than
+     * appended; re-previewing the same release replaces its existing card in
+     * place instead of duplicating it. Also drops the "Cached only" filter
+     * when the new card is uncached — that filter defaults on, and without
+     * this a manually-added uncached release would vanish from view the
+     * instant it's added, with only the success toast as a clue why. */
+    function addOrReplaceStream(candidate: StreamCandidate) {
+        const idx = streams.findIndex((s) => s.key === candidate.key);
+        if (idx >= 0) {
+            streams = streams.map((s, i) => (i === idx ? candidate : s));
+        } else {
+            streams = [candidate, ...streams];
+        }
+        if (!candidate.isCached) cachedOnly = false;
+    }
+
+    function manualTargetSeasonNumber() {
+        if (isEpisodeMode) return seasonNumber;
+        return mediaType === "tv" ? (selectedSeasons[0] ?? null) : null;
+    }
+
+    /** `false` means a season/episode precondition failed and an error toast
+     * was already shown — the caller just bails without going further. */
+    function validateManualTarget(): boolean {
+        if (isEpisodeMode) {
+            if (seasonNumber == null) {
+                error = "No season number available for this episode";
+                toast.error(error);
+                return false;
+            }
+            return true;
+        }
+        if (mediaType === "tv" && selectedSeasons.length === 0) {
+            error = "Select at least one season first";
+            toast.error(error);
+            return false;
+        }
+        return true;
+    }
+
     function downloadStream(stream: StreamCandidate) {
         // A pack that parses to multiple seasons fills every one it contains;
         // the backend links it to the show rather than a single season. Not
@@ -332,6 +411,21 @@
         const packSeasons = isEpisodeMode
             ? []
             : (stream.parsedData?.seasons?.filter((n) => n > 0) ?? []);
+
+        if (stream.manualNzbUrl) {
+            return runDownload(stream.key, DOWNLOAD_EXPLICIT_NZB_MUTATION, {
+                itemType: stream.itemType,
+                title: title ?? "Unknown",
+                imdbId: null,
+                tmdbId: resolvedTmdbId,
+                tvdbId: resolvedTvdbId,
+                seasonNumber: stream.seasonNumber ?? null,
+                episodeNumber: stream.episodeNumber ?? null,
+                seasons: packSeasons.length ? packSeasons : null,
+                nzbUrl: stream.manualNzbUrl
+            });
+        }
+
         return submitDownload(stream.key, {
             itemType: stream.itemType,
             seasonNumber: stream.seasonNumber ?? null,
@@ -344,90 +438,79 @@
         });
     }
 
-    function downloadExplicitHash() {
+    /** Turns a pasted magnet/hash into a full stream-candidate card (same
+     * badges a real scrape result gets) instead of downloading it
+     * sight-unseen — the card's own "Download This" is what actually queues
+     * it, via `downloadStream` above. */
+    async function previewManualMagnet() {
         if (!cleanedHash) {
             error = "Enter a valid 40-char info hash or paste a magnet link";
-            return;
-        }
-
-        if (isEpisodeMode) {
-            if (seasonNumber == null) {
-                error = "No season number available for this episode";
-                toast.error(error);
-                return;
-            }
-            return submitDownload(`manual:${cleanedHash}`, {
-                itemType: "EPISODE",
-                seasonNumber,
-                episodeNumber,
-                seasons: null,
-                infoHash: cleanedHash,
-                magnet: `magnet:?xt=urn:btih:${cleanedHash}`,
-                parsedData: null
-            });
-        }
-
-        if (mediaType === "tv" && selectedSeasons.length === 0) {
-            error = "Select at least one season before downloading an explicit hash";
             toast.error(error);
             return;
         }
+        if (!validateManualTarget()) return;
 
-        return submitDownload(`manual:${cleanedHash}`, {
-            itemType: mediaType === "movie" ? "MOVIE" : "SEASON",
-            seasonNumber: mediaType === "tv" ? selectedSeasons[0] : null,
-            seasons: mediaType === "tv" ? selectedSeasons : null,
-            infoHash: cleanedHash,
-            magnet: `magnet:?xt=urn:btih:${cleanedHash}`,
-            parsedData: null
-        });
+        const trimmed = explicitHash.trim();
+        const magnet = trimmed.toLowerCase().startsWith("magnet:")
+            ? trimmed
+            : `magnet:?xt=urn:btih:${cleanedHash}`;
+
+        previewingManual = true;
+        error = null;
+        try {
+            const data = await gqlClient<{ previewManualMagnet: StreamCandidate }>(
+                PREVIEW_MANUAL_MAGNET_MUTATION,
+                {
+                    itemType: isEpisodeMode ? "EPISODE" : mediaType === "movie" ? "MOVIE" : "SEASON",
+                    infoHash: cleanedHash,
+                    magnet,
+                    seasonNumber: manualTargetSeasonNumber(),
+                    episodeNumber: isEpisodeMode ? episodeNumber : null
+                }
+            );
+            addOrReplaceStream(data.previewManualMagnet);
+            explicitHash = "";
+            toast.success("Added to stream candidates");
+        } catch (e) {
+            error = e instanceof Error ? e.message : "Failed to preview magnet";
+            toast.error(error);
+        } finally {
+            previewingManual = false;
+        }
     }
 
-    function downloadNzbUrl() {
+    /** NZB equivalent of `previewManualMagnet` — same "add a card, download
+     * from the list" flow, for either a pasted URL or one handed back by
+     * `uploadNzbFile`. */
+    async function previewManualNzb() {
         if (!cleanedNzbUrl) {
             error = "Enter a valid NZB URL (must start with http:// or https://)";
             toast.error(error);
             return;
         }
+        if (!validateManualTarget()) return;
 
-        const key = `manual-nzb:${cleanedNzbUrl}`;
-
-        if (isEpisodeMode) {
-            if (seasonNumber == null) {
-                error = "No season number available for this episode";
-                toast.error(error);
-                return;
-            }
-            return runDownload(key, DOWNLOAD_EXPLICIT_NZB_MUTATION, {
-                itemType: "EPISODE",
-                title: title ?? "Unknown",
-                imdbId: null,
-                tmdbId: resolvedTmdbId,
-                tvdbId: resolvedTvdbId,
-                seasonNumber,
-                episodeNumber,
-                seasons: null,
-                nzbUrl: cleanedNzbUrl
-            });
-        }
-
-        if (mediaType === "tv" && selectedSeasons.length === 0) {
-            error = "Select at least one season before downloading an NZB";
+        previewingManual = true;
+        error = null;
+        try {
+            const data = await gqlClient<{ previewManualNzb: StreamCandidate }>(
+                PREVIEW_MANUAL_NZB_MUTATION,
+                {
+                    itemType: isEpisodeMode ? "EPISODE" : mediaType === "movie" ? "MOVIE" : "SEASON",
+                    nzbUrl: cleanedNzbUrl,
+                    seasonNumber: manualTargetSeasonNumber(),
+                    episodeNumber: isEpisodeMode ? episodeNumber : null
+                }
+            );
+            addOrReplaceStream({ ...data.previewManualNzb, manualNzbUrl: cleanedNzbUrl });
+            nzbUrl = "";
+            toast.success("Added to stream candidates");
+        } catch (e) {
+            error = e instanceof Error ? e.message : "Failed to preview NZB";
             toast.error(error);
-            return;
+        } finally {
+            previewingManual = false;
         }
-
-        return runDownload(key, DOWNLOAD_EXPLICIT_NZB_MUTATION, {
-            itemType: mediaType === "movie" ? "MOVIE" : "SEASON",
-            title: title ?? "Unknown",
-            imdbId: null,
-            tmdbId: resolvedTmdbId,
-            tvdbId: resolvedTvdbId,
-            seasonNumber: mediaType === "tv" ? selectedSeasons[0] : null,
-            episodeNumber: null,
-            seasons: mediaType === "tv" ? selectedSeasons : null,
-            nzbUrl: cleanedNzbUrl
-        });
     }
 
     $effect(() => {
@@ -557,11 +640,12 @@
                                     {#if cleanedHash}
                                         <Button
                                             size="sm"
-                                            onclick={downloadExplicitHash}
-                                            disabled={downloadingKey !== null}>
-                                            {#if downloadingKey === `manual:${cleanedHash}`}<LoaderCircle
-                                                    class="mr-2 h-4 w-4 animate-spin" />{/if}
-                                            Download Explicit Hash
+                                            onclick={previewManualMagnet}
+                                            disabled={previewingManual}>
+                                            {#if previewingManual}
+                                                <LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
+                                            {/if}
+                                            Add to Candidates
                                         </Button>
                                     {/if}
                                 </div>
@@ -594,11 +678,12 @@
                                         {#if cleanedNzbUrl}
                                             <Button
                                                 size="sm"
-                                                onclick={downloadNzbUrl}
-                                                disabled={downloadingKey !== null}>
-                                                {#if downloadingKey === `manual-nzb:${cleanedNzbUrl}`}<LoaderCircle
-                                                        class="mr-2 h-4 w-4 animate-spin" />{/if}
-                                                Download NZB
+                                                onclick={previewManualNzb}
+                                                disabled={previewingManual}>
+                                                {#if previewingManual}
+                                                    <LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
+                                                {/if}
+                                                Add to Candidates
                                             </Button>
                                         {/if}
                                     </div>

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -704,16 +704,22 @@
                                     <Input
                                         bind:value={explicitHash}
                                         placeholder="magnet:?xt=urn:btih:... or 40-char hash" />
-                                    {#if cleanedHash}
+                                    {#if explicitHash.trim()}
                                         <Button
                                             size="sm"
                                             onclick={previewManualMagnet}
-                                            disabled={previewingManual}>
+                                            disabled={previewingManual || !cleanedHash}>
                                             {#if previewingManual}
                                                 <LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
                                             {/if}
                                             Add to Candidates
                                         </Button>
+                                        {#if !cleanedHash}
+                                            <p class="text-xs text-amber-400">
+                                                Enter a valid 40-char info hash or paste a magnet
+                                                link.
+                                            </p>
+                                        {/if}
                                     {/if}
                                 </div>
                                 <div class="space-y-2">
@@ -742,11 +748,11 @@
                                             {/if}
                                             Upload NZB file
                                         </Button>
-                                        {#if cleanedNzbUrl}
+                                        {#if nzbUrl.trim()}
                                             <Button
                                                 size="sm"
                                                 onclick={previewManualNzb}
-                                                disabled={previewingManual}>
+                                                disabled={previewingManual || !cleanedNzbUrl}>
                                                 {#if previewingManual}
                                                     <LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
                                                 {/if}
@@ -754,6 +760,12 @@
                                             </Button>
                                         {/if}
                                     </div>
+                                    {#if nzbUrl.trim() && !cleanedNzbUrl}
+                                        <p class="text-xs text-amber-400">
+                                            Enter a valid NZB URL (must start with http:// or
+                                            https://).
+                                        </p>
+                                    {/if}
                                 </div>
                             </div>
                         {/if}

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -268,6 +268,17 @@
             : [...selectedSeasons, seasonNumber].sort((a, b) => a - b);
     }
 
+    /** Clears only what the Filter dropdown itself controls (provider,
+     * resolution, quality) — matches `activeFilterCount`, which the dropdown's
+     * own Reset button is enabled/disabled by. The separate search box is
+     * cleared by `reset()`, not here, so Reset's enabled state always
+     * reflects exactly what it's about to clear. */
+    function resetFilters() {
+        providerFilter = { torrent: true, usenet: true };
+        resolutionFilter.clear();
+        qualityFilter.clear();
+    }
+
     function reset() {
         loading = false;
         error = null;
@@ -280,9 +291,7 @@
         uploadingNzb = false;
         previewingManual = false;
         searchQuery = "";
-        providerFilter = { torrent: true, usenet: true };
-        resolutionFilter.clear();
-        qualityFilter.clear();
+        resetFilters();
         advancedOpen = false;
         selectedSeasons = seasons
             .filter((season) => season.status !== "Available")
@@ -784,6 +793,18 @@
                                     <DropdownMenu.Content
                                         align="end"
                                         class="max-h-80 overflow-y-auto rounded-2xl border border-white/10 bg-zinc-950/95 shadow-2xl shadow-black/50 backdrop-blur-2xl">
+                                        <div class="flex items-center justify-between gap-3 px-1.5 py-1">
+                                            <DropdownMenu.Label class="p-0"
+                                                >Filters</DropdownMenu.Label>
+                                            <button
+                                                type="button"
+                                                class="text-xs text-zinc-400 transition hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-50"
+                                                onclick={resetFilters}
+                                                disabled={activeFilterCount === 0}>
+                                                Reset
+                                            </button>
+                                        </div>
+                                        <DropdownMenu.Separator />
                                         <DropdownMenu.Label>Download provider</DropdownMenu.Label>
                                         <DropdownMenu.Separator />
                                         <DropdownMenu.CheckboxItem
@@ -851,7 +872,12 @@
                             </div>
                         {:else}
                             <div
-                                class="max-h-[48vh] overflow-y-auto rounded-xl pr-1 sm:max-h-[52vh]">
+                                style="scrollbar-width: thin;"
+                                class="max-h-[48vh] overflow-y-auto rounded-xl pr-1 sm:max-h-[52vh]
+                                    [&::-webkit-scrollbar]:block [&::-webkit-scrollbar]:w-1.5
+                                    [&::-webkit-scrollbar-thumb]:rounded-full
+                                    [&::-webkit-scrollbar-thumb]:bg-white/15
+                                    [&::-webkit-scrollbar-track]:bg-transparent">
                                 <div class="space-y-3">
                                     {#each visibleStreams as stream (stream.key)}
                                         <div

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -569,18 +569,16 @@
                                         accept=".nzb,application/x-nzb,text/xml"
                                         class="hidden"
                                         onchange={handleNzbFileSelected} />
-                                    <button
-                                        type="button"
-                                        class="inline-flex w-fit items-center gap-1.5 rounded-full border border-white/10 px-2.5 py-1 text-xs text-zinc-400 transition hover:border-white/20 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-50"
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
                                         disabled={uploadingNzb}
                                         onclick={() => nzbFileInput?.click()}>
                                         {#if uploadingNzb}
-                                            <LoaderCircle class="h-3 w-3 animate-spin" />
-                                            Uploading...
-                                        {:else}
-                                            Upload .nzb file instead
+                                            <LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
                                         {/if}
-                                    </button>
+                                        Upload .nzb file instead
+                                    </Button>
                                 </div>
                             </div>
                         {/if}

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -4,6 +4,7 @@
     import { gqlClient } from "$lib/graphql-client";
     import { toast } from "svelte-sonner";
     import type { Snippet } from "svelte";
+    import { SvelteSet } from "svelte/reactivity";
     import * as Dialog from "$lib/components/ui/dialog/index.js";
     import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
     import { Button } from "$lib/components/ui/button/index.js";
@@ -158,6 +159,12 @@
     let nzbFileInput = $state<HTMLInputElement | undefined>(undefined);
     let searchQuery = $state("");
     let providerFilter = $state({ torrent: true, usenet: true });
+    // Empty set = no restriction (show everything) — same convention as the
+    // search box being empty. Populated with whatever distinct values are
+    // actually present in `streams`, so this never offers a resolution/
+    // quality nobody actually has.
+    const resolutionFilter = new SvelteSet<string>();
+    const qualityFilter = new SvelteSet<string>();
     let streams = $state<StreamCandidate[]>([]);
     let downloadingKey = $state<string | null>(null);
 
@@ -173,11 +180,43 @@
                 .filter((stream) => !query || stream.title.toLowerCase().includes(query))
                 .filter((stream) =>
                     isUsenet(stream.infoHash) ? providerFilter.usenet : providerFilter.torrent
+                )
+                .filter(
+                    (stream) =>
+                        resolutionFilter.size === 0 ||
+                        (stream.parsedData?.resolution &&
+                            resolutionFilter.has(stream.parsedData.resolution))
+                )
+                .filter(
+                    (stream) =>
+                        qualityFilter.size === 0 ||
+                        (stream.parsedData?.quality && qualityFilter.has(stream.parsedData.quality))
                 );
         })()
     );
     const disabledProviderCount = $derived(
         (providerFilter.torrent ? 0 : 1) + (providerFilter.usenet ? 0 : 1)
+    );
+    const activeFilterCount = $derived(
+        disabledProviderCount + resolutionFilter.size + qualityFilter.size
+    );
+    const availableResolutions = $derived(
+        Array.from(
+            new Set(
+                streams
+                    .map((stream) => stream.parsedData?.resolution)
+                    .filter((value): value is string => Boolean(value))
+            )
+        ).sort()
+    );
+    const availableQualities = $derived(
+        Array.from(
+            new Set(
+                streams
+                    .map((stream) => stream.parsedData?.quality)
+                    .filter((value): value is string => Boolean(value))
+            )
+        ).sort()
     );
     const resolvedTmdbId = $derived(
         mediaType === "movie" ? (clean(customTmdbId) ?? externalId) : null
@@ -242,6 +281,8 @@
         previewingManual = false;
         searchQuery = "";
         providerFilter = { torrent: true, usenet: true };
+        resolutionFilter.clear();
+        qualityFilter.clear();
         advancedOpen = false;
         selectedSeasons = seasons
             .filter((season) => season.status !== "Available")
@@ -728,39 +769,65 @@
                                 <DropdownMenu.Root>
                                     <DropdownMenu.Trigger>
                                         {#snippet child({ props })}
-                                            <Button
-                                                {...props}
-                                                variant="outline"
-                                                size="sm"
-                                                class="shrink-0">
+                                            <Button {...props} variant="outline" class="shrink-0">
                                                 <Filter class="h-3.5 w-3.5" />
                                                 Filter
-                                                {#if disabledProviderCount > 0}
+                                                {#if activeFilterCount > 0}
                                                     <Badge
                                                         variant="outline"
                                                         class="ml-1 h-4 px-1 text-[0.65rem]"
-                                                        >{disabledProviderCount}</Badge>
+                                                        >{activeFilterCount}</Badge>
                                                 {/if}
                                             </Button>
                                         {/snippet}
                                     </DropdownMenu.Trigger>
                                     <DropdownMenu.Content
                                         align="end"
-                                        class="rounded-2xl border border-white/10 bg-zinc-950/95 shadow-2xl shadow-black/50 backdrop-blur-2xl">
+                                        class="max-h-80 overflow-y-auto rounded-2xl border border-white/10 bg-zinc-950/95 shadow-2xl shadow-black/50 backdrop-blur-2xl">
                                         <DropdownMenu.Label>Download provider</DropdownMenu.Label>
                                         <DropdownMenu.Separator />
                                         <DropdownMenu.CheckboxItem
                                             bind:checked={providerFilter.torrent}
-                                            onSelect={(e) => e.preventDefault()}>
+                                            closeOnSelect={false}>
                                             <Magnet class="h-3.5 w-3.5 text-amber-400" />
                                             Torrent
                                         </DropdownMenu.CheckboxItem>
                                         <DropdownMenu.CheckboxItem
                                             bind:checked={providerFilter.usenet}
-                                            onSelect={(e) => e.preventDefault()}>
+                                            closeOnSelect={false}>
                                             <Newspaper class="h-3.5 w-3.5 text-sky-400" />
                                             Usenet
                                         </DropdownMenu.CheckboxItem>
+                                        {#if availableResolutions.length}
+                                            <DropdownMenu.Separator />
+                                            <DropdownMenu.Label>Resolution</DropdownMenu.Label>
+                                            {#each availableResolutions as resolution (resolution)}
+                                                <DropdownMenu.CheckboxItem
+                                                    checked={resolutionFilter.has(resolution)}
+                                                    onCheckedChange={(checked) =>
+                                                        checked
+                                                            ? resolutionFilter.add(resolution)
+                                                            : resolutionFilter.delete(resolution)}
+                                                    closeOnSelect={false}>
+                                                    {resolution}
+                                                </DropdownMenu.CheckboxItem>
+                                            {/each}
+                                        {/if}
+                                        {#if availableQualities.length}
+                                            <DropdownMenu.Separator />
+                                            <DropdownMenu.Label>Quality</DropdownMenu.Label>
+                                            {#each availableQualities as quality (quality)}
+                                                <DropdownMenu.CheckboxItem
+                                                    checked={qualityFilter.has(quality)}
+                                                    onCheckedChange={(checked) =>
+                                                        checked
+                                                            ? qualityFilter.add(quality)
+                                                            : qualityFilter.delete(quality)}
+                                                    closeOnSelect={false}>
+                                                    {quality}
+                                                </DropdownMenu.CheckboxItem>
+                                            {/each}
+                                        {/if}
                                     </DropdownMenu.Content>
                                 </DropdownMenu.Root>
                             </div>
@@ -774,8 +841,8 @@
                                     Waiting for backend results...
                                 {:else if streams.length && searchQuery.trim()}
                                     No streams matched "{searchQuery.trim()}".
-                                {:else if streams.length && disabledProviderCount > 0}
-                                    No streams matched the current provider filter.
+                                {:else if streams.length && activeFilterCount > 0}
+                                    No streams matched the current filter.
                                 {:else if streams.length && cachedOnly}
                                     No cached streams matched the current filter.
                                 {:else}

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -5,6 +5,7 @@
     import { toast } from "svelte-sonner";
     import type { Snippet } from "svelte";
     import * as Dialog from "$lib/components/ui/dialog/index.js";
+    import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
     import { Button } from "$lib/components/ui/button/index.js";
     import { Label } from "$lib/components/ui/label/index.js";
     import { Badge } from "$lib/components/ui/badge/index.js";
@@ -15,6 +16,7 @@
     import HardDrive from "@lucide/svelte/icons/hard-drive";
     import Newspaper from "@lucide/svelte/icons/newspaper";
     import Magnet from "@lucide/svelte/icons/magnet";
+    import Filter from "@lucide/svelte/icons/filter";
     import SeasonSelector, { type SeasonInfo } from "./season-selector.svelte";
     import { page } from "$app/state";
 
@@ -155,6 +157,7 @@
     let previewingManual = $state(false);
     let nzbFileInput = $state<HTMLInputElement | undefined>(undefined);
     let searchQuery = $state("");
+    let providerFilter = $state({ torrent: true, usenet: true });
     let streams = $state<StreamCandidate[]>([]);
     let downloadingKey = $state<string | null>(null);
 
@@ -167,8 +170,14 @@
             const query = searchQuery.trim().toLowerCase();
             return streams
                 .filter((stream) => !cachedOnly || stream.isCached)
-                .filter((stream) => !query || stream.title.toLowerCase().includes(query));
+                .filter((stream) => !query || stream.title.toLowerCase().includes(query))
+                .filter((stream) =>
+                    isUsenet(stream.infoHash) ? providerFilter.usenet : providerFilter.torrent
+                );
         })()
+    );
+    const disabledProviderCount = $derived(
+        (providerFilter.torrent ? 0 : 1) + (providerFilter.usenet ? 0 : 1)
     );
     const resolvedTmdbId = $derived(
         mediaType === "movie" ? (clean(customTmdbId) ?? externalId) : null
@@ -232,6 +241,7 @@
         uploadingNzb = false;
         previewingManual = false;
         searchQuery = "";
+        providerFilter = { torrent: true, usenet: true };
         advancedOpen = false;
         selectedSeasons = seasons
             .filter((season) => season.status !== "Available")
@@ -710,10 +720,50 @@
                         </div>
 
                         {#if streams.length}
-                            <Input
-                                class="mb-4"
-                                bind:value={searchQuery}
-                                placeholder="Filter by title, release group, resolution..." />
+                            <div class="mb-4 flex gap-2">
+                                <Input
+                                    class="flex-1"
+                                    bind:value={searchQuery}
+                                    placeholder="Filter by title, release group, resolution..." />
+                                <DropdownMenu.Root>
+                                    <DropdownMenu.Trigger>
+                                        {#snippet child({ props })}
+                                            <Button
+                                                {...props}
+                                                variant="outline"
+                                                size="sm"
+                                                class="shrink-0">
+                                                <Filter class="h-3.5 w-3.5" />
+                                                Filter
+                                                {#if disabledProviderCount > 0}
+                                                    <Badge
+                                                        variant="outline"
+                                                        class="ml-1 h-4 px-1 text-[0.65rem]"
+                                                        >{disabledProviderCount}</Badge>
+                                                {/if}
+                                            </Button>
+                                        {/snippet}
+                                    </DropdownMenu.Trigger>
+                                    <DropdownMenu.Content
+                                        align="end"
+                                        class="rounded-2xl border border-white/10 bg-zinc-950/95 shadow-2xl shadow-black/50 backdrop-blur-2xl">
+                                        <DropdownMenu.Label>Download provider</DropdownMenu.Label>
+                                        <DropdownMenu.Separator />
+                                        <DropdownMenu.CheckboxItem
+                                            bind:checked={providerFilter.torrent}
+                                            onSelect={(e) => e.preventDefault()}>
+                                            <Magnet class="h-3.5 w-3.5 text-amber-400" />
+                                            Torrent
+                                        </DropdownMenu.CheckboxItem>
+                                        <DropdownMenu.CheckboxItem
+                                            bind:checked={providerFilter.usenet}
+                                            onSelect={(e) => e.preventDefault()}>
+                                            <Newspaper class="h-3.5 w-3.5 text-sky-400" />
+                                            Usenet
+                                        </DropdownMenu.CheckboxItem>
+                                    </DropdownMenu.Content>
+                                </DropdownMenu.Root>
+                            </div>
                         {/if}
 
                         {#if !visibleStreams.length}
@@ -724,6 +774,8 @@
                                     Waiting for backend results...
                                 {:else if streams.length && searchQuery.trim()}
                                     No streams matched "{searchQuery.trim()}".
+                                {:else if streams.length && disabledProviderCount > 0}
+                                    No streams matched the current provider filter.
                                 {:else if streams.length && cachedOnly}
                                     No cached streams matched the current filter.
                                 {:else}

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -328,7 +328,10 @@
     /** Uploads a raw .nzb file and, on success, drops the resulting (loopback)
      * URL straight into `nzbUrl` — everything downstream (validation, the
      * download button, the mutation itself) is exactly what pasting a URL
-     * already drives, with no separate upload-specific download path. */
+     * already drives, with no separate upload-specific download path. Once
+     * uploaded, the URL is already known-good — straight into
+     * `previewManualNzb` rather than making the user click a second,
+     * redundant "add it" button for a file they just picked. */
     async function uploadNzbFile(file: File) {
         uploadingNzb = true;
         error = null;
@@ -351,9 +354,12 @@
         } catch (e) {
             error = e instanceof Error ? e.message : "Failed to upload NZB file";
             toast.error(error);
+            return;
         } finally {
             uploadingNzb = false;
         }
+
+        await previewManualNzb();
     }
 
     function handleNzbFileSelected(e: Event) {

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -586,7 +586,6 @@
                             <div class="mt-4 flex justify-end gap-2">
                                 {#if cleanedHash}
                                     <Button
-                                        variant="outline"
                                         onclick={downloadExplicitHash}
                                         disabled={downloadingKey !== null}>
                                         {#if downloadingKey === `manual:${cleanedHash}`}<LoaderCircle
@@ -596,7 +595,6 @@
                                 {/if}
                                 {#if cleanedNzbUrl}
                                     <Button
-                                        variant="outline"
                                         onclick={downloadNzbUrl}
                                         disabled={downloadingKey !== null}>
                                         {#if downloadingKey === `manual-nzb:${cleanedNzbUrl}`}<LoaderCircle

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -86,6 +86,10 @@
         downloadDiscoveredStream(itemType: $itemType, title: $title, imdbId: $imdbId, tmdbId: $tmdbId, tvdbId: $tvdbId, seasonNumber: $seasonNumber, episodeNumber: $episodeNumber, seasons: $seasons, infoHash: $infoHash, magnet: $magnet, parsedData: $parsedData, rank: $rank)
     }`;
 
+    const DOWNLOAD_EXPLICIT_NZB_MUTATION = `mutation($itemType: MediaItemType!, $title: String!, $imdbId: String, $tmdbId: String, $tvdbId: String, $seasonNumber: Int, $episodeNumber: Int, $seasons: [Int!], $nzbUrl: String!) {
+        downloadExplicitNzb(itemType: $itemType, title: $title, imdbId: $imdbId, tmdbId: $tmdbId, tvdbId: $tvdbId, seasonNumber: $seasonNumber, episodeNumber: $episodeNumber, seasons: $seasons, nzbUrl: $nzbUrl)
+    }`;
+
     let {
         title,
         itemId,
@@ -109,6 +113,8 @@
     let customTmdbId = $state("");
     let customTvdbId = $state("");
     let explicitHash = $state("");
+    let nzbUrl = $state("");
+    let searchQuery = $state("");
     let streams = $state<StreamCandidate[]>([]);
     let downloadingKey = $state<string | null>(null);
 
@@ -117,7 +123,12 @@
         mediaType === "tv" && seasons.length > 0 && !isEpisodeMode
     );
     const visibleStreams = $derived(
-        cachedOnly ? streams.filter((stream) => stream.isCached) : streams
+        (() => {
+            const query = searchQuery.trim().toLowerCase();
+            return streams
+                .filter((stream) => !cachedOnly || stream.isCached)
+                .filter((stream) => !query || stream.title.toLowerCase().includes(query));
+        })()
     );
     const resolvedTmdbId = $derived(
         mediaType === "movie" ? (clean(customTmdbId) ?? externalId) : null
@@ -136,6 +147,13 @@
             if (/^[0-9a-fA-F]{40}$/.test(trimmed) || /^[0-9a-fA-F]{64}$/.test(trimmed))
                 return trimmed.toLowerCase();
             return null;
+        })()
+    );
+    const cleanedNzbUrl = $derived(
+        (() => {
+            const trimmed = nzbUrl.trim();
+            if (!trimmed) return null;
+            return /^https?:\/\//i.test(trimmed) ? trimmed : null;
         })()
     );
     const hadExistingItem = $derived(Boolean(itemId));
@@ -170,6 +188,8 @@
         customTmdbId = "";
         customTvdbId = "";
         explicitHash = "";
+        nzbUrl = "";
+        searchQuery = "";
         advancedOpen = false;
         selectedSeasons = seasons
             .filter((season) => season.status !== "Available")
@@ -177,40 +197,14 @@
             .sort((a, b) => a - b);
     }
 
-    async function submitDownload(
-        key: string,
-        vars: {
-            itemType: "MOVIE" | "SEASON" | "EPISODE";
-            seasonNumber: number | null;
-            episodeNumber?: number | null;
-            seasons?: number[] | null;
-            infoHash: string;
-            magnet: string;
-            parsedData?: StreamCandidate["parsedData"];
-            rank?: number | null;
-        }
-    ) {
+    /** Shared by every mutation this dialog can fire: track the in-flight key,
+     * surface errors, and on success close the dialog and refresh the page. */
+    async function runDownload(key: string, mutation: string, variables: Record<string, unknown>) {
         downloadingKey = key;
         error = null;
 
         try {
-            await gqlClient<{ downloadDiscoveredStream: string }>(
-                DOWNLOAD_DISCOVERED_STREAM_MUTATION,
-                {
-                    itemType: vars.itemType,
-                    title: title ?? "Unknown",
-                    imdbId: null,
-                    tmdbId: resolvedTmdbId,
-                    tvdbId: resolvedTvdbId,
-                    seasonNumber: vars.seasonNumber,
-                    episodeNumber: vars.episodeNumber ?? null,
-                    seasons: vars.seasons ?? null,
-                    infoHash: vars.infoHash,
-                    magnet: vars.magnet,
-                    parsedData: vars.parsedData ?? null,
-                    rank: vars.rank ?? null
-                }
-            );
+            await gqlClient(mutation, variables);
 
             toast.success(
                 hadExistingItem
@@ -225,6 +219,35 @@
         } finally {
             downloadingKey = null;
         }
+    }
+
+    function submitDownload(
+        key: string,
+        vars: {
+            itemType: "MOVIE" | "SEASON" | "EPISODE";
+            seasonNumber: number | null;
+            episodeNumber?: number | null;
+            seasons?: number[] | null;
+            infoHash: string;
+            magnet: string;
+            parsedData?: StreamCandidate["parsedData"];
+            rank?: number | null;
+        }
+    ) {
+        return runDownload(key, DOWNLOAD_DISCOVERED_STREAM_MUTATION, {
+            itemType: vars.itemType,
+            title: title ?? "Unknown",
+            imdbId: null,
+            tmdbId: resolvedTmdbId,
+            tvdbId: resolvedTvdbId,
+            seasonNumber: vars.seasonNumber,
+            episodeNumber: vars.episodeNumber ?? null,
+            seasons: vars.seasons ?? null,
+            infoHash: vars.infoHash,
+            magnet: vars.magnet,
+            parsedData: vars.parsedData ?? null,
+            rank: vars.rank ?? null
+        });
     }
 
     async function discoverStreams() {
@@ -316,6 +339,53 @@
             infoHash: cleanedHash,
             magnet: `magnet:?xt=urn:btih:${cleanedHash}`,
             parsedData: null
+        });
+    }
+
+    function downloadNzbUrl() {
+        if (!cleanedNzbUrl) {
+            error = "Enter a valid NZB URL (must start with http:// or https://)";
+            toast.error(error);
+            return;
+        }
+
+        const key = `manual-nzb:${cleanedNzbUrl}`;
+
+        if (isEpisodeMode) {
+            if (seasonNumber == null) {
+                error = "No season number available for this episode";
+                toast.error(error);
+                return;
+            }
+            return runDownload(key, DOWNLOAD_EXPLICIT_NZB_MUTATION, {
+                itemType: "EPISODE",
+                title: title ?? "Unknown",
+                imdbId: null,
+                tmdbId: resolvedTmdbId,
+                tvdbId: resolvedTvdbId,
+                seasonNumber,
+                episodeNumber,
+                seasons: null,
+                nzbUrl: cleanedNzbUrl
+            });
+        }
+
+        if (mediaType === "tv" && selectedSeasons.length === 0) {
+            error = "Select at least one season before downloading an NZB";
+            toast.error(error);
+            return;
+        }
+
+        return runDownload(key, DOWNLOAD_EXPLICIT_NZB_MUTATION, {
+            itemType: mediaType === "movie" ? "MOVIE" : "SEASON",
+            title: title ?? "Unknown",
+            imdbId: null,
+            tmdbId: resolvedTmdbId,
+            tvdbId: resolvedTvdbId,
+            seasonNumber: mediaType === "tv" ? selectedSeasons[0] : null,
+            episodeNumber: null,
+            seasons: mediaType === "tv" ? selectedSeasons : null,
+            nzbUrl: cleanedNzbUrl
         });
     }
 
@@ -423,8 +493,8 @@
                         {/if}
 
                         {#if advancedOpen}
-                            <div class="mt-4 grid gap-3 md:grid-cols-2">
-                                <div class="space-y-2">
+                            <div class="mt-4">
+                                <div class="max-w-xs space-y-2">
                                     <Label
                                         >{mediaType === "movie"
                                             ? "Custom TMDB ID"
@@ -435,26 +505,56 @@
                                             bind:value={customTvdbId}
                                             placeholder={externalId} />{/if}
                                 </div>
-                                <div class="space-y-2">
-                                    <Label>Explicit Stream Hash</Label>
-                                    <Input
-                                        bind:value={explicitHash}
-                                        placeholder="40-char info hash" />
-                                </div>
                             </div>
                         {/if}
-                        {#if cleanedHash}
-                            <div class="mt-4 flex justify-end">
-                                <Button
-                                    variant="outline"
-                                    onclick={downloadExplicitHash}
-                                    disabled={downloadingKey !== null}>
-                                    {#if downloadingKey === `manual:${cleanedHash}`}<LoaderCircle
-                                            class="mr-2 h-4 w-4 animate-spin" />{/if}
-                                    Download Explicit Hash
-                                </Button>
+                    </div>
+
+                    <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                        <p class="mb-3 text-sm font-semibold text-white">Add a specific release</p>
+                        <p class="mb-4 text-xs text-zinc-400">
+                            Already know what you want? Paste a magnet link/hash or an NZB URL to
+                            queue it directly, skipping discovery entirely.
+                        </p>
+                        <div class="grid gap-4 md:grid-cols-2">
+                            <div class="space-y-2">
+                                <Label class="flex items-center gap-1.5">
+                                    <Magnet class="h-3.5 w-3.5" />
+                                    Magnet link or info hash
+                                </Label>
+                                <Input
+                                    bind:value={explicitHash}
+                                    placeholder="magnet:?xt=urn:btih:... or 40-char hash" />
+                                {#if cleanedHash}
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onclick={downloadExplicitHash}
+                                        disabled={downloadingKey !== null}>
+                                        {#if downloadingKey === `manual:${cleanedHash}`}<LoaderCircle
+                                                class="mr-2 h-4 w-4 animate-spin" />{/if}
+                                        Download This Magnet
+                                    </Button>
+                                {/if}
                             </div>
-                        {/if}
+                            <div class="space-y-2">
+                                <Label class="flex items-center gap-1.5">
+                                    <Newspaper class="h-3.5 w-3.5" />
+                                    NZB URL
+                                </Label>
+                                <Input bind:value={nzbUrl} placeholder="https://.../release.nzb" />
+                                {#if cleanedNzbUrl}
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onclick={downloadNzbUrl}
+                                        disabled={downloadingKey !== null}>
+                                        {#if downloadingKey === `manual-nzb:${cleanedNzbUrl}`}<LoaderCircle
+                                                class="mr-2 h-4 w-4 animate-spin" />{/if}
+                                        Download This NZB
+                                    </Button>
+                                {/if}
+                            </div>
+                        </div>
                     </div>
 
                     <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
@@ -468,12 +568,21 @@
                             <Badge variant="outline">{visibleStreams.length} found</Badge>
                         </div>
 
+                        {#if streams.length}
+                            <Input
+                                class="mb-4"
+                                bind:value={searchQuery}
+                                placeholder="Filter by title, release group, resolution..." />
+                        {/if}
+
                         {#if !visibleStreams.length}
                             <div
                                 class="rounded-xl border border-dashed border-white/15 px-6 py-12 text-center text-sm text-zinc-400">
                                 {#if loading}
                                     <LoaderCircle class="mx-auto mb-3 h-5 w-5 animate-spin" />
                                     Waiting for backend results...
+                                {:else if streams.length && searchQuery.trim()}
+                                    No streams matched "{searchQuery.trim()}".
                                 {:else if streams.length && cachedOnly}
                                     No cached streams matched the current filter.
                                 {:else}

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -114,6 +114,8 @@
     let customTvdbId = $state("");
     let explicitHash = $state("");
     let nzbUrl = $state("");
+    let uploadingNzb = $state(false);
+    let nzbFileInput = $state<HTMLInputElement | undefined>(undefined);
     let searchQuery = $state("");
     let streams = $state<StreamCandidate[]>([]);
     let downloadingKey = $state<string | null>(null);
@@ -189,6 +191,7 @@
         customTvdbId = "";
         explicitHash = "";
         nzbUrl = "";
+        uploadingNzb = false;
         searchQuery = "";
         advancedOpen = false;
         selectedSeasons = seasons
@@ -281,6 +284,44 @@
         } finally {
             loading = false;
         }
+    }
+
+    /** Uploads a raw .nzb file and, on success, drops the resulting (loopback)
+     * URL straight into `nzbUrl` — everything downstream (validation, the
+     * download button, the mutation itself) is exactly what pasting a URL
+     * already drives, with no separate upload-specific download path. */
+    async function uploadNzbFile(file: File) {
+        uploadingNzb = true;
+        error = null;
+
+        try {
+            const formData = new FormData();
+            formData.append("file", file);
+            const response = await fetch("/internal/nzb-upload", {
+                method: "POST",
+                credentials: "include",
+                body: formData
+            });
+            if (!response.ok) {
+                const message = await response.text();
+                throw new Error(message || `Upload failed (${response.status})`);
+            }
+            const data: { url: string } = await response.json();
+            nzbUrl = data.url;
+            toast.success(`${file.name} uploaded`);
+        } catch (e) {
+            error = e instanceof Error ? e.message : "Failed to upload NZB file";
+            toast.error(error);
+        } finally {
+            uploadingNzb = false;
+        }
+    }
+
+    function handleNzbFileSelected(e: Event) {
+        const file = (e.target as HTMLInputElement).files?.[0];
+        if (file) uploadNzbFile(file);
+        // Cleared so selecting the same file again still fires `change`.
+        if (nzbFileInput) nzbFileInput.value = "";
     }
 
     function downloadStream(stream: StreamCandidate) {
@@ -522,6 +563,24 @@
                                     <Input
                                         bind:value={nzbUrl}
                                         placeholder="https://.../release.nzb" />
+                                    <input
+                                        bind:this={nzbFileInput}
+                                        type="file"
+                                        accept=".nzb,application/x-nzb,text/xml"
+                                        class="hidden"
+                                        onchange={handleNzbFileSelected} />
+                                    <button
+                                        type="button"
+                                        class="inline-flex w-fit items-center gap-1.5 rounded-full border border-white/10 px-2.5 py-1 text-xs text-zinc-400 transition hover:border-white/20 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-50"
+                                        disabled={uploadingNzb}
+                                        onclick={() => nzbFileInput?.click()}>
+                                        {#if uploadingNzb}
+                                            <LoaderCircle class="h-3 w-3 animate-spin" />
+                                            Uploading...
+                                        {:else}
+                                            Upload .nzb file instead
+                                        {/if}
+                                    </button>
                                 </div>
                             </div>
                         {/if}

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -554,6 +554,16 @@
                                     <Input
                                         bind:value={explicitHash}
                                         placeholder="magnet:?xt=urn:btih:... or 40-char hash" />
+                                    {#if cleanedHash}
+                                        <Button
+                                            size="sm"
+                                            onclick={downloadExplicitHash}
+                                            disabled={downloadingKey !== null}>
+                                            {#if downloadingKey === `manual:${cleanedHash}`}<LoaderCircle
+                                                    class="mr-2 h-4 w-4 animate-spin" />{/if}
+                                            Download Explicit Hash
+                                        </Button>
+                                    {/if}
                                 </div>
                                 <div class="space-y-2">
                                     <Label class="flex items-center gap-1.5">
@@ -563,45 +573,36 @@
                                     <Input
                                         bind:value={nzbUrl}
                                         placeholder="https://.../release.nzb" />
+                                    <p class="text-center text-[0.65rem] text-zinc-500">or</p>
                                     <input
                                         bind:this={nzbFileInput}
                                         type="file"
                                         accept=".nzb,application/x-nzb,text/xml"
                                         class="hidden"
                                         onchange={handleNzbFileSelected} />
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        disabled={uploadingNzb}
-                                        onclick={() => nzbFileInput?.click()}>
-                                        {#if uploadingNzb}
-                                            <LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
+                                    <div class="flex flex-wrap gap-2">
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            disabled={uploadingNzb}
+                                            onclick={() => nzbFileInput?.click()}>
+                                            {#if uploadingNzb}
+                                                <LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
+                                            {/if}
+                                            Upload NZB file
+                                        </Button>
+                                        {#if cleanedNzbUrl}
+                                            <Button
+                                                size="sm"
+                                                onclick={downloadNzbUrl}
+                                                disabled={downloadingKey !== null}>
+                                                {#if downloadingKey === `manual-nzb:${cleanedNzbUrl}`}<LoaderCircle
+                                                        class="mr-2 h-4 w-4 animate-spin" />{/if}
+                                                Download NZB
+                                            </Button>
                                         {/if}
-                                        Upload .nzb file instead
-                                    </Button>
+                                    </div>
                                 </div>
-                            </div>
-                        {/if}
-                        {#if cleanedHash || cleanedNzbUrl}
-                            <div class="mt-4 flex justify-end gap-2">
-                                {#if cleanedHash}
-                                    <Button
-                                        onclick={downloadExplicitHash}
-                                        disabled={downloadingKey !== null}>
-                                        {#if downloadingKey === `manual:${cleanedHash}`}<LoaderCircle
-                                                class="mr-2 h-4 w-4 animate-spin" />{/if}
-                                        Download Explicit Hash
-                                    </Button>
-                                {/if}
-                                {#if cleanedNzbUrl}
-                                    <Button
-                                        onclick={downloadNzbUrl}
-                                        disabled={downloadingKey !== null}>
-                                        {#if downloadingKey === `manual-nzb:${cleanedNzbUrl}`}<LoaderCircle
-                                                class="mr-2 h-4 w-4 animate-spin" />{/if}
-                                        Download NZB
-                                    </Button>
-                                {/if}
                             </div>
                         {/if}
                     </div>

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -159,12 +159,14 @@
     let nzbFileInput = $state<HTMLInputElement | undefined>(undefined);
     let searchQuery = $state("");
     let providerFilter = $state({ torrent: true, usenet: true });
-    // Empty set = no restriction (show everything) — same convention as the
-    // search box being empty. Populated with whatever distinct values are
-    // actually present in `streams`, so this never offers a resolution/
-    // quality nobody actually has.
-    const resolutionFilter = new SvelteSet<string>();
-    const qualityFilter = new SvelteSet<string>();
+    // Every checkbox in the Filter dropdown starts checked (nothing
+    // excluded) — tracking *excluded* values rather than *included* ones is
+    // what makes that true by construction, with no sync step needed: a
+    // resolution/quality that doesn't exist yet (a stream not previewed/
+    // discovered yet) is, by definition, not in this set, so it starts
+    // included the moment it appears.
+    const excludedResolutions = new SvelteSet<string>();
+    const excludedQualities = new SvelteSet<string>();
     let streams = $state<StreamCandidate[]>([]);
     let downloadingKey = $state<string | null>(null);
 
@@ -183,14 +185,13 @@
                 )
                 .filter(
                     (stream) =>
-                        resolutionFilter.size === 0 ||
-                        (stream.parsedData?.resolution &&
-                            resolutionFilter.has(stream.parsedData.resolution))
+                        !stream.parsedData?.resolution ||
+                        !excludedResolutions.has(stream.parsedData.resolution)
                 )
                 .filter(
                     (stream) =>
-                        qualityFilter.size === 0 ||
-                        (stream.parsedData?.quality && qualityFilter.has(stream.parsedData.quality))
+                        !stream.parsedData?.quality ||
+                        !excludedQualities.has(stream.parsedData.quality)
                 );
         })()
     );
@@ -198,7 +199,7 @@
         (providerFilter.torrent ? 0 : 1) + (providerFilter.usenet ? 0 : 1)
     );
     const activeFilterCount = $derived(
-        disabledProviderCount + resolutionFilter.size + qualityFilter.size
+        disabledProviderCount + excludedResolutions.size + excludedQualities.size
     );
     const availableResolutions = $derived(
         Array.from(
@@ -275,8 +276,8 @@
      * reflects exactly what it's about to clear. */
     function resetFilters() {
         providerFilter = { torrent: true, usenet: true };
-        resolutionFilter.clear();
-        qualityFilter.clear();
+        excludedResolutions.clear();
+        excludedQualities.clear();
     }
 
     function reset() {
@@ -824,11 +825,11 @@
                                             <DropdownMenu.Label>Resolution</DropdownMenu.Label>
                                             {#each availableResolutions as resolution (resolution)}
                                                 <DropdownMenu.CheckboxItem
-                                                    checked={resolutionFilter.has(resolution)}
+                                                    checked={!excludedResolutions.has(resolution)}
                                                     onCheckedChange={(checked) =>
                                                         checked
-                                                            ? resolutionFilter.add(resolution)
-                                                            : resolutionFilter.delete(resolution)}
+                                                            ? excludedResolutions.delete(resolution)
+                                                            : excludedResolutions.add(resolution)}
                                                     closeOnSelect={false}>
                                                     {resolution}
                                                 </DropdownMenu.CheckboxItem>
@@ -839,11 +840,11 @@
                                             <DropdownMenu.Label>Quality</DropdownMenu.Label>
                                             {#each availableQualities as quality (quality)}
                                                 <DropdownMenu.CheckboxItem
-                                                    checked={qualityFilter.has(quality)}
+                                                    checked={!excludedQualities.has(quality)}
                                                     onCheckedChange={(checked) =>
                                                         checked
-                                                            ? qualityFilter.add(quality)
-                                                            : qualityFilter.delete(quality)}
+                                                            ? excludedQualities.delete(quality)
+                                                            : excludedQualities.add(quality)}
                                                     closeOnSelect={false}>
                                                     {quality}
                                                 </DropdownMenu.CheckboxItem>

--- a/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
+++ b/frontend/src/lib/components/media/riven/item-manual-scrape.svelte
@@ -493,8 +493,8 @@
                         {/if}
 
                         {#if advancedOpen}
-                            <div class="mt-4">
-                                <div class="max-w-xs space-y-2">
+                            <div class="mt-4 grid gap-3 md:grid-cols-3">
+                                <div class="space-y-2">
                                     <Label
                                         >{mediaType === "movie"
                                             ? "Custom TMDB ID"
@@ -505,56 +505,50 @@
                                             bind:value={customTvdbId}
                                             placeholder={externalId} />{/if}
                                 </div>
+                                <div class="space-y-2">
+                                    <Label class="flex items-center gap-1.5">
+                                        <Magnet class="h-3.5 w-3.5" />
+                                        Magnet link or info hash
+                                    </Label>
+                                    <Input
+                                        bind:value={explicitHash}
+                                        placeholder="magnet:?xt=urn:btih:... or 40-char hash" />
+                                </div>
+                                <div class="space-y-2">
+                                    <Label class="flex items-center gap-1.5">
+                                        <Newspaper class="h-3.5 w-3.5" />
+                                        NZB URL
+                                    </Label>
+                                    <Input
+                                        bind:value={nzbUrl}
+                                        placeholder="https://.../release.nzb" />
+                                </div>
                             </div>
                         {/if}
-                    </div>
-
-                    <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
-                        <p class="mb-3 text-sm font-semibold text-white">Add a specific release</p>
-                        <p class="mb-4 text-xs text-zinc-400">
-                            Already know what you want? Paste a magnet link/hash or an NZB URL to
-                            queue it directly, skipping discovery entirely.
-                        </p>
-                        <div class="grid gap-4 md:grid-cols-2">
-                            <div class="space-y-2">
-                                <Label class="flex items-center gap-1.5">
-                                    <Magnet class="h-3.5 w-3.5" />
-                                    Magnet link or info hash
-                                </Label>
-                                <Input
-                                    bind:value={explicitHash}
-                                    placeholder="magnet:?xt=urn:btih:... or 40-char hash" />
+                        {#if cleanedHash || cleanedNzbUrl}
+                            <div class="mt-4 flex justify-end gap-2">
                                 {#if cleanedHash}
                                     <Button
-                                        size="sm"
                                         variant="outline"
                                         onclick={downloadExplicitHash}
                                         disabled={downloadingKey !== null}>
                                         {#if downloadingKey === `manual:${cleanedHash}`}<LoaderCircle
                                                 class="mr-2 h-4 w-4 animate-spin" />{/if}
-                                        Download This Magnet
+                                        Download Explicit Hash
                                     </Button>
                                 {/if}
-                            </div>
-                            <div class="space-y-2">
-                                <Label class="flex items-center gap-1.5">
-                                    <Newspaper class="h-3.5 w-3.5" />
-                                    NZB URL
-                                </Label>
-                                <Input bind:value={nzbUrl} placeholder="https://.../release.nzb" />
                                 {#if cleanedNzbUrl}
                                     <Button
-                                        size="sm"
                                         variant="outline"
                                         onclick={downloadNzbUrl}
                                         disabled={downloadingKey !== null}>
                                         {#if downloadingKey === `manual-nzb:${cleanedNzbUrl}`}<LoaderCircle
                                                 class="mr-2 h-4 w-4 animate-spin" />{/if}
-                                        Download This NZB
+                                        Download NZB
                                     </Button>
                                 {/if}
                             </div>
-                        </div>
+                        {/if}
                     </div>
 
                     <div class="rounded-2xl border border-white/10 bg-white/5 p-4">

--- a/frontend/src/lib/gql/schema.ts
+++ b/frontend/src/lib/gql/schema.ts
@@ -226,6 +226,13 @@ export type Episode = {
   lastScrapeAttemptAt?: Maybe<Scalars['DateTime']['output']>;
   /** Lookup keys: `["abs:{absoluteNumber}", "{seasonNumber}:{episodeNumber}"]`. */
   lookupKeys: Array<Scalars['String']['output']>;
+  /**
+   * Set once a Manual Scrape (a picked discovery result, a pasted
+   * magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+   * `get_pending_items_for_retry`'s automatic re-scrape loop, since the
+   * user has already made the pick that loop exists to make on its own.
+   */
+  manualScrapeOnly: Scalars['Boolean']['output'];
   network?: Maybe<Scalars['String']['output']>;
   networkTimezone?: Maybe<Scalars['String']['output']>;
   parentId?: Maybe<Scalars['Int']['output']>;
@@ -283,6 +290,13 @@ export type EpisodeFull = {
   itemType: MediaItemType;
   language?: Maybe<Scalars['String']['output']>;
   lastScrapeAttemptAt?: Maybe<Scalars['DateTime']['output']>;
+  /**
+   * Set once a Manual Scrape (a picked discovery result, a pasted
+   * magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+   * `get_pending_items_for_retry`'s automatic re-scrape loop, since the
+   * user has already made the pick that loop exists to make on its own.
+   */
+  manualScrapeOnly: Scalars['Boolean']['output'];
   network?: Maybe<Scalars['String']['output']>;
   networkTimezone?: Maybe<Scalars['String']['output']>;
   parentId?: Maybe<Scalars['Int']['output']>;
@@ -634,6 +648,13 @@ export type MediaItem = {
   itemType: MediaItemType;
   language?: Maybe<Scalars['String']['output']>;
   lastScrapeAttemptAt?: Maybe<Scalars['DateTime']['output']>;
+  /**
+   * Set once a Manual Scrape (a picked discovery result, a pasted
+   * magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+   * `get_pending_items_for_retry`'s automatic re-scrape loop, since the
+   * user has already made the pick that loop exists to make on its own.
+   */
+  manualScrapeOnly: Scalars['Boolean']['output'];
   network?: Maybe<Scalars['String']['output']>;
   networkTimezone?: Maybe<Scalars['String']['output']>;
   parentId?: Maybe<Scalars['Int']['output']>;
@@ -683,6 +704,13 @@ export type MediaItemFull = {
   itemType: MediaItemType;
   language?: Maybe<Scalars['String']['output']>;
   lastScrapeAttemptAt?: Maybe<Scalars['DateTime']['output']>;
+  /**
+   * Set once a Manual Scrape (a picked discovery result, a pasted
+   * magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+   * `get_pending_items_for_retry`'s automatic re-scrape loop, since the
+   * user has already made the pick that loop exists to make on its own.
+   */
+  manualScrapeOnly: Scalars['Boolean']['output'];
   network?: Maybe<Scalars['String']['output']>;
   networkTimezone?: Maybe<Scalars['String']['output']>;
   parentId?: Maybe<Scalars['Int']['output']>;
@@ -730,6 +758,13 @@ export type MediaItemListRow = {
   itemType: MediaItemType;
   language?: Maybe<Scalars['String']['output']>;
   lastScrapeAttemptAt?: Maybe<Scalars['DateTime']['output']>;
+  /**
+   * Set once a Manual Scrape (a picked discovery result, a pasted
+   * magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+   * `get_pending_items_for_retry`'s automatic re-scrape loop, since the
+   * user has already made the pick that loop exists to make on its own.
+   */
+  manualScrapeOnly: Scalars['Boolean']['output'];
   network?: Maybe<Scalars['String']['output']>;
   networkTimezone?: Maybe<Scalars['String']['output']>;
   parentId?: Maybe<Scalars['Int']['output']>;
@@ -861,6 +896,13 @@ export type Movie = {
   itemType: MediaItemType;
   language?: Maybe<Scalars['String']['output']>;
   lastScrapeAttemptAt?: Maybe<Scalars['DateTime']['output']>;
+  /**
+   * Set once a Manual Scrape (a picked discovery result, a pasted
+   * magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+   * `get_pending_items_for_retry`'s automatic re-scrape loop, since the
+   * user has already made the pick that loop exists to make on its own.
+   */
+  manualScrapeOnly: Scalars['Boolean']['output'];
   network?: Maybe<Scalars['String']['output']>;
   networkTimezone?: Maybe<Scalars['String']['output']>;
   parentId?: Maybe<Scalars['Int']['output']>;
@@ -948,6 +990,19 @@ export type MutationRoot = {
    * flow can fill every season it contains.
    */
   downloadDiscoveredStream: Scalars['String']['output'];
+  /**
+   * Manually queue a specific NZB by URL, bypassing indexer search entirely
+   * — the usenet equivalent of [`download_discovered_stream`]'s explicit
+   * magnet/hash field. The URL is hashed into the same `nzb-`-prefixed
+   * `info_hash` a real newznab scrape would produce and stashed in Redis
+   * under the same keys ([`nzb_url_redis_key`]), so `plugin-usenet`'s
+   * download-time fetch can't tell the difference from a scraped result.
+   *
+   * TV has no parsed release metadata to infer seasons from here (there was
+   * no scrape), so the caller must supply `season_number`/`episode_number`
+   * or `seasons` explicitly.
+   */
+  downloadExplicitNzb: Scalars['String']['output'];
   downloadMediaItem: DownloadMediaItemMutationResponse;
   /**
    * Persist indexer data for a movie and advance it to the scraping stage.
@@ -1132,6 +1187,19 @@ export type MutationRootDownloadDiscoveredStreamArgs = {
   magnet: Scalars['String']['input'];
   parsedData?: InputMaybe<Scalars['JSON']['input']>;
   rank?: InputMaybe<Scalars['Int']['input']>;
+  seasonNumber?: InputMaybe<Scalars['Int']['input']>;
+  seasons?: InputMaybe<Array<Scalars['Int']['input']>>;
+  title: Scalars['String']['input'];
+  tmdbId?: InputMaybe<Scalars['String']['input']>;
+  tvdbId?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type MutationRootDownloadExplicitNzbArgs = {
+  episodeNumber?: InputMaybe<Scalars['Int']['input']>;
+  imdbId?: InputMaybe<Scalars['String']['input']>;
+  itemType: MediaItemType;
+  nzbUrl: Scalars['String']['input'];
   seasonNumber?: InputMaybe<Scalars['Int']['input']>;
   seasons?: InputMaybe<Array<Scalars['Int']['input']>>;
   title: Scalars['String']['input'];
@@ -1847,6 +1915,13 @@ export type Season = {
   itemType: MediaItemType;
   language?: Maybe<Scalars['String']['output']>;
   lastScrapeAttemptAt?: Maybe<Scalars['DateTime']['output']>;
+  /**
+   * Set once a Manual Scrape (a picked discovery result, a pasted
+   * magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+   * `get_pending_items_for_retry`'s automatic re-scrape loop, since the
+   * user has already made the pick that loop exists to make on its own.
+   */
+  manualScrapeOnly: Scalars['Boolean']['output'];
   network?: Maybe<Scalars['String']['output']>;
   networkTimezone?: Maybe<Scalars['String']['output']>;
   parentId?: Maybe<Scalars['Int']['output']>;
@@ -1905,6 +1980,13 @@ export type SeasonFull = {
   itemType: MediaItemType;
   language?: Maybe<Scalars['String']['output']>;
   lastScrapeAttemptAt?: Maybe<Scalars['DateTime']['output']>;
+  /**
+   * Set once a Manual Scrape (a picked discovery result, a pasted
+   * magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+   * `get_pending_items_for_retry`'s automatic re-scrape loop, since the
+   * user has already made the pick that loop exists to make on its own.
+   */
+  manualScrapeOnly: Scalars['Boolean']['output'];
   network?: Maybe<Scalars['String']['output']>;
   networkTimezone?: Maybe<Scalars['String']['output']>;
   parentId?: Maybe<Scalars['Int']['output']>;
@@ -2007,6 +2089,13 @@ export type Show = {
   itemType: MediaItemType;
   language?: Maybe<Scalars['String']['output']>;
   lastScrapeAttemptAt?: Maybe<Scalars['DateTime']['output']>;
+  /**
+   * Set once a Manual Scrape (a picked discovery result, a pasted
+   * magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+   * `get_pending_items_for_retry`'s automatic re-scrape loop, since the
+   * user has already made the pick that loop exists to make on its own.
+   */
+  manualScrapeOnly: Scalars['Boolean']['output'];
   network?: Maybe<Scalars['String']['output']>;
   networkTimezone?: Maybe<Scalars['String']['output']>;
   parentId?: Maybe<Scalars['Int']['output']>;

--- a/frontend/src/lib/gql/schema.ts
+++ b/frontend/src/lib/gql/schema.ts
@@ -1022,6 +1022,28 @@ export type MutationRoot = {
   /** Pause items. */
   pauseItems: Scalars['Int']['output'];
   /**
+   * Turns a manually-pasted magnet link/hash into a full [`DiscoveredStream`]
+   * card — same shape, same badges as a real scrape result — instead of
+   * downloading it sight-unseen. Parses whatever the magnet's own `dn=`
+   * carries through [`riven_rank::parse`] (the exact parser real scrape
+   * results go through) for resolution/quality/audio/etc., and checks
+   * debrid cache status via the same dispatch [`discover_streams`] uses.
+   * Creates or mutates nothing — the pick only becomes real when the
+   * resulting card's "Download This" calls `downloadDiscoveredStream`,
+   * same as any other result in the list.
+   */
+  previewManualMagnet: DiscoveredStream;
+  /**
+   * The NZB equivalent of [`preview_manual_magnet`]: fetches the URL
+   * (whether pasted directly or handed back by the upload endpoint),
+   * peeks its release title the same way `plugin-usenet` does at ingest
+   * time, and parses that through [`riven_rank::parse`]. Usenet has no
+   * debrid-style cache concept — every `nzb-` hash is unconditionally
+   * "cached" here, matching `plugin-usenet`'s own cache-check response.
+   * Nothing is persisted; the fetched content is discarded once peeked.
+   */
+  previewManualNzb: DiscoveredStream;
+  /**
    * Re-acquire a usenet title whose release is broken (missing data) or was
    * never ingested. The item is "completed" only because it still has a
    * media filesystem entry, so reset alone bounces back to completed; we
@@ -1225,6 +1247,23 @@ export type MutationRootIndexShowArgs = {
 
 export type MutationRootPauseItemsArgs = {
   ids: Array<Scalars['Int']['input']>;
+};
+
+
+export type MutationRootPreviewManualMagnetArgs = {
+  episodeNumber?: InputMaybe<Scalars['Int']['input']>;
+  infoHash: Scalars['String']['input'];
+  itemType: MediaItemType;
+  magnet: Scalars['String']['input'];
+  seasonNumber?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type MutationRootPreviewManualNzbArgs = {
+  episodeNumber?: InputMaybe<Scalars['Int']['input']>;
+  itemType: MediaItemType;
+  nzbUrl: Scalars['String']['input'];
+  seasonNumber?: InputMaybe<Scalars['Int']['input']>;
 };
 
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1187,6 +1187,28 @@ type MutationRoot {
 	"""
 	downloadExplicitNzb(itemType: MediaItemType!, title: String!, imdbId: String, tmdbId: String, tvdbId: String, seasonNumber: Int, episodeNumber: Int, seasons: [Int!], nzbUrl: String!): String!
 	"""
+	Turns a manually-pasted magnet link/hash into a full [`DiscoveredStream`]
+	card — same shape, same badges as a real scrape result — instead of
+	downloading it sight-unseen. Parses whatever the magnet's own `dn=`
+	carries through [`riven_rank::parse`] (the exact parser real scrape
+	results go through) for resolution/quality/audio/etc., and checks
+	debrid cache status via the same dispatch [`discover_streams`] uses.
+	Creates or mutates nothing — the pick only becomes real when the
+	resulting card's "Download This" calls `downloadDiscoveredStream`,
+	same as any other result in the list.
+	"""
+	previewManualMagnet(itemType: MediaItemType!, infoHash: String!, magnet: String!, seasonNumber: Int, episodeNumber: Int): DiscoveredStream!
+	"""
+	The NZB equivalent of [`preview_manual_magnet`]: fetches the URL
+	(whether pasted directly or handed back by the upload endpoint),
+	peeks its release title the same way `plugin-usenet` does at ingest
+	time, and parses that through [`riven_rank::parse`]. Usenet has no
+	debrid-style cache concept — every `nzb-` hash is unconditionally
+	"cached" here, matching `plugin-usenet`'s own cache-check response.
+	Nothing is persisted; the fetched content is discarded once peeked.
+	"""
+	previewManualNzb(itemType: MediaItemType!, nzbUrl: String!, seasonNumber: Int, episodeNumber: Int): DiscoveredStream!
+	"""
 	Re-acquire a usenet title whose release is broken (missing data) or was
 	never ingested. The item is "completed" only because it still has a
 	media filesystem entry, so reset alone bounces back to completed; we

--- a/schema.graphql
+++ b/schema.graphql
@@ -230,6 +230,13 @@ type Episode {
 	airedAtUtc: DateTime
 	lastScrapeAttemptAt: DateTime
 	"""
+	Set once a Manual Scrape (a picked discovery result, a pasted
+	magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+	`get_pending_items_for_retry`'s automatic re-scrape loop, since the
+	user has already made the pick that loop exists to make on its own.
+	"""
+	manualScrapeOnly: Boolean!
+	"""
 	Absolute artwork URL. The column holds a bare path for anything indexed
 	before the plugins normalised what they wrote, so it is resolved here
 	rather than in each client.
@@ -291,6 +298,13 @@ type EpisodeFull {
 	networkTimezone: String
 	airedAtUtc: DateTime
 	lastScrapeAttemptAt: DateTime
+	"""
+	Set once a Manual Scrape (a picked discovery result, a pasted
+	magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+	`get_pending_items_for_retry`'s automatic re-scrape loop, since the
+	user has already made the pick that loop exists to make on its own.
+	"""
+	manualScrapeOnly: Boolean!
 	"""
 	Absolute artwork URL. The column holds a bare path for anything indexed
 	before the plugins normalised what they wrote, so it is resolved here
@@ -691,6 +705,13 @@ type MediaItem {
 	airedAtUtc: DateTime
 	lastScrapeAttemptAt: DateTime
 	"""
+	Set once a Manual Scrape (a picked discovery result, a pasted
+	magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+	`get_pending_items_for_retry`'s automatic re-scrape loop, since the
+	user has already made the pick that loop exists to make on its own.
+	"""
+	manualScrapeOnly: Boolean!
+	"""
 	Absolute artwork URL. The column holds a bare path for anything indexed
 	before the plugins normalised what they wrote, so it is resolved here
 	rather than in each client.
@@ -740,6 +761,13 @@ type MediaItemFull {
 	airedAtUtc: DateTime
 	lastScrapeAttemptAt: DateTime
 	"""
+	Set once a Manual Scrape (a picked discovery result, a pasted
+	magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+	`get_pending_items_for_retry`'s automatic re-scrape loop, since the
+	user has already made the pick that loop exists to make on its own.
+	"""
+	manualScrapeOnly: Boolean!
+	"""
 	Absolute artwork URL. The column holds a bare path for anything indexed
 	before the plugins normalised what they wrote, so it is resolved here
 	rather than in each client.
@@ -788,6 +816,13 @@ type MediaItemListRow {
 	networkTimezone: String
 	airedAtUtc: DateTime
 	lastScrapeAttemptAt: DateTime
+	"""
+	Set once a Manual Scrape (a picked discovery result, a pasted
+	magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+	`get_pending_items_for_retry`'s automatic re-scrape loop, since the
+	user has already made the pick that loop exists to make on its own.
+	"""
+	manualScrapeOnly: Boolean!
 	"""
 	Absolute artwork URL. The column holds a bare path for anything indexed
 	before the plugins normalised what they wrote, so it is resolved here
@@ -925,6 +960,13 @@ type Movie {
 	networkTimezone: String
 	airedAtUtc: DateTime
 	lastScrapeAttemptAt: DateTime
+	"""
+	Set once a Manual Scrape (a picked discovery result, a pasted
+	magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+	`get_pending_items_for_retry`'s automatic re-scrape loop, since the
+	user has already made the pick that loop exists to make on its own.
+	"""
+	manualScrapeOnly: Boolean!
 	"""
 	Absolute artwork URL. The column holds a bare path for anything indexed
 	before the plugins normalised what they wrote, so it is resolved here
@@ -1131,6 +1173,19 @@ type MutationRoot {
 	flow can fill every season it contains.
 	"""
 	downloadDiscoveredStream(itemType: MediaItemType!, title: String!, imdbId: String, tmdbId: String, tvdbId: String, seasonNumber: Int, episodeNumber: Int, seasons: [Int!], infoHash: String!, magnet: String!, parsedData: JSON, rank: Int): String!
+	"""
+	Manually queue a specific NZB by URL, bypassing indexer search entirely
+	— the usenet equivalent of [`download_discovered_stream`]'s explicit
+	magnet/hash field. The URL is hashed into the same `nzb-`-prefixed
+	`info_hash` a real newznab scrape would produce and stashed in Redis
+	under the same keys ([`nzb_url_redis_key`]), so `plugin-usenet`'s
+	download-time fetch can't tell the difference from a scraped result.
+	
+	TV has no parsed release metadata to infer seasons from here (there was
+	no scrape), so the caller must supply `season_number`/`episode_number`
+	or `seasons` explicitly.
+	"""
+	downloadExplicitNzb(itemType: MediaItemType!, title: String!, imdbId: String, tmdbId: String, tvdbId: String, seasonNumber: Int, episodeNumber: Int, seasons: [Int!], nzbUrl: String!): String!
 	"""
 	Re-acquire a usenet title whose release is broken (missing data) or was
 	never ingested. The item is "completed" only because it still has a
@@ -1592,6 +1647,13 @@ type Season {
 	airedAtUtc: DateTime
 	lastScrapeAttemptAt: DateTime
 	"""
+	Set once a Manual Scrape (a picked discovery result, a pasted
+	magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+	`get_pending_items_for_retry`'s automatic re-scrape loop, since the
+	user has already made the pick that loop exists to make on its own.
+	"""
+	manualScrapeOnly: Boolean!
+	"""
 	Absolute artwork URL. The column holds a bare path for anything indexed
 	before the plugins normalised what they wrote, so it is resolved here
 	rather than in each client.
@@ -1657,6 +1719,13 @@ type SeasonFull {
 	networkTimezone: String
 	airedAtUtc: DateTime
 	lastScrapeAttemptAt: DateTime
+	"""
+	Set once a Manual Scrape (a picked discovery result, a pasted
+	magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+	`get_pending_items_for_retry`'s automatic re-scrape loop, since the
+	user has already made the pick that loop exists to make on its own.
+	"""
+	manualScrapeOnly: Boolean!
 	"""
 	Absolute artwork URL. The column holds a bare path for anything indexed
 	before the plugins normalised what they wrote, so it is resolved here
@@ -1769,6 +1838,13 @@ type Show {
 	networkTimezone: String
 	airedAtUtc: DateTime
 	lastScrapeAttemptAt: DateTime
+	"""
+	Set once a Manual Scrape (a picked discovery result, a pasted
+	magnet/hash, or a pasted NZB URL) resolves this item. Opts it out of
+	`get_pending_items_for_retry`'s automatic re-scrape loop, since the
+	user has already made the pick that loop exists to make on its own.
+	"""
+	manualScrapeOnly: Boolean!
 	"""
 	Absolute artwork URL. The column holds a bare path for anything indexed
 	before the plugins normalised what they wrote, so it is resolved here


### PR DESCRIPTION
## Summary

Manual Scrape's magnet/hash and NZB entry points used to be a dead end: paste a hash, hit a dedicated button, and it downloads sight-unseen with no title, no resolution/quality, no cache status — a different, lesser experience than a real scrape result. This bundles a set of changes that bring manual entry up to parity with (and adds a couple of capabilities beyond) automatic discovery.

- **Magnet/hash paste** promoted out from behind an "Advanced" toggle to a first-class field, alongside a new **NZB URL** field.
- **NZB file upload**: `POST /internal/nzb-upload` (plain route, not GraphQL — see safety notes below), staged in a container-local temp dir, handed back as a loopback URL that plugs into the existing NZB flow unchanged. Auto-previews the moment upload succeeds.
- **Manual entries now populate the Stream Candidates list as full cards** instead of downloading blind: `previewManualMagnet`/`previewManualNzb` parse the release title (from the magnet's `dn=`, or peeked from the NZB itself) through the exact same `riven_rank::parse` real scrape results go through, and check cache status via the same dispatch `discoverStreams` uses. Nothing is created or mutated — the pick only becomes real when the card's own "Download This" fires, same as any other result.
- **`manual_scrape_only` flag**: an item resolved via any manual-scrape path is opted out of the automatic retry scheduler (`get_pending_items_for_retry` and the job-level cooldown retry) — a manual pick shouldn't get silently second-guessed by the next automatic scrape cycle.
- **Search + Filter** over Stream Candidates: text search, plus a Filter dropdown with Torrent/Usenet, Resolution, and Quality checkboxes (dynamically populated from whatever's actually present in the results) and a Reset button.

## Safety (NZB upload)

The upload route is the one place in the API that accepts and persists an arbitrary file body:
- Capped at 8MB via a route-scoped `DefaultBodyLimit`.
- Content is sniffed for a plausible XML/NZB prefix before it's ever written to disk.
- The on-disk filename is always a fresh server-generated UUID, never anything derived from client input.
- The cleanup path (`uploaded_nzb_filename`) re-validates any URL-derived filename as a strict `{uuid}.nzb` shape before it ever reaches a filesystem path — closes a real path-traversal risk (a crafted `downloadExplicitNzb` URL trying to smuggle `..` through) that a weaker "no `/` in the tail" check would have missed, since `..` itself contains no `/`.
- Deleted the moment `plugin-usenet` ingests it, with an hourly sweep as a backstop for anything that never reaches that point.

## Test plan

- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass
- [x] Frontend `svelte-check` and `biome lint` pass
- [x] `schema.graphql` / codegen verified in sync (no drift)
- [x] Live-verified against a running instance: magnet preview (title/resolution/quality/HDR/codec/audio/group all correctly parsed from `dn=`), NZB preview (title + real size summed from segment bytes, `S01E02` correctly parsed into `seasons`/`episodes`), upload + auto-preview round trip, path-traversal rejection, unauthenticated-upload rejection, `manual_scrape_only` correctly excluding an item from the retry query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added manual scrape tools for previewing and downloading content from magnet links and NZB URLs.
  - Added NZB file uploads with validation, size limits, and temporary download support.
  - Added candidate search and filters for provider, resolution, and quality.
  - Added manual scrape status visibility across media items.
- **Bug Fixes**
  - Prevented manually resolved items from automatic re-scraping.
  - Cleaned up temporary NZB uploads after processing and removed stale files.
  - Improved protection when fetching manually supplied external NZB URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->