### PR TITLE
feat: show who requested/added a media item

### DIFF
--- a/crates/plugin-listrr/src/lib.rs
+++ b/crates/plugin-listrr/src/lib.rs
@@ -122,6 +122,7 @@ async fn fetch_list_items(
                 imdb_id: item.imdb_id.clone(),
                 tvdb_id: item.tvdb_id.map(|id| id.to_string()),
                 tmdb_id: item.tmdb_id.map(|id| id.to_string()),
+                requested_by: Some("Listrr".to_string()),
                 ..Default::default()
             });
         }

--- a/crates/plugin-mdblist/src/lib.rs
+++ b/crates/plugin-mdblist/src/lib.rs
@@ -101,6 +101,7 @@ async fn fetch_and_build_content(
                 imdb_id: item.imdb_id(),
                 tmdb_id: item.tmdb_id().map(|id| id.to_string()),
                 tvdb_id: item.tvdb_id().map(|id| id.to_string()),
+                requested_by: Some("MDBList".to_string()),
                 ..Default::default()
             });
         }
@@ -120,6 +121,7 @@ async fn fetch_and_build_content(
             content.insert_show(ExternalIds {
                 imdb_id: item.imdb_id(),
                 tvdb_id: item.tvdb_id().map(|id| id.to_string()),
+                requested_by: Some("MDBList".to_string()),
                 ..Default::default()
             });
         }

--- a/crates/plugin-trakt/src/lib.rs
+++ b/crates/plugin-trakt/src/lib.rs
@@ -209,6 +209,7 @@ fn ids_to_external(ids: &TraktIds) -> Option<ExternalIds> {
         imdb_id: ids.imdb.clone(),
         tmdb_id: ids.tmdb.map(|n| n.to_string()),
         tvdb_id: ids.tvdb.map(|n| n.to_string()),
+        requested_by: Some("Trakt".to_string()),
         ..Default::default()
     })
 }

--- a/crates/riven-api/src/schema.rs
+++ b/crates/riven-api/src/schema.rs
@@ -6,6 +6,7 @@ use riven_core::downloader::DownloaderConfig;
 use riven_core::http::HttpClient;
 use riven_core::logging::LogControl;
 use riven_core::plugin::PluginRegistry;
+use sea_orm::DatabaseConnection;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -45,6 +46,7 @@ impl StremioAddonToken {
 pub fn build_schema(
     registry: Arc<PluginRegistry>,
     job_queue: Arc<riven_queue::JobQueue>,
+    db: DatabaseConnection,
     http_client: HttpClient,
     log_directory: String,
     downloader_config: Arc<RwLock<DownloaderConfig>>,
@@ -60,6 +62,7 @@ pub fn build_schema(
     )
     .data(registry)
     .data(job_queue)
+    .data(db)
     .data(http_client)
     .data(downloader_config)
     .data(log_control)

--- a/crates/riven-api/src/schema/mutations/item_request.rs
+++ b/crates/riven-api/src/schema/mutations/item_request.rs
@@ -6,7 +6,7 @@ use riven_queue::lifecycle::{upsert_requested_movie, upsert_requested_show};
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::schema::auth::{Capability, require};
+use crate::schema::auth::{Capability, RequestAuth, require};
 
 use super::MutationStatusText;
 
@@ -66,6 +66,17 @@ pub(super) struct RequestItemsResult {
     updated_items: Vec<ItemRequest>,
 }
 
+/// The signed-in riven user who is requesting, if any — always preferred
+/// over a caller-supplied `requested_by` on the input, which exists for
+/// non-interactive callers (an API-key-authenticated integration) that have
+/// no riven session to draw an identity from. A signed-in user's own
+/// requests must attribute to *them*, not to whatever string the client
+/// happened to send — trusting the input here would let one riven user's
+/// request be misattributed to another by simply setting the field.
+fn session_requester(ctx: &Context<'_>) -> Result<Option<String>> {
+    Ok(ctx.data::<RequestAuth>()?.username.clone())
+}
+
 #[derive(Default)]
 pub struct ItemRequestMutations;
 
@@ -83,11 +94,12 @@ impl ItemRequestMutations {
     ) -> Result<RequestItemMutationResponse> {
         require(ctx, Capability::RequestItems)?;
         let job_queue = ctx.data::<Arc<JobQueue>>()?;
+        let requested_by = session_requester(ctx)?.or_else(|| input.requested_by.clone());
         let outcome = match upsert_requested_movie(
             &input.title,
             input.imdb_id.as_deref(),
             input.tmdb_id.as_deref(),
-            input.requested_by.as_deref(),
+            requested_by.as_deref(),
             input.external_request_id.as_deref(),
         )
         .await
@@ -139,11 +151,12 @@ impl ItemRequestMutations {
     ) -> Result<RequestItemMutationResponse> {
         require(ctx, Capability::RequestItems)?;
         let job_queue = ctx.data::<Arc<JobQueue>>()?;
+        let requested_by = session_requester(ctx)?.or_else(|| input.requested_by.clone());
         let outcome = match upsert_requested_show(
             &input.title,
             input.imdb_id.as_deref(),
             input.tvdb_id.as_deref(),
-            input.requested_by.as_deref(),
+            requested_by.as_deref(),
             input.external_request_id.as_deref(),
             input.seasons.as_deref(),
         )
@@ -213,6 +226,7 @@ impl ItemRequestMutations {
     ) -> Result<RequestItemsResult> {
         require(ctx, Capability::RequestItems)?;
         let job_queue = ctx.data::<Arc<JobQueue>>()?;
+        let requester = session_requester(ctx)?;
         let mut seen: HashSet<String> = HashSet::new();
         let mut new_items: Vec<ItemRequest> = Vec::new();
         let mut updated_items: Vec<ItemRequest> = Vec::new();
@@ -233,11 +247,12 @@ impl ItemRequestMutations {
 
             count += 1;
 
+            let requested_by = requester.clone().or_else(|| movie.requested_by.clone());
             let outcome = upsert_requested_movie(
                 &movie.title,
                 movie.imdb_id.as_deref(),
                 movie.tmdb_id.as_deref(),
-                movie.requested_by.as_deref(),
+                requested_by.as_deref(),
                 movie.external_request_id.as_deref(),
             )
             .await
@@ -277,11 +292,12 @@ impl ItemRequestMutations {
 
             let seasons = show.seasons.as_deref();
 
+            let requested_by = requester.clone().or_else(|| show.requested_by.clone());
             let outcome = upsert_requested_show(
                 &show.title,
                 show.imdb_id.as_deref(),
                 show.tvdb_id.as_deref(),
-                show.requested_by.as_deref(),
+                requested_by.as_deref(),
                 show.external_request_id.as_deref(),
                 seasons,
             )

--- a/crates/riven-api/src/schema/mutations/item_request.rs
+++ b/crates/riven-api/src/schema/mutations/item_request.rs
@@ -66,15 +66,28 @@ pub(super) struct RequestItemsResult {
     updated_items: Vec<ItemRequest>,
 }
 
-/// The signed-in riven user who is requesting, if any — always preferred
-/// over a caller-supplied `requested_by` on the input, which exists for
-/// non-interactive callers (an API-key-authenticated integration) that have
-/// no riven session to draw an identity from. A signed-in user's own
-/// requests must attribute to *them*, not to whatever string the client
-/// happened to send — trusting the input here would let one riven user's
-/// request be misattributed to another by simply setting the field.
-fn session_requester(ctx: &Context<'_>) -> Result<Option<String>> {
-    Ok(ctx.data::<RequestAuth>()?.username.clone())
+/// The requester to record for a direct riven request: the signed-in
+/// user's own identity when there is one, the caller-supplied
+/// `requested_by` only for a trusted-API-key caller (a non-interactive
+/// integration, which has no session identity to draw from at all), and
+/// `None` otherwise.
+///
+/// The API-key fallback must never apply to a *session*-authenticated call,
+/// even one whose account happens to have no `username`/`display_username`
+/// set (`RequestAuth::username` is `None` for both cases, which is why this
+/// checks `is_trusted_api_key` explicitly rather than treating "no
+/// username" as "no session"): a signed-in user must never be able to
+/// attribute their own request to an arbitrary string just by leaving both
+/// name fields unset — that defeats the whole point of preferring the
+/// session identity over caller input in the first place.
+fn resolve_requester(auth: &RequestAuth, input_requested_by: Option<&str>) -> Option<String> {
+    if let Some(username) = &auth.username {
+        return Some(username.clone());
+    }
+    if auth.is_trusted_api_key {
+        return input_requested_by.map(str::to_owned);
+    }
+    None
 }
 
 #[derive(Default)]
@@ -94,7 +107,8 @@ impl ItemRequestMutations {
     ) -> Result<RequestItemMutationResponse> {
         require(ctx, Capability::RequestItems)?;
         let job_queue = ctx.data::<Arc<JobQueue>>()?;
-        let requested_by = session_requester(ctx)?.or_else(|| input.requested_by.clone());
+        let requested_by =
+            resolve_requester(ctx.data::<RequestAuth>()?, input.requested_by.as_deref());
         let outcome = match upsert_requested_movie(
             &input.title,
             input.imdb_id.as_deref(),
@@ -151,7 +165,8 @@ impl ItemRequestMutations {
     ) -> Result<RequestItemMutationResponse> {
         require(ctx, Capability::RequestItems)?;
         let job_queue = ctx.data::<Arc<JobQueue>>()?;
-        let requested_by = session_requester(ctx)?.or_else(|| input.requested_by.clone());
+        let requested_by =
+            resolve_requester(ctx.data::<RequestAuth>()?, input.requested_by.as_deref());
         let outcome = match upsert_requested_show(
             &input.title,
             input.imdb_id.as_deref(),
@@ -226,7 +241,7 @@ impl ItemRequestMutations {
     ) -> Result<RequestItemsResult> {
         require(ctx, Capability::RequestItems)?;
         let job_queue = ctx.data::<Arc<JobQueue>>()?;
-        let requester = session_requester(ctx)?;
+        let auth = ctx.data::<RequestAuth>()?;
         let mut seen: HashSet<String> = HashSet::new();
         let mut new_items: Vec<ItemRequest> = Vec::new();
         let mut updated_items: Vec<ItemRequest> = Vec::new();
@@ -247,7 +262,7 @@ impl ItemRequestMutations {
 
             count += 1;
 
-            let requested_by = requester.clone().or_else(|| movie.requested_by.clone());
+            let requested_by = resolve_requester(auth, movie.requested_by.as_deref());
             let outcome = upsert_requested_movie(
                 &movie.title,
                 movie.imdb_id.as_deref(),
@@ -292,7 +307,7 @@ impl ItemRequestMutations {
 
             let seasons = show.seasons.as_deref();
 
-            let requested_by = requester.clone().or_else(|| show.requested_by.clone());
+            let requested_by = resolve_requester(auth, show.requested_by.as_deref());
             let outcome = upsert_requested_show(
                 &show.title,
                 show.imdb_id.as_deref(),

--- a/crates/riven-api/src/schema/mutations/library.rs
+++ b/crates/riven-api/src/schema/mutations/library.rs
@@ -7,7 +7,7 @@ use riven_queue::lifecycle::{upsert_requested_movie, upsert_requested_show};
 use riven_queue::{IndexJob, JobQueue};
 use std::sync::Arc;
 
-use crate::schema::auth::{Capability, require, require_settings_access};
+use crate::schema::auth::{Capability, RequestAuth, require, require_settings_access};
 
 #[derive(Default)]
 pub struct LibraryMutations;
@@ -136,17 +136,22 @@ impl LibraryMutations {
     ) -> Result<MediaItem> {
         require(ctx, Capability::AddItems)?;
         let job_queue = ctx.data::<Arc<JobQueue>>()?;
+        let requested_by = ctx.data::<RequestAuth>()?.username.clone();
         let outcome = match item_type {
-            MediaItemType::Movie => {
-                upsert_requested_movie(&title, imdb_id.as_deref(), tmdb_id.as_deref(), None, None)
-                    .await
-                    .map_err(Error::from)?
-            }
+            MediaItemType::Movie => upsert_requested_movie(
+                &title,
+                imdb_id.as_deref(),
+                tmdb_id.as_deref(),
+                requested_by.as_deref(),
+                None,
+            )
+            .await
+            .map_err(Error::from)?,
             MediaItemType::Show => upsert_requested_show(
                 &title,
                 imdb_id.as_deref(),
                 tvdb_id.as_deref(),
-                None,
+                requested_by.as_deref(),
                 None,
                 seasons.as_deref(),
             )

--- a/crates/riven-api/src/schema/queries/media.rs
+++ b/crates/riven-api/src/schema/queries/media.rs
@@ -394,6 +394,7 @@ impl MediaQuery {
             tvdb_id: item.tvdb_id,
             expected_file_count,
             seasons,
+            item_request_id: item.item_request_id,
         })
     }
 

--- a/crates/riven-api/src/schema/types.rs
+++ b/crates/riven-api/src/schema/types.rs
@@ -50,6 +50,7 @@ pub struct SeasonState {
 
 /// Lightweight media state tree used for live state subscriptions.
 #[derive(SimpleObject)]
+#[graphql(complex)]
 pub struct MediaItemStateTree {
     pub id: i64,
     pub state: MediaItemState,
@@ -58,6 +59,28 @@ pub struct MediaItemStateTree {
     pub tvdb_id: Option<String>,
     pub expected_file_count: i64,
     pub seasons: Vec<SeasonState>,
+    /// Not exposed directly — resolved through [`Self::added_by`], the same
+    /// as `media_items::Model` does for the full item view. This type has no
+    /// other link back to `MediaItem`, so the id has to travel with it.
+    #[graphql(skip)]
+    pub item_request_id: Option<i64>,
+}
+
+#[async_graphql::ComplexObject]
+impl MediaItemStateTree {
+    /// Mirrors `MediaItem.addedBy` — see
+    /// [`riven_core::entities::item_requests::resolve_added_by`] for the
+    /// full rules. Kept in sync with the full item view so this page's live
+    /// state updates (which use this lightweight type, not `MediaItemFull`)
+    /// don't silently drop the field once a subscription push overwrites the
+    /// initial full fetch.
+    async fn added_by(
+        &self,
+        ctx: &async_graphql::Context<'_>,
+    ) -> async_graphql::Result<Option<String>> {
+        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
+        Ok(riven_core::entities::item_requests::resolve_added_by(self.item_request_id, db).await?)
+    }
 }
 
 /// Minimal per-item library status: just enough to render a "Request" vs

--- a/crates/riven-api/src/server.rs
+++ b/crates/riven-api/src/server.rs
@@ -115,6 +115,7 @@ pub async fn start_server(config: StartServerConfig) -> Result<()> {
     let schema = build_schema(
         registry.clone(),
         job_queue.clone(),
+        riven_db::orm().clone(),
         http_client,
         log_directory,
         downloader_config,

--- a/crates/riven-api/src/server/auth.rs
+++ b/crates/riven-api/src/server/auth.rs
@@ -104,8 +104,8 @@ pub(super) async fn authorize_request(
     headers: &HeaderMap,
     query: Option<&str>,
 ) -> Result<RequestAuth, Unauthorized> {
-    if let Some(role) = session_role(state, headers).await? {
-        return Ok(RequestAuth { role });
+    if let Some(auth) = session_auth(state, headers).await? {
+        return Ok(auth);
     }
 
     if has_valid_api_key(state, headers, query) {
@@ -129,10 +129,10 @@ pub(super) async fn authorize_request(
 /// A session that *exists* but is unusable (expired or revoked) still returns
 /// `Err`. Falling through only offers the value to `api_key_matches`, which
 /// grants nothing unless it equals the configured key.
-async fn session_role(
+async fn session_auth(
     state: &ApiState,
     headers: &HeaderMap,
-) -> Result<Option<UserRole>, Unauthorized> {
+) -> Result<Option<RequestAuth>, Unauthorized> {
     use super::authn::SessionState;
 
     let session_state = super::authn::authenticate(&state.auth, headers)
@@ -148,7 +148,13 @@ async fn session_role(
             tracing::debug!("auth rejected: session expired or revoked");
             Err(Unauthorized)
         }
-        SessionState::Valid { user, .. } => Ok(Some(role_from_user(user.role.as_deref()))),
+        SessionState::Valid { user, .. } => Ok(Some(RequestAuth {
+            role: role_from_user(user.role.as_deref()),
+            username: user
+                .display_username
+                .clone()
+                .or_else(|| user.username.clone()),
+        })),
     }
 }
 
@@ -199,7 +205,7 @@ mod tests {
 
     /// `Authorization: Bearer <api-key>` is documented as a supported way to
     /// call the API, and `api_key_matches` reads that header — but every such
-    /// request was rejected before reaching it, because `session_role` treated
+    /// request was rejected before reaching it, because `session_auth` treated
     /// the value as a session token and failed on the miss.
     #[test]
     fn an_api_key_presented_as_a_bearer_token_is_accepted() {

--- a/crates/riven-api/src/server/auth.rs
+++ b/crates/riven-api/src/server/auth.rs
@@ -154,6 +154,7 @@ async fn session_auth(
                 .display_username
                 .clone()
                 .or_else(|| user.username.clone()),
+            is_trusted_api_key: false,
         })),
     }
 }

--- a/crates/riven-core/src/auth.rs
+++ b/crates/riven-core/src/auth.rs
@@ -96,7 +96,18 @@ pub struct RequestAuth {
     /// for this account, see `sidebar.svelte`/`user-management.svelte`).
     /// `None` for a trusted-API-key caller, which has no user behind it, or
     /// for the rare account with neither field set.
+    ///
+    /// `None` alone doesn't say *why* — that's [`Self::is_trusted_api_key`].
+    /// A caller that wants to fall back to some other source of identity
+    /// (e.g. a caller-supplied string) only when there's no session at all
+    /// must check that flag first: treating "no username" as "no session"
+    /// would let a signed-in user with an unset username masquerade as
+    /// whatever identity they supply themselves.
     pub username: Option<String>,
+    /// Whether this request authenticated via the configured API key rather
+    /// than a real session. See [`Self::username`]'s doc for why this needs
+    /// to be checked separately from it being `None`.
+    pub is_trusted_api_key: bool,
 }
 
 impl RequestAuth {
@@ -104,6 +115,7 @@ impl RequestAuth {
         Self {
             role: UserRole::Admin,
             username: None,
+            is_trusted_api_key: true,
         }
     }
 }

--- a/crates/riven-core/src/auth.rs
+++ b/crates/riven-core/src/auth.rs
@@ -91,12 +91,19 @@ impl Capability {
 #[derive(Clone, Debug)]
 pub struct RequestAuth {
     pub role: UserRole,
+    /// The signed-in user's display handle (`display_username`, falling back
+    /// to `username` — the same preference order the frontend already uses
+    /// for this account, see `sidebar.svelte`/`user-management.svelte`).
+    /// `None` for a trusted-API-key caller, which has no user behind it, or
+    /// for the rare account with neither field set.
+    pub username: Option<String>,
 }
 
 impl RequestAuth {
     pub fn trusted_api_key() -> Self {
         Self {
             role: UserRole::Admin,
+            username: None,
         }
     }
 }

--- a/crates/riven-core/src/entities/item_requests.rs
+++ b/crates/riven-core/src/entities/item_requests.rs
@@ -52,3 +52,33 @@ impl Related<super::media_items::Entity> for Entity {
 }
 
 impl ActiveModelBehavior for ActiveModel {}
+
+/// Who is responsible for the item this request is linked to existing —
+/// shared by every GraphQL type that surfaces an `addedBy`-style field
+/// (`media_items::Model` and `riven-api`'s `MediaItemStateTree`), so both the
+/// full item view and the lightweight live-state view resolve it identically
+/// rather than one of them silently drifting from the other. `None` for a
+/// `media_item_id` with no linked request at all — a list-plugin auto-add
+/// with the source-attribution wired up ("Trakt"/"Listrr"/"MDBList" as
+/// `requested_by`) still resolves to a real label; only something with
+/// neither a request row nor a source label falls through to `None`.
+///
+/// A Seerr-originated request (`external_request_id` set) collapses to the
+/// fixed label `"Seerr"` rather than the specific Seerr user who asked for
+/// it — that identity lives in Seerr's own UI, not duplicated here.
+pub async fn resolve_added_by(
+    item_request_id: Option<i64>,
+    db: &sea_orm::DatabaseConnection,
+) -> Result<Option<String>, sea_orm::DbErr> {
+    let Some(item_request_id) = item_request_id else {
+        return Ok(None);
+    };
+    let request = Entity::find_by_id(item_request_id).one(db).await?;
+    Ok(request.and_then(|request| {
+        if request.external_request_id.is_some() {
+            Some("Seerr".to_string())
+        } else {
+            request.requested_by
+        }
+    }))
+}

--- a/crates/riven-core/src/entities/media_items.rs
+++ b/crates/riven-core/src/entities/media_items.rs
@@ -190,4 +190,36 @@ impl Model {
             crate::entities::helpers::Artwork::Poster,
         )
     }
+
+    /// Who is responsible for this item existing, for display next to other
+    /// item metadata. `None` for anything with no linked request at all — a
+    /// list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+    /// `discoverItem`, which never creates an `item_requests` row.
+    ///
+    /// A Seerr-originated request collapses to the fixed label `"Seerr"`
+    /// rather than the specific Seerr user who asked for it — that identity
+    /// lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+    /// doubles as that Seerr-requester email *and*, for a request made
+    /// directly through riven's own `requestMovie`/`requestShow`/`addItem`
+    /// mutations, the riven username that called them — `external_request_id`
+    /// (set only by Seerr) is what tells the two apart.
+    async fn added_by(
+        &self,
+        ctx: &async_graphql::Context<'_>,
+    ) -> async_graphql::Result<Option<String>> {
+        let Some(item_request_id) = self.item_request_id else {
+            return Ok(None);
+        };
+        let db = ctx.data::<sea_orm::DatabaseConnection>()?;
+        let request = super::item_requests::Entity::find_by_id(item_request_id)
+            .one(db)
+            .await?;
+        Ok(request.and_then(|request| {
+            if request.external_request_id.is_some() {
+                Some("Seerr".to_string())
+            } else {
+                request.requested_by
+            }
+        }))
+    }
 }

--- a/crates/riven-core/src/entities/media_items.rs
+++ b/crates/riven-core/src/entities/media_items.rs
@@ -192,34 +192,14 @@ impl Model {
     }
 
     /// Who is responsible for this item existing, for display next to other
-    /// item metadata. `None` for anything with no linked request at all — a
-    /// list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-    /// `discoverItem`, which never creates an `item_requests` row.
-    ///
-    /// A Seerr-originated request collapses to the fixed label `"Seerr"`
-    /// rather than the specific Seerr user who asked for it — that identity
-    /// lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-    /// doubles as that Seerr-requester email *and*, for a request made
-    /// directly through riven's own `requestMovie`/`requestShow`/`addItem`
-    /// mutations, the riven username that called them — `external_request_id`
-    /// (set only by Seerr) is what tells the two apart.
+    /// item metadata. See [`super::item_requests::resolve_added_by`] for the
+    /// full rules — `None` only for an item with no linked request at all
+    /// (e.g. `discoverItem`, which never creates one).
     async fn added_by(
         &self,
         ctx: &async_graphql::Context<'_>,
     ) -> async_graphql::Result<Option<String>> {
-        let Some(item_request_id) = self.item_request_id else {
-            return Ok(None);
-        };
         let db = ctx.data::<sea_orm::DatabaseConnection>()?;
-        let request = super::item_requests::Entity::find_by_id(item_request_id)
-            .one(db)
-            .await?;
-        Ok(request.and_then(|request| {
-            if request.external_request_id.is_some() {
-                Some("Seerr".to_string())
-            } else {
-                request.requested_by
-            }
-        }))
+        Ok(super::item_requests::resolve_added_by(self.item_request_id, db).await?)
     }
 }

--- a/frontend/src/lib/gql/schema.ts
+++ b/frontend/src/lib/gql/schema.ts
@@ -202,6 +202,21 @@ export type DownloadMediaItemMutationResponse = {
 export type Episode = {
   absoluteNumber?: Maybe<Scalars['Int']['output']>;
   activeStreamId?: Maybe<Scalars['Int']['output']>;
+  /**
+   * Who is responsible for this item existing, for display next to other
+   * item metadata. `None` for anything with no linked request at all — a
+   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+   * `discoverItem`, which never creates an `item_requests` row.
+   *
+   * A Seerr-originated request collapses to the fixed label `"Seerr"`
+   * rather than the specific Seerr user who asked for it — that identity
+   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+   * doubles as that Seerr-requester email *and*, for a request made
+   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
+   * mutations, the riven username that called them — `external_request_id`
+   * (set only by Seerr) is what tells the two apart.
+   */
+  addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
   airedAtUtc?: Maybe<Scalars['DateTime']['output']>;
   aliases?: Maybe<Scalars['JSON']['output']>;
@@ -261,6 +276,21 @@ export type EpisodeStreamsArgs = {
 export type EpisodeFull = {
   absoluteNumber?: Maybe<Scalars['Int']['output']>;
   activeStreamId?: Maybe<Scalars['Int']['output']>;
+  /**
+   * Who is responsible for this item existing, for display next to other
+   * item metadata. `None` for anything with no linked request at all — a
+   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+   * `discoverItem`, which never creates an `item_requests` row.
+   *
+   * A Seerr-originated request collapses to the fixed label `"Seerr"`
+   * rather than the specific Seerr user who asked for it — that identity
+   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+   * doubles as that Seerr-requester email *and*, for a request made
+   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
+   * mutations, the riven username that called them — `external_request_id`
+   * (set only by Seerr) is what tells the two apart.
+   */
+  addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
   airedAtUtc?: Maybe<Scalars['DateTime']['output']>;
   aliases?: Maybe<Scalars['JSON']['output']>;
@@ -614,6 +644,21 @@ export type MediaDetails = {
 export type MediaItem = {
   absoluteNumber?: Maybe<Scalars['Int']['output']>;
   activeStreamId?: Maybe<Scalars['Int']['output']>;
+  /**
+   * Who is responsible for this item existing, for display next to other
+   * item metadata. `None` for anything with no linked request at all — a
+   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+   * `discoverItem`, which never creates an `item_requests` row.
+   *
+   * A Seerr-originated request collapses to the fixed label `"Seerr"`
+   * rather than the specific Seerr user who asked for it — that identity
+   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+   * doubles as that Seerr-requester email *and*, for a request made
+   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
+   * mutations, the riven username that called them — `external_request_id`
+   * (set only by Seerr) is what tells the two apart.
+   */
+  addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
   airedAtUtc?: Maybe<Scalars['DateTime']['output']>;
   aliases?: Maybe<Scalars['JSON']['output']>;
@@ -661,6 +706,21 @@ export type MediaItem = {
 export type MediaItemFull = {
   absoluteNumber?: Maybe<Scalars['Int']['output']>;
   activeStreamId?: Maybe<Scalars['Int']['output']>;
+  /**
+   * Who is responsible for this item existing, for display next to other
+   * item metadata. `None` for anything with no linked request at all — a
+   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+   * `discoverItem`, which never creates an `item_requests` row.
+   *
+   * A Seerr-originated request collapses to the fixed label `"Seerr"`
+   * rather than the specific Seerr user who asked for it — that identity
+   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+   * doubles as that Seerr-requester email *and*, for a request made
+   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
+   * mutations, the riven username that called them — `external_request_id`
+   * (set only by Seerr) is what tells the two apart.
+   */
+  addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
   airedAtUtc?: Maybe<Scalars['DateTime']['output']>;
   aliases?: Maybe<Scalars['JSON']['output']>;
@@ -710,6 +770,21 @@ export type MediaItemFull = {
 export type MediaItemListRow = {
   absoluteNumber?: Maybe<Scalars['Int']['output']>;
   activeStreamId?: Maybe<Scalars['Int']['output']>;
+  /**
+   * Who is responsible for this item existing, for display next to other
+   * item metadata. `None` for anything with no linked request at all — a
+   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+   * `discoverItem`, which never creates an `item_requests` row.
+   *
+   * A Seerr-originated request collapses to the fixed label `"Seerr"`
+   * rather than the specific Seerr user who asked for it — that identity
+   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+   * doubles as that Seerr-requester email *and*, for a request made
+   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
+   * mutations, the riven username that called them — `external_request_id`
+   * (set only by Seerr) is what tells the two apart.
+   */
+  addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
   airedAtUtc?: Maybe<Scalars['DateTime']['output']>;
   aliases?: Maybe<Scalars['JSON']['output']>;
@@ -839,6 +914,21 @@ export type MediaMetadata = {
 export type Movie = {
   absoluteNumber?: Maybe<Scalars['Int']['output']>;
   activeStreamId?: Maybe<Scalars['Int']['output']>;
+  /**
+   * Who is responsible for this item existing, for display next to other
+   * item metadata. `None` for anything with no linked request at all — a
+   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+   * `discoverItem`, which never creates an `item_requests` row.
+   *
+   * A Seerr-originated request collapses to the fixed label `"Seerr"`
+   * rather than the specific Seerr user who asked for it — that identity
+   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+   * doubles as that Seerr-requester email *and*, for a request made
+   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
+   * mutations, the riven username that called them — `external_request_id`
+   * (set only by Seerr) is what tells the two apart.
+   */
+  addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
   airedAtUtc?: Maybe<Scalars['DateTime']['output']>;
   aliases?: Maybe<Scalars['JSON']['output']>;
@@ -1823,6 +1913,21 @@ export type ScrapeMediaItemMutationResponse = {
 export type Season = {
   absoluteNumber?: Maybe<Scalars['Int']['output']>;
   activeStreamId?: Maybe<Scalars['Int']['output']>;
+  /**
+   * Who is responsible for this item existing, for display next to other
+   * item metadata. `None` for anything with no linked request at all — a
+   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+   * `discoverItem`, which never creates an `item_requests` row.
+   *
+   * A Seerr-originated request collapses to the fixed label `"Seerr"`
+   * rather than the specific Seerr user who asked for it — that identity
+   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+   * doubles as that Seerr-requester email *and*, for a request made
+   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
+   * mutations, the riven username that called them — `external_request_id`
+   * (set only by Seerr) is what tells the two apart.
+   */
+  addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
   airedAtUtc?: Maybe<Scalars['DateTime']['output']>;
   aliases?: Maybe<Scalars['JSON']['output']>;
@@ -1884,6 +1989,21 @@ export type SeasonStreamsArgs = {
 export type SeasonFull = {
   absoluteNumber?: Maybe<Scalars['Int']['output']>;
   activeStreamId?: Maybe<Scalars['Int']['output']>;
+  /**
+   * Who is responsible for this item existing, for display next to other
+   * item metadata. `None` for anything with no linked request at all — a
+   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+   * `discoverItem`, which never creates an `item_requests` row.
+   *
+   * A Seerr-originated request collapses to the fixed label `"Seerr"`
+   * rather than the specific Seerr user who asked for it — that identity
+   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+   * doubles as that Seerr-requester email *and*, for a request made
+   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
+   * mutations, the riven username that called them — `external_request_id`
+   * (set only by Seerr) is what tells the two apart.
+   */
+  addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
   airedAtUtc?: Maybe<Scalars['DateTime']['output']>;
   aliases?: Maybe<Scalars['JSON']['output']>;
@@ -1982,6 +2102,21 @@ export type SetupGroup = {
 export type Show = {
   absoluteNumber?: Maybe<Scalars['Int']['output']>;
   activeStreamId?: Maybe<Scalars['Int']['output']>;
+  /**
+   * Who is responsible for this item existing, for display next to other
+   * item metadata. `None` for anything with no linked request at all — a
+   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+   * `discoverItem`, which never creates an `item_requests` row.
+   *
+   * A Seerr-originated request collapses to the fixed label `"Seerr"`
+   * rather than the specific Seerr user who asked for it — that identity
+   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+   * doubles as that Seerr-requester email *and*, for a request made
+   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
+   * mutations, the riven username that called them — `external_request_id`
+   * (set only by Seerr) is what tells the two apart.
+   */
+  addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
   airedAtUtc?: Maybe<Scalars['DateTime']['output']>;
   aliases?: Maybe<Scalars['JSON']['output']>;

--- a/frontend/src/lib/gql/schema.ts
+++ b/frontend/src/lib/gql/schema.ts
@@ -204,17 +204,9 @@ export type Episode = {
   activeStreamId?: Maybe<Scalars['Int']['output']>;
   /**
    * Who is responsible for this item existing, for display next to other
-   * item metadata. `None` for anything with no linked request at all — a
-   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-   * `discoverItem`, which never creates an `item_requests` row.
-   *
-   * A Seerr-originated request collapses to the fixed label `"Seerr"`
-   * rather than the specific Seerr user who asked for it — that identity
-   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-   * doubles as that Seerr-requester email *and*, for a request made
-   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
-   * mutations, the riven username that called them — `external_request_id`
-   * (set only by Seerr) is what tells the two apart.
+   * item metadata. See [`super::item_requests::resolve_added_by`] for the
+   * full rules — `None` only for an item with no linked request at all
+   * (e.g. `discoverItem`, which never creates one).
    */
   addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
@@ -278,17 +270,9 @@ export type EpisodeFull = {
   activeStreamId?: Maybe<Scalars['Int']['output']>;
   /**
    * Who is responsible for this item existing, for display next to other
-   * item metadata. `None` for anything with no linked request at all — a
-   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-   * `discoverItem`, which never creates an `item_requests` row.
-   *
-   * A Seerr-originated request collapses to the fixed label `"Seerr"`
-   * rather than the specific Seerr user who asked for it — that identity
-   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-   * doubles as that Seerr-requester email *and*, for a request made
-   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
-   * mutations, the riven username that called them — `external_request_id`
-   * (set only by Seerr) is what tells the two apart.
+   * item metadata. See [`super::item_requests::resolve_added_by`] for the
+   * full rules — `None` only for an item with no linked request at all
+   * (e.g. `discoverItem`, which never creates one).
    */
   addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
@@ -646,17 +630,9 @@ export type MediaItem = {
   activeStreamId?: Maybe<Scalars['Int']['output']>;
   /**
    * Who is responsible for this item existing, for display next to other
-   * item metadata. `None` for anything with no linked request at all — a
-   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-   * `discoverItem`, which never creates an `item_requests` row.
-   *
-   * A Seerr-originated request collapses to the fixed label `"Seerr"`
-   * rather than the specific Seerr user who asked for it — that identity
-   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-   * doubles as that Seerr-requester email *and*, for a request made
-   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
-   * mutations, the riven username that called them — `external_request_id`
-   * (set only by Seerr) is what tells the two apart.
+   * item metadata. See [`super::item_requests::resolve_added_by`] for the
+   * full rules — `None` only for an item with no linked request at all
+   * (e.g. `discoverItem`, which never creates one).
    */
   addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
@@ -708,17 +684,9 @@ export type MediaItemFull = {
   activeStreamId?: Maybe<Scalars['Int']['output']>;
   /**
    * Who is responsible for this item existing, for display next to other
-   * item metadata. `None` for anything with no linked request at all — a
-   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-   * `discoverItem`, which never creates an `item_requests` row.
-   *
-   * A Seerr-originated request collapses to the fixed label `"Seerr"`
-   * rather than the specific Seerr user who asked for it — that identity
-   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-   * doubles as that Seerr-requester email *and*, for a request made
-   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
-   * mutations, the riven username that called them — `external_request_id`
-   * (set only by Seerr) is what tells the two apart.
+   * item metadata. See [`super::item_requests::resolve_added_by`] for the
+   * full rules — `None` only for an item with no linked request at all
+   * (e.g. `discoverItem`, which never creates one).
    */
   addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
@@ -772,17 +740,9 @@ export type MediaItemListRow = {
   activeStreamId?: Maybe<Scalars['Int']['output']>;
   /**
    * Who is responsible for this item existing, for display next to other
-   * item metadata. `None` for anything with no linked request at all — a
-   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-   * `discoverItem`, which never creates an `item_requests` row.
-   *
-   * A Seerr-originated request collapses to the fixed label `"Seerr"`
-   * rather than the specific Seerr user who asked for it — that identity
-   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-   * doubles as that Seerr-requester email *and*, for a request made
-   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
-   * mutations, the riven username that called them — `external_request_id`
-   * (set only by Seerr) is what tells the two apart.
+   * item metadata. See [`super::item_requests::resolve_added_by`] for the
+   * full rules — `None` only for an item with no linked request at all
+   * (e.g. `discoverItem`, which never creates one).
    */
   addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
@@ -849,6 +809,15 @@ export type MediaItemState =
 
 /** Lightweight media state tree used for live state subscriptions. */
 export type MediaItemStateTree = {
+  /**
+   * Mirrors `MediaItem.addedBy` — see
+   * [`riven_core::entities::item_requests::resolve_added_by`] for the
+   * full rules. Kept in sync with the full item view so this page's live
+   * state updates (which use this lightweight type, not `MediaItemFull`)
+   * don't silently drop the field once a subscription push overwrites the
+   * initial full fetch.
+   */
+  addedBy?: Maybe<Scalars['String']['output']>;
   expectedFileCount: Scalars['Int']['output'];
   id: Scalars['Int']['output'];
   imdbId?: Maybe<Scalars['String']['output']>;
@@ -916,17 +885,9 @@ export type Movie = {
   activeStreamId?: Maybe<Scalars['Int']['output']>;
   /**
    * Who is responsible for this item existing, for display next to other
-   * item metadata. `None` for anything with no linked request at all — a
-   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-   * `discoverItem`, which never creates an `item_requests` row.
-   *
-   * A Seerr-originated request collapses to the fixed label `"Seerr"`
-   * rather than the specific Seerr user who asked for it — that identity
-   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-   * doubles as that Seerr-requester email *and*, for a request made
-   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
-   * mutations, the riven username that called them — `external_request_id`
-   * (set only by Seerr) is what tells the two apart.
+   * item metadata. See [`super::item_requests::resolve_added_by`] for the
+   * full rules — `None` only for an item with no linked request at all
+   * (e.g. `discoverItem`, which never creates one).
    */
   addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
@@ -1915,17 +1876,9 @@ export type Season = {
   activeStreamId?: Maybe<Scalars['Int']['output']>;
   /**
    * Who is responsible for this item existing, for display next to other
-   * item metadata. `None` for anything with no linked request at all — a
-   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-   * `discoverItem`, which never creates an `item_requests` row.
-   *
-   * A Seerr-originated request collapses to the fixed label `"Seerr"`
-   * rather than the specific Seerr user who asked for it — that identity
-   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-   * doubles as that Seerr-requester email *and*, for a request made
-   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
-   * mutations, the riven username that called them — `external_request_id`
-   * (set only by Seerr) is what tells the two apart.
+   * item metadata. See [`super::item_requests::resolve_added_by`] for the
+   * full rules — `None` only for an item with no linked request at all
+   * (e.g. `discoverItem`, which never creates one).
    */
   addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
@@ -1991,17 +1944,9 @@ export type SeasonFull = {
   activeStreamId?: Maybe<Scalars['Int']['output']>;
   /**
    * Who is responsible for this item existing, for display next to other
-   * item metadata. `None` for anything with no linked request at all — a
-   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-   * `discoverItem`, which never creates an `item_requests` row.
-   *
-   * A Seerr-originated request collapses to the fixed label `"Seerr"`
-   * rather than the specific Seerr user who asked for it — that identity
-   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-   * doubles as that Seerr-requester email *and*, for a request made
-   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
-   * mutations, the riven username that called them — `external_request_id`
-   * (set only by Seerr) is what tells the two apart.
+   * item metadata. See [`super::item_requests::resolve_added_by`] for the
+   * full rules — `None` only for an item with no linked request at all
+   * (e.g. `discoverItem`, which never creates one).
    */
   addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;
@@ -2104,17 +2049,9 @@ export type Show = {
   activeStreamId?: Maybe<Scalars['Int']['output']>;
   /**
    * Who is responsible for this item existing, for display next to other
-   * item metadata. `None` for anything with no linked request at all — a
-   * list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-   * `discoverItem`, which never creates an `item_requests` row.
-   *
-   * A Seerr-originated request collapses to the fixed label `"Seerr"`
-   * rather than the specific Seerr user who asked for it — that identity
-   * lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-   * doubles as that Seerr-requester email *and*, for a request made
-   * directly through riven's own `requestMovie`/`requestShow`/`addItem`
-   * mutations, the riven username that called them — `external_request_id`
-   * (set only by Seerr) is what tells the two apart.
+   * item metadata. See [`super::item_requests::resolve_added_by`] for the
+   * full rules — `None` only for an item with no linked request at all
+   * (e.g. `discoverItem`, which never creates one).
    */
   addedBy?: Maybe<Scalars['String']['output']>;
   airedAt?: Maybe<Scalars['NaiveDate']['output']>;

--- a/frontend/src/lib/services/riven-media.ts
+++ b/frontend/src/lib/services/riven-media.ts
@@ -84,7 +84,7 @@ export type GqlSeasonState = Pick<
 
 export type GqlMediaItemStateTree = Pick<
 	MediaItemStateTree,
-	"id" | "state" | "imdbId" | "tmdbId" | "tvdbId"
+	"id" | "state" | "imdbId" | "tmdbId" | "tvdbId" | "addedBy"
 > & {
 	seasons?: GqlSeasonState[];
 };
@@ -169,7 +169,7 @@ const RAW_MEDIA_ITEM_FULL_FIELDS = `
 `;
 
 const MEDIA_ITEM_STATE_FIELDS = `
-    id state imdbId tmdbId tvdbId
+    id state imdbId tmdbId tvdbId addedBy
     seasons {
         id seasonNumber state isRequested
         episodes {

--- a/frontend/src/lib/services/riven-media.ts
+++ b/frontend/src/lib/services/riven-media.ts
@@ -63,7 +63,7 @@ export type GqlSeasonFull = Pick<
 
 export type GqlMediaItemFull = Pick<
 	MediaItemFull,
-	"id" | "state" | "imdbId" | "tmdbId" | "tvdbId"
+	"id" | "state" | "imdbId" | "tmdbId" | "tvdbId" | "addedBy"
 > & {
 	filesystemEntry?: GqlFilesystemEntry | null;
 	filesystemEntries?: GqlFilesystemEntry[];
@@ -111,7 +111,7 @@ const FILESYSTEM_ENTRY_FIELDS = `
 `;
 
 const MEDIA_ITEM_FULL_FIELDS = `
-    id state imdbId tmdbId tvdbId
+    id state imdbId tmdbId tvdbId addedBy
     filesystemEntry {
         ${FILESYSTEM_ENTRY_FIELDS}
     }
@@ -145,7 +145,7 @@ const RAW_MEDIA_ITEM_FULL_FIELDS = `
     createdAt updatedAt indexedAt scrapedAt scrapedTimes
     aliases network country language isAnime airedAt year genres rating contentRating
     failedAttempts itemType isRequested showStatus seasonNumber isSpecial parentId
-    episodeNumber absoluteNumber runtime itemRequestId activeStreamId
+    episodeNumber absoluteNumber runtime itemRequestId activeStreamId addedBy
     filesystemEntry {
         ${RAW_FILESYSTEM_ENTRY_FIELDS}
     }

--- a/frontend/src/routes/(protected)/details/media/[id]/[mediaType]/+page.svelte
+++ b/frontend/src/routes/(protected)/details/media/[id]/[mediaType]/+page.svelte
@@ -859,6 +859,12 @@
                                     {completedFileCount}/{totalFileCount} files
                                 </span>
                             {/if}
+                            {#if riven?.addedBy}
+                                <span
+                                    class="text-muted-foreground border-border rounded-full border px-3 py-1.5 text-sm font-medium">
+                                    Added by {riven.addedBy}
+                                </span>
+                            {/if}
                         </div>
 
                         <!-- Actions - Right under title -->

--- a/schema.graphql
+++ b/schema.graphql
@@ -235,6 +235,21 @@ type Episode {
 	rather than in each client.
 	"""
 	posterPath: String
+	"""
+	Who is responsible for this item existing, for display next to other
+	item metadata. `None` for anything with no linked request at all — a
+	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+	`discoverItem`, which never creates an `item_requests` row.
+	
+	A Seerr-originated request collapses to the fixed label `"Seerr"`
+	rather than the specific Seerr user who asked for it — that identity
+	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+	doubles as that Seerr-requester email *and*, for a request made
+	directly through riven's own `requestMovie`/`requestShow`/`addItem`
+	mutations, the riven username that called them — `external_request_id`
+	(set only by Seerr) is what tells the two apart.
+	"""
+	addedBy: String
 	streams(infoHashes: [String!]): [Stream!]!
 	"""
 	The parent season for this episode.
@@ -297,6 +312,21 @@ type EpisodeFull {
 	rather than in each client.
 	"""
 	posterPath: String
+	"""
+	Who is responsible for this item existing, for display next to other
+	item metadata. `None` for anything with no linked request at all — a
+	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+	`discoverItem`, which never creates an `item_requests` row.
+	
+	A Seerr-originated request collapses to the fixed label `"Seerr"`
+	rather than the specific Seerr user who asked for it — that identity
+	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+	doubles as that Seerr-requester email *and*, for a request made
+	directly through riven's own `requestMovie`/`requestShow`/`addItem`
+	mutations, the riven username that called them — `external_request_id`
+	(set only by Seerr) is what tells the two apart.
+	"""
+	addedBy: String
 	filesystemEntry: FileSystemEntry
 	filesystemEntries: [FileSystemEntry!]!
 }
@@ -696,6 +726,21 @@ type MediaItem {
 	rather than in each client.
 	"""
 	posterPath: String
+	"""
+	Who is responsible for this item existing, for display next to other
+	item metadata. `None` for anything with no linked request at all — a
+	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+	`discoverItem`, which never creates an `item_requests` row.
+	
+	A Seerr-originated request collapses to the fixed label `"Seerr"`
+	rather than the specific Seerr user who asked for it — that identity
+	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+	doubles as that Seerr-requester email *and*, for a request made
+	directly through riven's own `requestMovie`/`requestShow`/`addItem`
+	mutations, the riven username that called them — `external_request_id`
+	(set only by Seerr) is what tells the two apart.
+	"""
+	addedBy: String
 }
 
 """
@@ -745,6 +790,21 @@ type MediaItemFull {
 	rather than in each client.
 	"""
 	posterPath: String
+	"""
+	Who is responsible for this item existing, for display next to other
+	item metadata. `None` for anything with no linked request at all — a
+	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+	`discoverItem`, which never creates an `item_requests` row.
+	
+	A Seerr-originated request collapses to the fixed label `"Seerr"`
+	rather than the specific Seerr user who asked for it — that identity
+	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+	doubles as that Seerr-requester email *and*, for a request made
+	directly through riven's own `requestMovie`/`requestShow`/`addItem`
+	mutations, the riven username that called them — `external_request_id`
+	(set only by Seerr) is what tells the two apart.
+	"""
+	addedBy: String
 	filesystemEntry: FileSystemEntry
 	filesystemEntries: [FileSystemEntry!]!
 	seasons: [SeasonFull!]!
@@ -794,6 +854,21 @@ type MediaItemListRow {
 	rather than in each client.
 	"""
 	posterPath: String
+	"""
+	Who is responsible for this item existing, for display next to other
+	item metadata. `None` for anything with no linked request at all — a
+	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+	`discoverItem`, which never creates an `item_requests` row.
+	
+	A Seerr-originated request collapses to the fixed label `"Seerr"`
+	rather than the specific Seerr user who asked for it — that identity
+	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+	doubles as that Seerr-requester email *and*, for a request made
+	directly through riven's own `requestMovie`/`requestShow`/`addItem`
+	mutations, the riven username that called them — `external_request_id`
+	(set only by Seerr) is what tells the two apart.
+	"""
+	addedBy: String
 	showId: Int
 	showTitle: String
 	showTmdbId: String
@@ -931,6 +1006,21 @@ type Movie {
 	rather than in each client.
 	"""
 	posterPath: String
+	"""
+	Who is responsible for this item existing, for display next to other
+	item metadata. `None` for anything with no linked request at all — a
+	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+	`discoverItem`, which never creates an `item_requests` row.
+	
+	A Seerr-originated request collapses to the fixed label `"Seerr"`
+	rather than the specific Seerr user who asked for it — that identity
+	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+	doubles as that Seerr-requester email *and*, for a request made
+	directly through riven's own `requestMovie`/`requestShow`/`addItem`
+	mutations, the riven username that called them — `external_request_id`
+	(set only by Seerr) is what tells the two apart.
+	"""
+	addedBy: String
 	streams(infoHashes: [String!]): [Stream!]!
 	"""
 	Always 1 — a movie has exactly one expected media file.
@@ -1597,6 +1687,21 @@ type Season {
 	rather than in each client.
 	"""
 	posterPath: String
+	"""
+	Who is responsible for this item existing, for display next to other
+	item metadata. `None` for anything with no linked request at all — a
+	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+	`discoverItem`, which never creates an `item_requests` row.
+	
+	A Seerr-originated request collapses to the fixed label `"Seerr"`
+	rather than the specific Seerr user who asked for it — that identity
+	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+	doubles as that Seerr-requester email *and*, for a request made
+	directly through riven's own `requestMovie`/`requestShow`/`addItem`
+	mutations, the riven username that called them — `external_request_id`
+	(set only by Seerr) is what tells the two apart.
+	"""
+	addedBy: String
 	streams(infoHashes: [String!]): [Stream!]!
 	"""
 	The parent show for this season.
@@ -1663,6 +1768,21 @@ type SeasonFull {
 	rather than in each client.
 	"""
 	posterPath: String
+	"""
+	Who is responsible for this item existing, for display next to other
+	item metadata. `None` for anything with no linked request at all — a
+	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+	`discoverItem`, which never creates an `item_requests` row.
+	
+	A Seerr-originated request collapses to the fixed label `"Seerr"`
+	rather than the specific Seerr user who asked for it — that identity
+	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+	doubles as that Seerr-requester email *and*, for a request made
+	directly through riven's own `requestMovie`/`requestShow`/`addItem`
+	mutations, the riven username that called them — `external_request_id`
+	(set only by Seerr) is what tells the two apart.
+	"""
+	addedBy: String
 	episodes: [EpisodeFull!]!
 }
 
@@ -1775,6 +1895,21 @@ type Show {
 	rather than in each client.
 	"""
 	posterPath: String
+	"""
+	Who is responsible for this item existing, for display next to other
+	item metadata. `None` for anything with no linked request at all — a
+	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
+	`discoverItem`, which never creates an `item_requests` row.
+	
+	A Seerr-originated request collapses to the fixed label `"Seerr"`
+	rather than the specific Seerr user who asked for it — that identity
+	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
+	doubles as that Seerr-requester email *and*, for a request made
+	directly through riven's own `requestMovie`/`requestShow`/`addItem`
+	mutations, the riven username that called them — `external_request_id`
+	(set only by Seerr) is what tells the two apart.
+	"""
+	addedBy: String
 	streams(infoHashes: [String!]): [Stream!]!
 	"""
 	Seasons for this show. Excludes season 0 (specials) by default.

--- a/schema.graphql
+++ b/schema.graphql
@@ -237,17 +237,9 @@ type Episode {
 	posterPath: String
 	"""
 	Who is responsible for this item existing, for display next to other
-	item metadata. `None` for anything with no linked request at all — a
-	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-	`discoverItem`, which never creates an `item_requests` row.
-	
-	A Seerr-originated request collapses to the fixed label `"Seerr"`
-	rather than the specific Seerr user who asked for it — that identity
-	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-	doubles as that Seerr-requester email *and*, for a request made
-	directly through riven's own `requestMovie`/`requestShow`/`addItem`
-	mutations, the riven username that called them — `external_request_id`
-	(set only by Seerr) is what tells the two apart.
+	item metadata. See [`super::item_requests::resolve_added_by`] for the
+	full rules — `None` only for an item with no linked request at all
+	(e.g. `discoverItem`, which never creates one).
 	"""
 	addedBy: String
 	streams(infoHashes: [String!]): [Stream!]!
@@ -314,17 +306,9 @@ type EpisodeFull {
 	posterPath: String
 	"""
 	Who is responsible for this item existing, for display next to other
-	item metadata. `None` for anything with no linked request at all — a
-	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-	`discoverItem`, which never creates an `item_requests` row.
-	
-	A Seerr-originated request collapses to the fixed label `"Seerr"`
-	rather than the specific Seerr user who asked for it — that identity
-	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-	doubles as that Seerr-requester email *and*, for a request made
-	directly through riven's own `requestMovie`/`requestShow`/`addItem`
-	mutations, the riven username that called them — `external_request_id`
-	(set only by Seerr) is what tells the two apart.
+	item metadata. See [`super::item_requests::resolve_added_by`] for the
+	full rules — `None` only for an item with no linked request at all
+	(e.g. `discoverItem`, which never creates one).
 	"""
 	addedBy: String
 	filesystemEntry: FileSystemEntry
@@ -728,17 +712,9 @@ type MediaItem {
 	posterPath: String
 	"""
 	Who is responsible for this item existing, for display next to other
-	item metadata. `None` for anything with no linked request at all — a
-	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-	`discoverItem`, which never creates an `item_requests` row.
-	
-	A Seerr-originated request collapses to the fixed label `"Seerr"`
-	rather than the specific Seerr user who asked for it — that identity
-	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-	doubles as that Seerr-requester email *and*, for a request made
-	directly through riven's own `requestMovie`/`requestShow`/`addItem`
-	mutations, the riven username that called them — `external_request_id`
-	(set only by Seerr) is what tells the two apart.
+	item metadata. See [`super::item_requests::resolve_added_by`] for the
+	full rules — `None` only for an item with no linked request at all
+	(e.g. `discoverItem`, which never creates one).
 	"""
 	addedBy: String
 }
@@ -792,17 +768,9 @@ type MediaItemFull {
 	posterPath: String
 	"""
 	Who is responsible for this item existing, for display next to other
-	item metadata. `None` for anything with no linked request at all — a
-	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-	`discoverItem`, which never creates an `item_requests` row.
-	
-	A Seerr-originated request collapses to the fixed label `"Seerr"`
-	rather than the specific Seerr user who asked for it — that identity
-	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-	doubles as that Seerr-requester email *and*, for a request made
-	directly through riven's own `requestMovie`/`requestShow`/`addItem`
-	mutations, the riven username that called them — `external_request_id`
-	(set only by Seerr) is what tells the two apart.
+	item metadata. See [`super::item_requests::resolve_added_by`] for the
+	full rules — `None` only for an item with no linked request at all
+	(e.g. `discoverItem`, which never creates one).
 	"""
 	addedBy: String
 	filesystemEntry: FileSystemEntry
@@ -856,17 +824,9 @@ type MediaItemListRow {
 	posterPath: String
 	"""
 	Who is responsible for this item existing, for display next to other
-	item metadata. `None` for anything with no linked request at all — a
-	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-	`discoverItem`, which never creates an `item_requests` row.
-	
-	A Seerr-originated request collapses to the fixed label `"Seerr"`
-	rather than the specific Seerr user who asked for it — that identity
-	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-	doubles as that Seerr-requester email *and*, for a request made
-	directly through riven's own `requestMovie`/`requestShow`/`addItem`
-	mutations, the riven username that called them — `external_request_id`
-	(set only by Seerr) is what tells the two apart.
+	item metadata. See [`super::item_requests::resolve_added_by`] for the
+	full rules — `None` only for an item with no linked request at all
+	(e.g. `discoverItem`, which never creates one).
 	"""
 	addedBy: String
 	showId: Int
@@ -902,6 +862,15 @@ type MediaItemStateTree {
 	tvdbId: String
 	expectedFileCount: Int!
 	seasons: [SeasonState!]!
+	"""
+	Mirrors `MediaItem.addedBy` — see
+	[`riven_core::entities::item_requests::resolve_added_by`] for the
+	full rules. Kept in sync with the full item view so this page's live
+	state updates (which use this lightweight type, not `MediaItemFull`)
+	don't silently drop the field once a subscription push overwrites the
+	initial full fetch.
+	"""
+	addedBy: String
 }
 
 """
@@ -1008,17 +977,9 @@ type Movie {
 	posterPath: String
 	"""
 	Who is responsible for this item existing, for display next to other
-	item metadata. `None` for anything with no linked request at all — a
-	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-	`discoverItem`, which never creates an `item_requests` row.
-	
-	A Seerr-originated request collapses to the fixed label `"Seerr"`
-	rather than the specific Seerr user who asked for it — that identity
-	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-	doubles as that Seerr-requester email *and*, for a request made
-	directly through riven's own `requestMovie`/`requestShow`/`addItem`
-	mutations, the riven username that called them — `external_request_id`
-	(set only by Seerr) is what tells the two apart.
+	item metadata. See [`super::item_requests::resolve_added_by`] for the
+	full rules — `None` only for an item with no linked request at all
+	(e.g. `discoverItem`, which never creates one).
 	"""
 	addedBy: String
 	streams(infoHashes: [String!]): [Stream!]!
@@ -1689,17 +1650,9 @@ type Season {
 	posterPath: String
 	"""
 	Who is responsible for this item existing, for display next to other
-	item metadata. `None` for anything with no linked request at all — a
-	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-	`discoverItem`, which never creates an `item_requests` row.
-	
-	A Seerr-originated request collapses to the fixed label `"Seerr"`
-	rather than the specific Seerr user who asked for it — that identity
-	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-	doubles as that Seerr-requester email *and*, for a request made
-	directly through riven's own `requestMovie`/`requestShow`/`addItem`
-	mutations, the riven username that called them — `external_request_id`
-	(set only by Seerr) is what tells the two apart.
+	item metadata. See [`super::item_requests::resolve_added_by`] for the
+	full rules — `None` only for an item with no linked request at all
+	(e.g. `discoverItem`, which never creates one).
 	"""
 	addedBy: String
 	streams(infoHashes: [String!]): [Stream!]!
@@ -1770,17 +1723,9 @@ type SeasonFull {
 	posterPath: String
 	"""
 	Who is responsible for this item existing, for display next to other
-	item metadata. `None` for anything with no linked request at all — a
-	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-	`discoverItem`, which never creates an `item_requests` row.
-	
-	A Seerr-originated request collapses to the fixed label `"Seerr"`
-	rather than the specific Seerr user who asked for it — that identity
-	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-	doubles as that Seerr-requester email *and*, for a request made
-	directly through riven's own `requestMovie`/`requestShow`/`addItem`
-	mutations, the riven username that called them — `external_request_id`
-	(set only by Seerr) is what tells the two apart.
+	item metadata. See [`super::item_requests::resolve_added_by`] for the
+	full rules — `None` only for an item with no linked request at all
+	(e.g. `discoverItem`, which never creates one).
 	"""
 	addedBy: String
 	episodes: [EpisodeFull!]!
@@ -1897,17 +1842,9 @@ type Show {
 	posterPath: String
 	"""
 	Who is responsible for this item existing, for display next to other
-	item metadata. `None` for anything with no linked request at all — a
-	list-plugin auto-add (Trakt/Listrr/mdblist), or an item created via
-	`discoverItem`, which never creates an `item_requests` row.
-	
-	A Seerr-originated request collapses to the fixed label `"Seerr"`
-	rather than the specific Seerr user who asked for it — that identity
-	lives in Seerr's own UI, not duplicated here. `item_requests.requested_by`
-	doubles as that Seerr-requester email *and*, for a request made
-	directly through riven's own `requestMovie`/`requestShow`/`addItem`
-	mutations, the riven username that called them — `external_request_id`
-	(set only by Seerr) is what tells the two apart.
+	item metadata. See [`super::item_requests::resolve_added_by`] for the
+	full rules — `None` only for an item with no linked request at all
+	(e.g. `discoverItem`, which never creates one).
 	"""
 	addedBy: String
 	streams(infoHashes: [String!]): [Stream!]!


### PR DESCRIPTION
## Summary

Adds a `MediaItem.addedBy` GraphQL field showing who is responsible for an item existing, for display in the item detail UI.

- **Seerr-originated requests** (`item_requests.external_request_id` set) collapse to a fixed `"Seerr"` label rather than the specific Seerr-side requester — that identity lives in Seerr's own UI, not duplicated here.
- **Direct riven requests** (`requestMovie`/`requestShow`/`requestItems`/`addItem`, called from riven's own frontend) now attribute to the calling riven user's own session identity (`display_username`/`username`), populated server-side rather than trusted from client input — a signed-in user's request can no longer be misattributed to someone else by simply setting `input.requestedBy`.
- **Everything else** (list-plugin auto-adds via Trakt/Listrr/mdblist, or `discoverItem`, which creates no `item_requests` row at all) resolves to `null`.

Deliberately out of scope: which release/download was picked for an item — this only covers who requested the item itself, not the download.

## Implementation notes

- `RequestAuth` (the GraphQL-context auth type) gained a `username: Option<String>` field, populated from the authenticated session's `display_username`/`username` (same preference order the frontend already uses for this account elsewhere). `None` for a trusted-API-key caller.
- `MediaItem.addedBy` is a new `#[ComplexObject]` resolver in `riven-core`'s `media_items` entity, joining the linked `item_requests` row by `item_request_id`. Since `riven-core`'s entities can't depend on `riven-db` (dependency runs the other way), a `sea_orm::DatabaseConnection` is now threaded into the GraphQL context via `build_schema`/`start_server` for this resolver to use directly.
- Frontend surfaces it as a small pill next to the status badge on the media item detail page.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (including the schema/frontend-codegen consistency check)
- [x] `svelte-check` / `biome lint`
- [x] Live-verified against a running instance via GraphQL: client-supplied-fallback path, Seerr-label path (`externalRequestId` set), and the no-requester → `null` path. Test items created during verification were cleaned up afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media details now display an “Added by” badge when attribution is available.
  * Media and live status data include who initiated the request or addition.
* **Improvements**
  * Signed-in users are automatically credited for requests and library additions, including bulk requests.
  * Trusted integrations can provide attribution when appropriate.
  * Imports from Listrr, MDBList, and Trakt retain clear source attribution.
  * Attribution is omitted when no matching request exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->